### PR TITLE
Rm WorkflowReactiveSwiftTesting dependency from WorkflowReactiveSwiftTests

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -16,6 +16,7 @@ on:
       - 'WorkflowUI/**'
       - '.github/workflows/swift.yaml'
       - '.buildscript/build_swift_docs.sh'
+      - '*.swift'
   pull_request:
     paths:
       - '*.podspec'

--- a/WorkflowReactiveSwift/Tests/SignalProducerTests.swift
+++ b/WorkflowReactiveSwift/Tests/SignalProducerTests.swift
@@ -15,7 +15,6 @@
  */
 
 import ReactiveSwift
-import WorkflowReactiveSwiftTesting
 import WorkflowTesting
 import XCTest
 @testable import Workflow

--- a/WorkflowReactiveSwift/Tests/WorkerTests.swift
+++ b/WorkflowReactiveSwift/Tests/WorkerTests.swift
@@ -16,16 +16,21 @@
 
 import ReactiveSwift
 import Workflow
-import WorkflowReactiveSwift
-import WorkflowReactiveSwiftTesting
 import WorkflowTesting
 import XCTest
+@testable import WorkflowReactiveSwift
 
 class WorkerTests: XCTestCase {
     func testExpectedWorker() {
         SignalProducerTestWorkflow(key: "123")
             .renderTester()
-            .expect(worker: SignalProducerTestWorker(), producingOutput: 1, key: "123")
+            .expectWorkflow(
+                type: WorkerWorkflow<SignalProducerTestWorker>.self,
+                key: "123",
+                producingRendering: (),
+                producingOutput: 1,
+                assertions: { _ in }
+            )
             .render { _ in }
             .verifyState { state in
                 XCTAssertEqual(state, 1)
@@ -56,7 +61,16 @@ class WorkerTests: XCTestCase {
             .renderTester()
             .render(
                 expectedState: ExpectedState(state: 1),
-                expectedWorkers: [ExpectedWorker(worker: SignalProducerTestWorker(), output: 1)]
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: WorkerWorkflow<SignalProducerTestWorker>.self,
+                        key: "",
+                        rendering: (),
+                        output: 1,
+                        assertions: { _ in }
+                    ),
+                ],
+                assertions: { _ in }
             )
     }
 


### PR DESCRIPTION
Created a circular `.podspec` dependency.