### PR TITLE
Update Swiftformat style - Inline case 

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -42,7 +42,7 @@
 --nowrapoperators 
 --octalgrouping none
 --operatorfunc spaced
---patternlet hoist
+--patternlet inline
 --self init-only
 --selfrequired 
 --semicolons inline
@@ -55,5 +55,3 @@
 --xcodeindentation disabled
 
 --disable unusedArguments
-
---header /*\n * Copyright {year} Square Inc.\n *\n * Licensed under the Apache License, Version 2.0 (the \"License\");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n * \ \ \ \ http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.44.9"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.44.14"),
     ],
     targets: [
         .target(

--- a/Samples/BackStackContainer/Sources/ScreenWrapperViewController.swift
+++ b/Samples/BackStackContainer/Sources/ScreenWrapperViewController.swift
@@ -64,7 +64,7 @@ final class ScreenWrapperViewController<ScreenType: Screen>: UIViewController {
     private func update(barVisibility: BackStackScreen<ScreenType>.BarVisibility) {
         navigationItem.setHidesBackButton(true, animated: false)
 
-        guard case let .visible(barContent) = barVisibility else {
+        guard case .visible(let barContent) = barVisibility else {
             return
         }
 
@@ -74,7 +74,7 @@ final class ScreenWrapperViewController<ScreenType: Screen>: UIViewController {
                 navigationItem.setLeftBarButton(nil, animated: true)
             }
 
-        case let .button(button):
+        case .button(let button):
             if let leftItem = navigationItem.leftBarButtonItem as? CallbackBarButtonItem {
                 leftItem.update(with: button)
             } else {
@@ -88,7 +88,7 @@ final class ScreenWrapperViewController<ScreenType: Screen>: UIViewController {
                 navigationItem.setRightBarButton(nil, animated: true)
             }
 
-        case let .button(button):
+        case .button(let button):
             if let rightItem = navigationItem.rightBarButtonItem as? CallbackBarButtonItem {
                 rightItem.update(with: button)
             } else {
@@ -100,7 +100,7 @@ final class ScreenWrapperViewController<ScreenType: Screen>: UIViewController {
         switch barContent.title {
         case .none:
             title = ""
-        case let .text(text):
+        case .text(let text):
             title = text
         }
         navigationItem.title = title
@@ -132,10 +132,10 @@ extension ScreenWrapperViewController {
 
         func update(with button: BackStackScreen<ScreenType>.BarContent.Button) {
             switch button.content {
-            case let .text(title):
+            case .text(let title):
                 self.title = title
 
-            case let .icon(image):
+            case .icon(let image):
                 self.image = image
             }
 

--- a/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -96,9 +96,9 @@ extension DemoWorkflow {
 
             case .refreshButtonTapped:
                 state.loadingState = .loading
-            case let .refreshComplete(message):
+            case .refreshComplete(let message):
                 state.loadingState = .idle(title: message)
-            case let .refreshError(error):
+            case .refreshError(let error):
                 state.loadingState = .idle(title: error.localizedDescription)
             }
             return nil
@@ -145,7 +145,7 @@ extension DemoWorkflow {
         let refreshEnabled: Bool
 
         switch state.loadingState {
-        case let .idle(title: refreshTitle):
+        case .idle(title: let refreshTitle):
             refreshText = refreshTitle
             refreshEnabled = true
 
@@ -158,9 +158,9 @@ extension DemoWorkflow {
 
             context.awaitResult(for: RefreshWorker()) { output -> Action in
                 switch output {
-                case let .success(result):
+                case .success(let result):
                     return .refreshComplete(result)
-                case let .error(error):
+                case .error(let error):
                     return .refreshError(error)
                 }
             }

--- a/Samples/SampleApp/Sources/RootWorkflow.swift
+++ b/Samples/SampleApp/Sources/RootWorkflow.swift
@@ -47,7 +47,7 @@ extension RootWorkflow {
 
         func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
             switch self {
-            case let .login(name: name):
+            case .login(name: let name):
                 state = .demo(name: name)
             }
 
@@ -68,14 +68,14 @@ extension RootWorkflow {
                 base: WelcomeWorkflow()
                     .mapOutput { output -> Action in
                         switch output {
-                        case let .login(name: name):
+                        case .login(name: let name):
                             return .login(name: name)
                         }
                     }
                     .rendered(in: context)
             )
 
-        case let .demo(name: name):
+        case .demo(name: let name):
             return CrossFadeScreen(
                 base: DemoWorkflow(name: name)
                     .rendered(in: context)

--- a/Samples/SampleApp/Sources/WelcomeWorkflow.swift
+++ b/Samples/SampleApp/Sources/WelcomeWorkflow.swift
@@ -48,7 +48,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(updatedName):
+            case .nameChanged(let updatedName):
                 state.name = updatedName
                 return nil
 

--- a/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -71,13 +71,13 @@ extension AuthenticationWorkflow {
                     fatalError("Unexpected back in state \(state)")
                 }
 
-            case let .login(email: email, password: password):
+            case .login(email: let email, password: let password):
                 state = .authorizingEmailPassword(email: email, password: password)
 
-            case let .verifySecondFactor(intermediateSession: intermediateSession, twoFactorCode: twoFactorCode):
+            case .verifySecondFactor(intermediateSession: let intermediateSession, twoFactorCode: let twoFactorCode):
                 state = .authorizingTwoFactor(twoFactorCode: twoFactorCode, intermediateSession: intermediateSession)
 
-            case let .authenticationSucceeded(response: response):
+            case .authenticationSucceeded(response: let response):
                 if response.secondFactorRequired {
                     state = .twoFactor(intermediateSession: response.token, authenticationError: nil)
                 } else {
@@ -87,7 +87,7 @@ extension AuthenticationWorkflow {
             case .dismissAuthenticationAlert:
                 state = .emailPassword
 
-            case let .authenticationError(error):
+            case .authenticationError(let error):
                 switch state {
                 case .authorizingEmailPassword:
                     state = .authenticationErrorAlert(error: error)
@@ -172,7 +172,7 @@ extension AuthenticationWorkflow {
 
         let loginScreen = LoginWorkflow().mapOutput { output -> Action in
             switch output {
-            case let .login(email: email, password: password):
+            case .login(email: let email, password: let password):
                 return .login(email: email, password: password)
             }
         }.rendered(in: context)
@@ -182,7 +182,7 @@ extension AuthenticationWorkflow {
         case .emailPassword:
             break
 
-        case let .authenticationErrorAlert(error: error):
+        case .authenticationErrorAlert(error: let error):
             if let error = error {
                 alert = Alert(
                     title: "Error",
@@ -197,7 +197,7 @@ extension AuthenticationWorkflow {
                 )
             }
 
-        case let .authorizingEmailPassword(email: email, password: password):
+        case .authorizingEmailPassword(email: let email, password: let password):
             context.awaitResult(for: AuthorizingEmailPasswordWorker(
                 authenticationService: authenticationService,
                 email: email,
@@ -205,14 +205,14 @@ extension AuthenticationWorkflow {
             ))
             modals.append(ModalContainerScreenModal(screen: AnyScreen(LoadingScreen()), style: .fullScreen, key: "", animated: false))
 
-        case let .twoFactor(intermediateSession: intermediateSession, authenticationError: authenticationError):
+        case .twoFactor(intermediateSession: let intermediateSession, authenticationError: let authenticationError):
             backStackItems.append(twoFactorScreen(
                 error: authenticationError,
                 intermediateSession: intermediateSession,
                 sink: sink
             ))
 
-        case let .authorizingTwoFactor(twoFactorCode: twoFactorCode, intermediateSession: intermediateSession):
+        case .authorizingTwoFactor(twoFactorCode: let twoFactorCode, intermediateSession: let intermediateSession):
             context.awaitResult(
                 for: AuthorizingTwoFactorWorker(
                     authenticationService: authenticationService,

--- a/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -51,10 +51,10 @@ extension LoginWorkflow {
 
         func apply(toState state: inout LoginWorkflow.State) -> LoginWorkflow.Output? {
             switch self {
-            case let .emailUpdated(email):
+            case .emailUpdated(let email):
                 state.email = email
 
-            case let .passwordUpdated(password):
+            case .passwordUpdated(let password):
                 state.password = password
 
             case .login:

--- a/Samples/TicTacToe/Sources/Game/GamePlayScreen.swift
+++ b/Samples/TicTacToe/Sources/Game/GamePlayScreen.swift
@@ -99,7 +99,7 @@ final class GamePlayViewController: ScreenViewController<GamePlayScreen> {
 
         let title: String
         switch screen.gameState {
-        case let .ongoing(turn: turn):
+        case .ongoing(turn: let turn):
             switch turn {
             case .x:
                 title = "\(screen.playerX), place your 🙅"
@@ -110,7 +110,7 @@ final class GamePlayViewController: ScreenViewController<GamePlayScreen> {
         case .tie:
             title = "It's a Tie!"
 
-        case let .win(player):
+        case .win(let player):
             switch player {
             case .x:
                 title = "The 🙅's have it, \(screen.playerX) wins!"
@@ -126,7 +126,7 @@ final class GamePlayViewController: ScreenViewController<GamePlayScreen> {
                 switch cols[col] {
                 case .empty:
                     cells[row][col].setTitle("", for: .normal)
-                case let .taken(player):
+                case .taken(let player):
                     switch player {
                     case .x:
                         cells[row][col].setTitle("🙅", for: .normal)

--- a/Samples/TicTacToe/Sources/Game/GameState.swift
+++ b/Samples/TicTacToe/Sources/Game/GameState.swift
@@ -21,7 +21,7 @@ enum GameState: Equatable {
 
     mutating func toggle() {
         switch self {
-        case let .ongoing(turn: player):
+        case .ongoing(turn: let player):
             switch player {
             case .x:
                 self = .ongoing(turn: .o)

--- a/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -60,10 +60,10 @@ extension RunGameWorkflow {
 
         func apply(toState state: inout RunGameWorkflow.State) -> RunGameWorkflow.Output? {
             switch self {
-            case let .updatePlayerX(name):
+            case .updatePlayerX(let name):
                 state.playerX = name
 
-            case let .updatePlayerO(name):
+            case .updatePlayerO(let name):
                 state.playerO = name
 
             case .startGame:
@@ -169,10 +169,10 @@ extension RunGameWorkflow {
                 case .startGame:
                     sink.send(.startGame)
 
-                case let .playerXChanged(name):
+                case .playerXChanged(let name):
                     sink.send(.updatePlayerX(name))
 
-                case let .playerOChanged(name):
+                case .playerOChanged(let name):
                     sink.send(.updatePlayerO(name))
                 }
             }

--- a/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
@@ -49,9 +49,9 @@ extension TakeTurnsWorkflow {
 
         func apply(toState state: inout TakeTurnsWorkflow.State) -> TakeTurnsWorkflow.Output? {
             switch state.gameState {
-            case let .ongoing(turn: turn):
+            case .ongoing(turn: let turn):
                 switch self {
-                case let .selected(row: row, col: col):
+                case .selected(row: let row, col: let col):
                     if !state.board.isEmpty(row: row, col: col) {
                         return nil
                     }

--- a/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -50,7 +50,7 @@ extension MainWorkflow {
 
         func apply(toState state: inout MainWorkflow.State) -> MainWorkflow.Output? {
             switch self {
-            case let .authenticated(sessionToken: sessionToken):
+            case .authenticated(sessionToken: let sessionToken):
                 state = .runningGame(sessionToken: sessionToken)
 
             case .logout:
@@ -73,7 +73,7 @@ extension MainWorkflow {
             return AuthenticationWorkflow(authenticationService: AuthenticationService())
                 .mapOutput { output -> Action in
                     switch output {
-                    case let .authorized(session: sessionToken):
+                    case .authorized(session: let sessionToken):
                         return .authenticated(sessionToken: sessionToken)
                     }
                 }

--- a/Samples/TicTacToe/Tests/AuthenticationWorkflowTests.swift
+++ b/Samples/TicTacToe/Tests/AuthenticationWorkflowTests.swift
@@ -39,7 +39,7 @@ class AuthenticationWorkflowTests: XCTestCase {
             .tester(withState: .emailPassword)
             .send(action: .login(email: "reza@example.com", password: "password"))
             .assertState { state in
-                if case let .authorizingEmailPassword(email, password) = state {
+                if case .authorizingEmailPassword(let email, let password) = state {
                     XCTAssertEqual(email, "reza@example.com")
                     XCTAssertEqual(password, "password")
                 } else {
@@ -59,7 +59,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 )
             )
             .assertState { state in
-                if case let .authorizingTwoFactor(twoFactorCode, intermediateSession) = state {
+                if case .authorizingTwoFactor(let twoFactorCode, let intermediateSession) = state {
                     XCTAssertEqual(intermediateSession, "intermediateSession")
                     XCTAssertEqual(twoFactorCode, "twoFactorCode")
                 } else {
@@ -81,7 +81,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 )
             )
             .assertState { state in
-                if case let .twoFactor(intermediateSession, authenticationError) = state {
+                if case .twoFactor(let intermediateSession, let authenticationError) = state {
                     XCTAssertEqual(intermediateSession, "token")
                     XCTAssertNil(authenticationError)
                 } else {
@@ -101,7 +101,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 ), outputAssertions: { output in
                     XCTAssertNotNil(output)
                     switch output! {
-                    case let .authorized(session: session):
+                    case .authorized(session: let session):
                         XCTAssertEqual(session, "token")
                     }
                 }
@@ -124,7 +124,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 action: .authenticationError(AuthenticationService.AuthenticationError.invalidUserPassword)
             )
             .assertState { state in
-                if case let .authenticationErrorAlert(error) = state {
+                if case .authenticationErrorAlert(let error) = state {
                     XCTAssertNotNil(error)
                     XCTAssertEqual(error, AuthenticationService.AuthenticationError.invalidUserPassword)
                 } else {
@@ -150,7 +150,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 action: .authenticationError(AuthenticationService.AuthenticationError.invalidUserPassword)
             )
             .assertState { state in
-                if case let .authenticationErrorAlert(error) = state {
+                if case .authenticationErrorAlert(let error) = state {
                     XCTAssertNotNil(error)
                     XCTAssertEqual(error, AuthenticationService.AuthenticationError.invalidUserPassword)
                 } else {
@@ -170,7 +170,7 @@ class AuthenticationWorkflowTests: XCTestCase {
                 action: .authenticationError(AuthenticationService.AuthenticationError.invalidTwoFactor)
             )
             .assertState { state in
-                if case let .twoFactor(intermediateSession, error) = state {
+                if case .twoFactor(let intermediateSession, let error) = state {
                     XCTAssertNotNil(intermediateSession)
                     XCTAssertNotNil(error)
                     XCTAssertEqual(error, AuthenticationService.AuthenticationError.invalidTwoFactor)

--- a/Samples/TicTacToe/Tests/LoginWorkflowTests.swift
+++ b/Samples/TicTacToe/Tests/LoginWorkflowTests.swift
@@ -79,7 +79,7 @@ class LoginWorkflowTests: XCTestCase {
                 outputAssertions: { output in
                     XCTAssertNotNil(output)
                     switch output! {
-                    case let .login(email, password):
+                    case .login(let email, let password):
                         XCTAssertEqual(email, "reza@example.com")
                         XCTAssertEqual(password, "password")
                     }

--- a/Samples/TicTacToe/Tests/MainWorkflowTests.swift
+++ b/Samples/TicTacToe/Tests/MainWorkflowTests.swift
@@ -31,7 +31,7 @@ class MainWorkflowTests: XCTestCase {
             .tester(withState: .authenticating)
             .send(action: .authenticated(sessionToken: "token"))
             .assertState { state in
-                if case let MainWorkflow.State.runningGame(token) = state {
+                if case MainWorkflow.State.runningGame(let token) = state {
                     XCTAssertEqual(token, "token")
                 } else {
                     XCTFail("Invalid state after authenticated")

--- a/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -48,7 +48,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(name: name):
+            case .nameChanged(name: let name):
                 // Update our state with the updated name.
                 state.name = name
                 // Return `nil` for the output, we want to handle this action only at the level of this workflow.

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
@@ -55,7 +55,7 @@ extension RootWorkflow {
 
         func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
             switch self {
-            case let .login(name: name):
+            case .login(name: let name):
                 // When the `login` action is received, change the state to `todo`.
                 state = .todo(name: name)
             case .logout:
@@ -99,7 +99,7 @@ extension RootWorkflow {
             .mapOutput { output -> Action in
                 switch output {
                 // When `WelcomeWorkflow` emits `didLogin`, turn it into our `login` action.
-                case let .didLogin(name: name):
+                case .didLogin(name: let name):
                     return .login(name: name)
                 }
             }
@@ -122,7 +122,7 @@ extension RootWorkflow {
             break
 
         // When the state is `.todo`, defer to the TodoListWorkflow.
-        case let .todo(name: name):
+        case .todo(name: let name):
 
             let todoListScreen = TodoListWorkflow()
                 .rendered(in: context)

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -51,7 +51,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(name: name):
+            case .nameChanged(name: let name):
                 // Update our state with the updated name.
                 state.name = name
                 // Return `nil` for the output, we want to handle this action only at the level of this workflow.

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
@@ -55,7 +55,7 @@ extension RootWorkflow {
 
         func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
             switch self {
-            case let .login(name: name):
+            case .login(name: let name):
                 // When the `login` action is received, change the state to `todo`.
                 state = .todo(name: name)
             case .logout:
@@ -98,7 +98,7 @@ extension RootWorkflow {
             .mapOutput { output -> Action in
                 switch output {
                 // When `WelcomeWorkflow` emits `didLogin`, turn it into our `login` action.
-                case let .didLogin(name: name):
+                case .didLogin(name: let name):
                     return .login(name: name)
                 }
             }
@@ -121,7 +121,7 @@ extension RootWorkflow {
             break
 
         // When the state is `.todo`, defer to the TodoListWorkflow.
-        case let .todo(name: name):
+        case .todo(name: let name):
 
             let todoBackStackItems = TodoListWorkflow(name: name)
                 .mapOutput { output -> Action in

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -67,10 +67,10 @@ extension TodoEditWorkflow {
 
         func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
             switch self {
-            case let .titleChanged(title):
+            case .titleChanged(let title):
                 state.todo.title = title
 
-            case let .noteChanged(note):
+            case .noteChanged(let note):
                 state.todo.note = note
 
             case .discardChanges:

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -76,7 +76,7 @@ extension TodoListWorkflow {
                 // When a `.onBack` action is received, emit a `.back` output
                 return .back
 
-            case let .selectTodo(index: index):
+            case .selectTodo(index: let index):
                 // When a todo item is selected, edit it.
                 state.step = .edit(index: index)
                 return nil
@@ -86,7 +86,7 @@ extension TodoListWorkflow {
                 state.step = .list
                 return nil
 
-            case let .saveChanges(todo: todo, index: index):
+            case .saveChanges(todo: let todo, index: let index):
                 // When changes are saved, update the state of that `todo` item and return to the list.
                 state.todos[index] = todo
 
@@ -151,7 +151,7 @@ extension TodoListWorkflow {
             // On the "list" step, return just the list screen.
             return [todoListItem]
 
-        case let .edit(index: index):
+        case .edit(index: let index):
             // On the "edit" step, return both the list and edit screens.
             let todoEditItem = TodoEditWorkflow(
                 initialTodo: state.todos[index])
@@ -161,7 +161,7 @@ extension TodoListWorkflow {
                         // Send the discardChanges action when the discard output is received.
                         return .discardChanges
 
-                    case let .save(todo):
+                    case .save(let todo):
                         // Send the saveChanges action when the save output is received.
                         return .saveChanges(todo: todo, index: index)
                     }

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -51,7 +51,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(name: name):
+            case .nameChanged(name: let name):
                 // Update our state with the updated name.
                 state.name = name
                 // Return `nil` for the output, we want to handle this action only at the level of this workflow.

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
@@ -55,7 +55,7 @@ extension RootWorkflow {
 
         func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
             switch self {
-            case let .login(name: name):
+            case .login(name: let name):
                 // When the `login` action is received, change the state to `todo`.
                 state = .todo(name: name)
             case .logout:
@@ -98,7 +98,7 @@ extension RootWorkflow {
             .mapOutput { output -> Action in
                 switch output {
                 // When `WelcomeWorkflow` emits `didLogin`, turn it into our `login` action.
-                case let .didLogin(name: name):
+                case .didLogin(name: let name):
                     return .login(name: name)
                 }
             }
@@ -121,7 +121,7 @@ extension RootWorkflow {
             break
 
         // When the state is `.todo`, defer to the TodoListWorkflow.
-        case let .todo(name: name):
+        case .todo(name: let name):
 
             // was: let todoBackStackItems = TodoListWorkflow(name: name)
             let todoBackStackItems = TodoWorkflow(name: name)

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -67,10 +67,10 @@ extension TodoEditWorkflow {
 
         func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
             switch self {
-            case let .titleChanged(title):
+            case .titleChanged(let title):
                 state.todo.title = title
 
-            case let .noteChanged(note):
+            case .noteChanged(let note):
                 state.todo.note = note
 
             case .discardChanges:

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -62,7 +62,7 @@ extension TodoListWorkflow {
                 // When a `.onBack` action is received, emit a `.back` output
                 return .back
 
-            case let .selectTodo(index: index):
+            case .selectTodo(index: let index):
                 // Tell our parent that a todo item was selected.
                 return .selectTodo(index: index)
 

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
@@ -73,7 +73,7 @@ extension TodoWorkflow {
             case .back:
                 return .back
 
-            case let .editTodo(index: index):
+            case .editTodo(index: let index):
                 state.step = .edit(index: index)
 
             case .newTodo:
@@ -103,7 +103,7 @@ extension TodoWorkflow {
             case .discardChanges:
                 state.step = .list
 
-            case let .saveChanges(index: index, todo: updatedTodo):
+            case .saveChanges(index: let index, todo: let updatedTodo):
                 state.todos[index] = updatedTodo
             }
             // Return to the list view for either a discard or save action.
@@ -145,7 +145,7 @@ extension TodoWorkflow {
             case .back:
                 return .back
 
-            case let .selectTodo(index: index):
+            case .selectTodo(index: let index):
                 return .editTodo(index: index)
 
             case .newTodo:
@@ -159,7 +159,7 @@ extension TodoWorkflow {
             // Return only the list item.
             return [todoListItem]
 
-        case let .edit(index: index):
+        case .edit(index: let index):
 
             let todoEditItem = TodoEditWorkflow(
                 initialTodo: state.todos[index])
@@ -168,7 +168,7 @@ extension TodoWorkflow {
                     case .discard:
                         return .discardChanges
 
-                    case let .save(updatedTodo):
+                    case .save(let updatedTodo):
                         return .saveChanges(index: index, todo: updatedTodo)
                     }
                 }

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -51,7 +51,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(name: name):
+            case .nameChanged(name: let name):
                 // Update our state with the updated name.
                 state.name = name
                 // Return `nil` for the output, we want to handle this action only at the level of this workflow.

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -55,7 +55,7 @@ extension RootWorkflow {
 
         func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
             switch self {
-            case let .login(name: name):
+            case .login(name: let name):
                 // When the `login` action is received, change the state to `todo`.
                 state = .todo(name: name)
             case .logout:
@@ -98,7 +98,7 @@ extension RootWorkflow {
             .mapOutput { output -> Action in
                 switch output {
                 // When `WelcomeWorkflow` emits `didLogin`, turn it into our `login` action.
-                case let .didLogin(name: name):
+                case .didLogin(name: let name):
                     return .login(name: name)
                 }
             }
@@ -121,7 +121,7 @@ extension RootWorkflow {
             break
 
         // When the state is `.todo`, defer to the TodoListWorkflow.
-        case let .todo(name: name):
+        case .todo(name: let name):
 
             // was: let todoBackStackItems = TodoListWorkflow(name: name)
             let todoBackStackItems = TodoWorkflow(name: name)

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -67,10 +67,10 @@ extension TodoEditWorkflow {
 
         func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
             switch self {
-            case let .titleChanged(title):
+            case .titleChanged(let title):
                 state.todo.title = title
 
-            case let .noteChanged(note):
+            case .noteChanged(let note):
                 state.todo.note = note
 
             case .discardChanges:

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -62,7 +62,7 @@ extension TodoListWorkflow {
                 // When a `.onBack` action is received, emit a `.back` output
                 return .back
 
-            case let .selectTodo(index: index):
+            case .selectTodo(index: let index):
                 // Tell our parent that a todo item was selected.
                 return .selectTodo(index: index)
 

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
@@ -73,7 +73,7 @@ extension TodoWorkflow {
             case .back:
                 return .back
 
-            case let .editTodo(index: index):
+            case .editTodo(index: let index):
                 state.step = .edit(index: index)
 
             case .newTodo:
@@ -103,7 +103,7 @@ extension TodoWorkflow {
             case .discardChanges:
                 state.step = .list
 
-            case let .saveChanges(index: index, todo: updatedTodo):
+            case .saveChanges(index: let index, todo: let updatedTodo):
                 state.todos[index] = updatedTodo
             }
             // Return to the list view for either a discard or save action.
@@ -145,7 +145,7 @@ extension TodoWorkflow {
             case .back:
                 return .back
 
-            case let .selectTodo(index: index):
+            case .selectTodo(index: let index):
                 return .editTodo(index: index)
 
             case .newTodo:
@@ -159,7 +159,7 @@ extension TodoWorkflow {
             // Return only the list item.
             return [todoListItem]
 
-        case let .edit(index: index):
+        case .edit(index: let index):
 
             let todoEditItem = TodoEditWorkflow(
                 initialTodo: state.todos[index])
@@ -168,7 +168,7 @@ extension TodoWorkflow {
                     case .discard:
                         return .discardChanges
 
-                    case let .save(updatedTodo):
+                    case .save(let updatedTodo):
                         return .saveChanges(index: index, todo: updatedTodo)
                     }
                 }

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -51,7 +51,7 @@ extension WelcomeWorkflow {
 
         func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
             switch self {
-            case let .nameChanged(name: name):
+            case .nameChanged(name: let name):
                 // Update our state with the updated name.
                 state.name = name
                 // Return `nil` for the output, we want to handle this action only at the level of this workflow.

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
@@ -197,15 +197,15 @@ class RootWorkflowTests: XCTestCase {
             case .hidden:
                 XCTFail("Expected a visible navigation bar")
 
-            case let .visible(barContent):
+            case .visible(let barContent):
                 switch barContent.rightItem {
                 case .none:
                     XCTFail("Expected a right bar button")
 
-                case let .button(button):
+                case .button(let button):
 
                     switch button.content {
-                    case let .text(text):
+                    case .text(let text):
                         XCTAssertEqual("Save", text)
 
                     case .icon:

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoEditWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoEditWorkflowTests.swift
@@ -60,7 +60,7 @@ class TodoEditWorkflowTests: XCTestCase {
             // Send a `.saveChanges` action, which will emit a `.save` output with the updated todo model.
             .send(action: .saveChanges) { output in
                 switch output {
-                case let .save(todo)?:
+                case .save(let todo)?:
                     XCTAssertEqual("Updated Title", todo.title)
                     XCTAssertEqual("Updated Note", todo.note)
                 default:

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoListWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoListWorkflowTests.swift
@@ -35,7 +35,7 @@ class TodoListWorkflowTests: XCTestCase {
             .send(action: .selectTodo(index: 7)) { output in
                 // The `.selectTodo` action should emit a `.selectTodo` output.
                 switch output {
-                case let .selectTodo(index)?:
+                case .selectTodo(let index)?:
                     XCTAssertEqual(7, index)
                 default:
                     XCTFail("Expected an output of `.selectTodo`")

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
@@ -15,9 +15,9 @@
  */
 
 import BackStackContainer
