### PR TITLE
Update ReactiveSwift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,7 +20,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.0.0"),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.44.9"),
     ],
     targets: [

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Workflow/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 6.0.0'
+  s.dependency 'ReactiveSwift', '~> 6.3.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Workflow/Tests/**/*.swift'

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'WorkflowTesting/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 6.0.0'
+  s.dependency 'ReactiveSwift', '~> 6.3.0'
   s.dependency 'Workflow', "#{s.version}"
   s.framework = 'XCTest'
 


### PR DESCRIPTION
`ReactiveSwift 6.0.0` was released more than a year ago now + there were Xcode warnings that will now be fixed.