### PR TITLE
Enable testing of SignalProducer/Signal/Observable used in Workflows

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -4,33 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '*.podspec'
-      - 'Gemfile*'
-      - 'Package.swift'
-      - 'Samples/**'
-      - 'Tooling/**'
-      - 'Workflow/**'
-      - 'WorkflowSwiftUI/**'
-      - 'WorkflowTesting/**'
-      - 'WorkflowUI/**'
-      - '.github/workflows/swift.yaml'
-      - '.buildscript/build_swift_docs.sh'
-      - '*.swift'
   pull_request:
-    paths:
-      - '*.podspec'
-      - 'Gemfile*'
-      - 'Package.swift'
-      - 'Samples/**'
-      - 'Tooling/**'
-      - 'Workflow/**'
-      - 'WorkflowSwiftUI/**'
-      - 'WorkflowTesting/**'
-      - 'WorkflowUI/**'
-      - '.github/workflows/swift.yaml'
-      - '.buildscript/build_swift_docs.sh'
-      - '*.swift'
 
 jobs:
   development-apps:

--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -21,33 +21,24 @@
     @testable import WorkflowReactiveSwift
 
     extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+        /// Expect a `SignalProducer`.
+        ///
+        /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
         ///
         /// - Parameters:
-        ///   - worker: The worker to be expected
         ///   - producingOutput: An output that should be returned when this worker is requested, if any.
         ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
+        public func expectSignalProducer<OutputType>(
+            producingOutput output: OutputType? = nil,
             key: String = "",
             file: StaticString = #file, line: UInt = #line
         ) -> RenderTester<WorkflowType> {
             expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
+                type: SignalProducerWorkflow<OutputType>.self,
                 key: key,
                 producingRendering: (),
                 producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
-                }
+                assertions: { _ in }
             )
         }
     }

--- a/WorkflowReactiveSwift/TestingTests/SignalProducerTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/SignalProducerTests.swift
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import ReactiveSwift
+import Workflow
+import WorkflowReactiveSwiftTesting
+import XCTest
+
+class SignalProducerTests: XCTestCase {
+    func testSignalProducerWorkflow() {
+        TestWorkflow()
+            .renderTester()
+            .expectSignalProducer(producingOutput: 1, key: "123")
+            .render {}
+    }
+
+    struct TestWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Void
+
+        func render(state: State, context: RenderContext<Self>) -> Rendering {
+            SignalProducer(value: 1)
+                .mapOutput { _ in AnyWorkflowAction<TestWorkflow>.noAction }
+                .running(in: context, key: "123")
+        }
+    }
+}

--- a/WorkflowRxSwift/Testing/ObservableTesting.swift
+++ b/WorkflowRxSwift/Testing/ObservableTesting.swift
@@ -18,36 +18,25 @@
     import Workflow
     import WorkflowTesting
     import XCTest
-    @testable import WorkflowReactiveSwift
+    @testable import WorkflowRxSwift
 
     extension RenderTester {
         /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
-        ///
+
         /// - Parameters:
         ///   - worker: The worker to be expected
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
+        ///   - output: An output that should be returned when this worker is requested, if any.
+        public func expectObservable<OutputType>(
+            producingOutput output: OutputType? = nil,
             key: String = "",
             file: StaticString = #file, line: UInt = #line
         ) -> RenderTester<WorkflowType> {
             expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
+                type: ObservableWorkflow<OutputType>.self,
                 key: key,
                 producingRendering: (),
                 producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
-                }
+                assertions: { _ in }
             )
         }
     }

--- a/WorkflowRxSwift/TestingTests/ObservableTests.swift
+++ b/WorkflowRxSwift/TestingTests/ObservableTests.swift
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import RxSwift
+import Workflow
+import WorkflowRxSwiftTesting
+import XCTest
+
+class ObservableTests: XCTestCase {
+    func testObservableWorkflow() {
+        TestWorkflow()
+            .renderTester()
+            .expectObservable(producingOutput: 1, key: "123")
+            .render {}
+    }
+
+    struct TestWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Void
+
+        func render(state: State, context: RenderContext<Self>) -> Rendering {
+            Observable.from([1])
+                .mapOutput { _ in AnyWorkflowAction<TestWorkflow>.noAction }
+                .running(in: context, key: "123")
+        }
+    }
+}


### PR DESCRIPTION
During migration @AquaGeek found that these were un-testable since `SignalProducerWorkflow` is `internal`. This unblocks this.

@AquaGeek , @bencochran : Any better ideas on how we can accomplish this?