+import Workflow
 import WorkflowTesting
 import XCTest
-import Workflow
 @testable import Tutorial5
 
 class TodoWorkflowTests: XCTestCase {

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/WelcomeWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/WelcomeWorkflowTests.swift
@@ -58,7 +58,7 @@ class WelcomeWorkflowTests: XCTestCase {
             .send(action: .didLogin) { output in
                 // Now a `.didLogin` output should be emitted when the `.didLogin` action was received.
                 switch output {
-                case let .didLogin(name)?:
+                case .didLogin(let name)?:
                     XCTAssertEqual("MyName", name)
                 case nil:
                     XCTFail("Did not receive an output for .didLogin")

--- a/Workflow/Sources/Debugging.swift
+++ b/Workflow/Sources/Debugging.swift
@@ -42,10 +42,10 @@ extension WorkflowUpdateDebugInfo.Kind: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
-        case let .didUpdate(source):
+        case .didUpdate(let source):
             try container.encode("didUpdate", forKey: .type)
             try container.encode(source, forKey: .source)
-        case let .childDidUpdate(info):
+        case .childDidUpdate(let info):
             try container.encode("childDidUpdate", forKey: .type)
             try container.encode(info, forKey: .childUpdate)
         }
@@ -94,7 +94,7 @@ extension WorkflowUpdateDebugInfo.Source: Codable {
             try container.encode("external", forKey: .type)
         case .worker:
             try container.encode("worker", forKey: .type)
-        case let .subtree(debugInfo):
+        case .subtree(let debugInfo):
             try container.encode("subtree", forKey: .type)
             try container.encode(debugInfo, forKey: .debugInfo)
         case .sideEffect:

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -350,7 +350,7 @@ extension WorkflowNode.SubtreeManager {
             case .queued:
                 fatalError("[\(WorkflowType.self)] Action sent to pipe while already in the `queueing` state.")
 
-            case let .valid(handler: handler):
+            case .valid(handler: let handler):
                 handler(event)
 
             case .invalid:
@@ -366,7 +366,7 @@ extension WorkflowNode.SubtreeManager {
         }
 
         func pendingOutput() -> Output? {
-            if case let .queued(output) = validationState {
+            if case .queued(let output) = validationState {
                 return output
             } else {
                 return nil
@@ -445,7 +445,7 @@ extension WorkflowNode.SubtreeManager {
                 .observe(on: QueueScheduler.workflowExecution)
                 .start { [weak self] event in
                     switch event {
-                    case let .value(output):
+                    case .value(let output):
                         WorkflowLogger.logWorkerOutput(ref: signpostRef, workerType: W.self)
 
                         self?.handle(output: output)

--- a/Workflow/Sources/WorkflowLogger.swift
+++ b/Workflow/Sources/WorkflowLogger.swift
@@ -16,7 +16,7 @@
 
 import os.signpost
 
-fileprivate extension OSLog {
+private extension OSLog {
     static let workflow = OSLog(subsystem: "com.squareup.Workflow", category: "Workflow")
     static let worker = OSLog(subsystem: "com.squareup.Workflow", category: "Worker")
 }
@@ -34,8 +34,14 @@ final class WorkflowLogger {
     static func logWorkflowStarted<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
         if #available(iOS 12.0, macOS 10.14, *) {
             let signpostID = OSSignpostID(log: .workflow, object: ref)
-            os_signpost(.begin, log: .workflow, name: "Alive", signpostID: signpostID,
-                        "Workflow: %{public}@", String(describing: WorkflowType.self))
+            os_signpost(
+                .begin,
+                log: .workflow,
+                name: "Alive",
+                signpostID: signpostID,
+                "Workflow: %{public}@",
+                String(describing: WorkflowType.self)
+            )
         }
     }
 
@@ -49,8 +55,14 @@ final class WorkflowLogger {
     static func logSinkEvent<Action: WorkflowAction>(ref: AnyObject, action: Action) {
         if #available(iOS 12.0, macOS 10.14, *) {
             let signpostID = OSSignpostID(log: .workflow, object: ref)
-            os_signpost(.event, log: .workflow, name: "Sink Event", signpostID: signpostID,
-                        "Event for workflow: %{public}@", String(describing: Action.WorkflowType.self))
+            os_signpost(
+                .event,
+                log: .workflow,
+                name: "Sink Event",
+                signpostID: signpostID,
+                "Event for workflow: %{public}@",
+                String(describing: Action.WorkflowType.self)
+            )
         }
     }
 
@@ -59,8 +71,14 @@ final class WorkflowLogger {
     static func logWorkflowStartedRendering<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
         if #available(iOS 12.0, macOS 10.14, *) {
             let signpostID = OSSignpostID(log: .workflow, object: ref)
-            os_signpost(.begin, log: .workflow, name: "Render", signpostID: signpostID,
-                        "Render Workflow: %{public}@", String(describing: WorkflowType.self))
+            os_signpost(
+                .begin,
+                log: .workflow,
+                name: "Render",
+                signpostID: signpostID,
+                "Render Workflow: %{public}@",
+                String(describing: WorkflowType.self)
+            )
         }
     }
 
@@ -76,8 +94,14 @@ final class WorkflowLogger {
     static func logWorkerStartedRunning<WorkerType>(ref: AnyObject, workerType: WorkerType.Type) {
         if #available(iOS 12.0, macOS 10.14, *) {
             let signpostID = OSSignpostID(log: .worker, object: ref)
-            os_signpost(.begin, log: .worker, name: "Running", signpostID: signpostID,
-                        "Worker: %{public}@", String(describing: WorkerType.self))
+            os_signpost(
+                .begin,
+                log: .worker,
+                name: "Running",
+                signpostID: signpostID,
+                "Worker: %{public}@",
+                String(describing: WorkerType.self)
+            )
         }
     }
 
@@ -91,8 +115,14 @@ final class WorkflowLogger {
     static func logWorkerOutput<WorkerType: Worker>(ref: AnyObject, workerType: WorkerType.Type) {
         if #available(iOS 12.0, macOS 10.14, *) {
             let signpostID = OSSignpostID(log: .worker, object: ref)
-            os_signpost(.event, log: .worker, name: "Worker Event", signpostID: signpostID,
-                        "Event: %{public}@", String(describing: WorkerType.self))
+            os_signpost(
+                .event,
+                log: .worker,
+                name: "Worker Event",
+                signpostID: signpostID,
+                "Event: %{public}@",
+                String(describing: WorkerType.self)
+            )
         }
     }
 }

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -50,7 +50,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
         let output: Output
 
         switch subtreeOutput {
-        case let .update(event, source):
+        case .update(let event, let source):
             /// Apply the update to the current state
             let outputEvent = event.apply(toState: &state)
 
@@ -63,7 +63,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
                 )
             )
 
-        case let .childDidUpdate(debugInfo):
+        case .childDidUpdate(let debugInfo):
             output = Output(
                 outputEvent: nil,
                 debugInfo: WorkflowUpdateDebugInfo(

--- a/Workflow/Tests/ConcurrencyTests.swift
+++ b/Workflow/Tests/ConcurrencyTests.swift
@@ -613,7 +613,7 @@ final class ConcurrencyTests: XCTestCase {
                     .update
                 }
 
-            case let .doubleSubscribing(secondSignal: signal2):
+            case .doubleSubscribing(secondSignal: let signal2):
                 context.awaitResult(for: signal2.signal.asWorker(key: "signal2")) { _ -> Action in
                     .secondUpdate
                 }

--- a/Workflow/Tests/SubtreeManagerTests.swift
+++ b/Workflow/Tests/SubtreeManagerTests.swift
@@ -71,7 +71,7 @@ final class SubtreeManagerTests: XCTestCase {
 
         manager.onUpdate = {
             switch $0 {
-            case let .update(event, _):
+            case .update(let event, _):
                 events.append(event)
             default:
                 break

--- a/Workflow/Tests/WorkflowNodeTests.swift
+++ b/Workflow/Tests/WorkflowNodeTests.swift
@@ -139,16 +139,16 @@ final class WorkflowNodeTests: XCTestCase {
         switch debugInfo.kind {
         case .childDidUpdate:
             XCTFail()
-        case let .didUpdate(source):
+        case .didUpdate(let source):
             switch source {
             case .external, .worker, .sideEffect:
                 XCTFail()
-            case let .subtree(childInfo):
+            case .subtree(let childInfo):
                 XCTAssert(childInfo.workflowType == "\(EventEmittingWorkflow.self)")
                 switch childInfo.kind {
                 case .childDidUpdate:
                     XCTFail()
-                case let .didUpdate(source):
+                case .didUpdate(let source):
                     switch source {
                     case .external:
                         break
@@ -283,9 +283,9 @@ extension CompositeWorkflow {
 
         func apply(toState state: inout CompositeWorkflow<A, B>.State) -> CompositeWorkflow<A, B>.Output? {
             switch self {
-            case let .a(childOutput):
+            case .a(let childOutput):
                 return .childADidSomething(childOutput)
-            case let .b(childOutput):
+            case .b(let childOutput):
                 return .childBDidSomething(childOutput)
             }
         }
@@ -317,9 +317,9 @@ extension CompositeWorkflow.Rendering: Equatable where A.Rendering: Equatable, B
 extension CompositeWorkflow.Output: Equatable where A.Output: Equatable, B.Output: Equatable {
     fileprivate static func == (lhs: CompositeWorkflow.Output, rhs: CompositeWorkflow.Output) -> Bool {
         switch (lhs, rhs) {
-        case let (.childADidSomething(l), .childADidSomething(r)):
+        case (.childADidSomething(let l), .childADidSomething(let r)):
             return l == r
-        case let (.childBDidSomething(l), .childBDidSomething(r)):
+        case (.childBDidSomething(let l), .childBDidSomething(let r)):
             return l == r
         default:
             return false

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -313,7 +313,7 @@
             case (.none, .some):
                 XCTFail("Expected an output, but received none.", file: file, line: line)
 
-            case let (.some(output), .some(expectedOutput)):
+            case (.some(let output), .some(let expectedOutput)):
                 XCTAssertTrue(expectedOutput.isEquivalent(output, expectedOutput.output), "expect output of \(expectedOutput.output) but received \(output)", file: file, line: line)
             }
             expectations.expectedOutput = nil

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -244,13 +244,13 @@
 
         func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
             switch self {
-            case let .counter(count):
+            case .counter(let count):
                 return ViewControllerDescription(
                     build: { CounterViewController(count: count) },
                     update: { $0.count = count }
                 )
 
-            case let .message(message):
+            case .message(let message):
                 return ViewControllerDescription(
                     build: { MessageViewController(message: message) },
                     update: { $0.message = message }


### PR DESCRIPTION
[Here](https://github.com/square/workflow/pull/1174#discussion_r438453982), @bencochran made a good point regarding our `case let` style. 

Moving from:

`case let .option(variable): `

to:

`case .option(let variable):`
