### PR TITLE
Constrain Worker Rendering type to Void

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -30,6 +30,7 @@ on:
       - 'WorkflowUI/**'
       - '.github/workflows/swift.yaml'
       - '.buildscript/build_swift_docs.sh'
+      - '*.swift'
 
 jobs:
   development-apps:

--- a/WorkflowReactiveSwift.podspec
+++ b/WorkflowReactiveSwift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files = 'WorkflowReactiveSwift/Sources/**/*.swift'
 
   s.dependency 'Workflow', "#{s.version}"
-  s.dependency 'ReactiveSwift'
+  s.dependency 'ReactiveSwift', '~> 6.3.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'WorkflowReactiveSwift/Tests/**/*.swift'

--- a/WorkflowReactiveSwift/Sources/Worker.swift
+++ b/WorkflowReactiveSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible {
+public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 
@@ -92,6 +92,6 @@ private extension WorkerLogger {
 
 extension Worker where Self: Equatable {
     public func isEquivalent(to otherWorker: Self) -> Bool {
-        return self == otherWorker
+        self == otherWorker
     }
 }

--- a/WorkflowRxSwift/Sources/Worker.swift
+++ b/WorkflowRxSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible {
+public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 
@@ -87,6 +87,6 @@ struct WorkerWorkflow<WorkerType: Worker>: Workflow {
 
 extension Worker where Self: Equatable {
     public func isEquivalent(to otherWorker: Self) -> Bool {
-        return self == otherWorker
+        self == otherWorker
     }
 }


### PR DESCRIPTION
@AquaGeek pointed this out during migration, `Rendering` for a `Worker` should always be `Void`. 