### PR TITLE
Get rid of warnings across the project

### DIFF
--- a/WorkflowReactiveSwift/Testing/WorkerTesting+Deprecated.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting+Deprecated.swift
@@ -61,6 +61,7 @@
         }
     }
 
+    @available(*, deprecated, message: "See `RenderTester` documentation for new style.")
     public extension RenderExpectations {
         init(
             expectedState: ExpectedState<WorkflowType>? = nil,

--- a/WorkflowReactiveSwift/Tests/WorkerTests.swift
+++ b/WorkflowReactiveSwift/Tests/WorkerTests.swift
@@ -51,6 +51,7 @@ class WorkerTests: XCTestCase {
         disposable?.dispose()
     }
 
+    @available(*, deprecated) // Marked to silence deprecation warnings
     func testExpectedWorkerDeprecatedTests() {
         SignalProducerTestWorkflow(key: "")
             .renderTester()

--- a/WorkflowTesting/Tests/WorkflowRenderTesterDeprecatedTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterDeprecatedTests.swift
@@ -19,6 +19,7 @@ import Workflow
 import WorkflowTesting
 import XCTest
 
+@available(*, deprecated) // Marked to silence deprecation warnings
 final class WorkflowRenderTesterDeprecatedTests: XCTestCase {
     func test_assertState() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()

--- a/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -212,10 +212,9 @@
         }
 
         func render(state: State, context: RenderContext<Self>) -> TestScreen {
-            context.awaitResult(
-                for: EchoWorker(value: value),
-                outputMap: { AnyWorkflowAction(sendingOutput: $0) }
-            )
+            EchoWorker(value: value)
+                .mapOutput { AnyWorkflowAction(sendingOutput: $0) }
+                .running(in: context)
             return TestScreen(string: "\(value)")
         }
     }


### PR DESCRIPTION
Mostly, mark tests that use deprecated things as themselves deprecated. Also migrated one missing thing thing off of deprecated methods.