### PR TITLE
Support keyPrefix for SignalWorkers [DNM]

### DIFF
--- a/WorkflowReactiveSwift/Sources/SignalWorker.swift
+++ b/WorkflowReactiveSwift/Sources/SignalWorker.swift
@@ -59,6 +59,10 @@ public struct SignalWorker<Key: Equatable, Value>: Worker {
     public func isEquivalent(to otherWorker: SignalWorker) -> Bool {
         return key == otherWorker.key
     }
+
+    public func asAnyWorkflow() -> AnyWorkflow<Void, Value> {
+        AnyWorkflow(WorkerWorkflow(worker: self), keyPrefix: "\(key)")
+    }
 }
 
 extension Signal where Error == Never {

--- a/WorkflowReactiveSwift/Testing/WorkerTesting.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting.swift
@@ -32,9 +32,10 @@
             key: String = "",
             file: StaticString = #file, line: UInt = #line
         ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
+            let anyWorkflow = worker.asAnyWorkflow()
+            return expectWorkflow(
                 type: WorkerWorkflow<ExpectedWorkerType>.self,
-                key: key,
+                key: anyWorkflow.keyPrefix + key,
                 producingRendering: (),
                 producingOutput: output,
                 assertions: { workflow in

--- a/WorkflowReactiveSwift/Tests/SignalWorkerTests+Deprecated.swift
+++ b/WorkflowReactiveSwift/Tests/SignalWorkerTests+Deprecated.swift
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import ReactiveSwift
+import Workflow
+import WorkflowReactiveSwiftTesting
+import XCTest
+@testable import WorkflowReactiveSwift
+
+@available(*, deprecated)
+class SignalWorkerTests: XCTestCase {
+    func test_singleSignalWorker() {
+        let (signal, _) = Signal<AnyWorkflowAction<MultipleSignalWorkersWorkflow>, Never>.pipe()
+        MultipleSignalWorkersWorkflow(numberOfSignalWorkers: 1)
+            .renderTester()
+            .expect(worker: SignalWorker(key: 0, signal: signal))
+            .render { _ in }
+    }
+
+    func test_multipleSignalWorkers() {
+        let (signal, _) = Signal<AnyWorkflowAction<MultipleSignalWorkersWorkflow>, Never>.pipe()
+        MultipleSignalWorkersWorkflow(numberOfSignalWorkers: 2)
+            .renderTester()
+            .expect(worker: SignalWorker(key: 0, signal: signal))
+            .expect(worker: SignalWorker(key: 1, signal: signal))
+            .render { _ in }
+    }
+}
+
+@available(*, deprecated)
+struct MultipleSignalWorkersWorkflow: Workflow {
+    typealias State = Void
+    typealias Rendering = Void
+
+    let numberOfSignalWorkers: Int
+
+    func render(state: Void, context: RenderContext<MultipleSignalWorkersWorkflow>) {
+        for i in 0 ..< numberOfSignalWorkers {
+            let (signal, _) = Signal<AnyWorkflowAction<MultipleSignalWorkersWorkflow>, Never>.pipe()
+            context.awaitResult(
+                for: signal
+                    .asWorker(key: i)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Rough draft of what needs to be done to support propagating the `SignalWorker.key` to the `Workflow`. 

I couldn't figure out a way to accomplish this without modifying `AnyWorkflow`. I think this is too invasive for a temporary change. Unless anybody else has a better idea or strongly believe we should do this, I'll close this.