### PR TITLE
Recover from unexpected void-rendering workflows in RenderTester

### DIFF
--- a/WorkflowReactiveSwift/TestingTests/TestingTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/TestingTests.swift
@@ -72,6 +72,15 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
         }
     }
 
+    func test_worker_unexpected() {
+        let tester = TestWorkflow()
+            .renderTester(initialState: .init(mode: .worker(input: "test"), output: ""))
+
+        expectingFailure(#"Unexpected workflow of type WorkerWorkflow<TestWorker> with key """#) {
+            tester.render { _ in }
+        }
+    }
+
     // MARK: - Failure Recording
 
     var expectedFailureStrings: [String] = []

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -63,6 +63,12 @@
                         diagnosticMessage = ""
                     }
                     XCTFail("Unexpected workflow of type \(Child.self) with key \"\(key)\". \(diagnosticMessage)", file: file, line: line)
+
+                    // We can “recover” from missing Void-rendering workflows since there’s only one possible value to return
+                    if Child.Rendering.self == Void.self {
+                        // Couldn’t find a nicer way to do this polymorphically
+                        return () as! Child.Rendering
+                    }
                     fatalError("Unable to continue.")
                 }
 


### PR DESCRIPTION
`Void` only has a single value, so it’s reasonable/possible for `RenderTester`’s `RenderContext` to return a rendering for unexpected workflows that render `Void`.

Notably, this allows us to fail but continue testing when we encounter an unexpected `Worker` (and thus we can bring back `test_worker_unexpected`).
