### PR TITLE
Hookup ExpectedWorkflow Assertions

### DIFF
--- a/WorkflowTesting/Sources/Internal/RenderExpectations.swift
+++ b/WorkflowTesting/Sources/Internal/RenderExpectations.swift
@@ -36,10 +36,12 @@
         internal class ExpectedWorkflow<ExpectedWorkflowType: Workflow>: AnyExpectedWorkflow {
             let rendering: ExpectedWorkflowType.Rendering
             let output: ExpectedWorkflowType.Output?
+            let assertions: (ExpectedWorkflowType) -> Void
 
-            init(key: String, rendering: ExpectedWorkflowType.Rendering, output: ExpectedWorkflowType.Output?, file: StaticString, line: UInt) {
+            init(key: String, rendering: ExpectedWorkflowType.Rendering, output: ExpectedWorkflowType.Output?, assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }, file: StaticString, line: UInt) {
                 self.rendering = rendering
                 self.output = output
+                self.assertions = assertions
                 super.init(workflowType: ExpectedWorkflowType.self, key: key, file: file, line: line)
             }
         }

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -74,6 +74,7 @@
                 if let output = expectedWorkflow.output {
                     apply(action: outputMap(output))
                 }
+                expectedWorkflow.assertions(workflow)
                 return expectedWorkflow.rendering
             }
 

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -154,7 +154,7 @@
             producingRendering rendering: ExpectedWorkflowType.Rendering,
             producingOutput output: ExpectedWorkflowType.Output? = nil,
             file: StaticString = #file, line: UInt = #line,
-            assertions: (ExpectedWorkflowType) -> Void = { _ in }
+            assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
         ) -> RenderTester<WorkflowType> {
             return RenderTester(
                 workflow: workflow,
@@ -164,6 +164,7 @@
                         key: key,
                         rendering: rendering,
                         output: output,
+                        assertions: assertions,
                         file: file,
                         line: line
                     )

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -289,6 +289,18 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         }
     }
 
+    func test_verifyWorkflow_assertion_fails() {
+        let tester = TestWorkflow()
+            .renderTester(initialState: .workflow(param: "", key: ""))
+            .expectWorkflow(type: TestChildWorkflow.self, key: "", producingRendering: "", producingOutput: nil) { workflow in
+                XCTFail("Workflow Assertion Fired")
+            }
+
+        expectingFailure("Workflow Assertion Fired") {
+            tester.render { _ in }
+        }
+    }
+
     // MARK: State
 
     func test_verifyState() {


### PR DESCRIPTION
#15  introduces a new `RenderTester` API, along with an `ExpectedWorkflow` type with `assertions`. However, we had missed hooking this up. Adding `assertions` to `ExpectedWorkflow` type.