### PR TITLE
Mark asWorker unavailable

### DIFF
--- a/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -174,11 +174,9 @@ extension DemoWorkflow {
             subscribeTitle = "Subscribe"
         case .subscribing:
             // Subscribe to the timer signal, simulating the title being tapped.
-            state.signal.signal.asWorker(key: "Timer")
-                .mapOutput { _ in
-                    Action.titleButtonTapped
-                }
-                .running(in: context)
+            state.signal.signal
+                .mapOutput { _ in Action.titleButtonTapped }
+                .running(in: context, key: "timer")
             subscribeTitle = "Stop"
         }
 

--- a/WorkflowReactiveSwift/Sources/SignalWorker.swift
+++ b/WorkflowReactiveSwift/Sources/SignalWorker.swift
@@ -62,7 +62,8 @@ public struct SignalWorker<Key: Equatable, Value>: Worker {
 }
 
 extension Signal where Error == Never {
-    @available(*, deprecated, message: "Use `Signal` as `Workflow` instead")
+    @available(*, deprecated)
+    @available(*, unavailable, message: "Use `Signal` as `Workflow` instead")
     public func asWorker<Key: Equatable>(key: Key) -> SignalWorker<Key, Value> {
         return SignalWorker(key: key, signal: self)
     }

--- a/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -168,13 +168,13 @@
         }
 
         func render(state: State, context: RenderContext<Self>) -> TestScreen {
-            subscription.asWorker(key: "signal")
+            subscription
                 .mapOutput { output in
                     AnyWorkflowAction { state in
                         state = output
                         return output
                     }
-                }.running(in: context)
+                }.running(in: context, key: "signal")
 
             return TestScreen(string: "\(state)")
         }


### PR DESCRIPTION
The `key` in `asWorker` is not carried over to the key used to render the `Workflows`. Since, the `Workers` are now keyed based on type + key, this may cause a run-time exception. Marking `asWorker` as `unavailable` minimize this risk.