### PR TITLE
[DNM] Ideas to make state mutations from Child Workflows easier

### DIFF
--- a/Samples/SampleApp/Sources/RootWorkflow.swift
+++ b/Samples/SampleApp/Sources/RootWorkflow.swift
@@ -37,25 +37,6 @@ extension RootWorkflow {
     }
 }
 
-// MARK: Actions
-
-extension RootWorkflow {
-    enum Action: WorkflowAction {
-        typealias WorkflowType = RootWorkflow
-
-        case login(name: String)
-
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
-            switch self {
-            case .login(name: let name):
-                state = .demo(name: name)
-            }
-
-            return nil
-        }
-    }
-}
-
 // MARK: Rendering
 
 extension RootWorkflow {
@@ -66,12 +47,13 @@ extension RootWorkflow {
         case .welcome:
             return CrossFadeScreen(
                 base: WelcomeWorkflow()
-                    .mapOutput { output -> Action in
+                    .mapOutput { output -> State in
                         switch output {
                         case .login(name: let name):
-                            return .login(name: name)
+                            return State.demo(name: name)
                         }
                     }
+                    .applyOutputToState(in: context, keyPath: \State.self)
                     .rendered(in: context)
             )
 

--- a/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
+++ b/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
@@ -34,25 +34,6 @@ extension DemoWorkflow {
     }
 }
 
-// MARK: Actions
-
-extension DemoWorkflow {
-    enum Action: WorkflowAction {
-        typealias WorkflowType = DemoWorkflow
-
-        case viewTapped
-
-        func apply(toState state: inout DemoWorkflow.State) -> Never? {
-            switch self {
-            case .viewTapped:
-                state += 1
-            }
-
-            return nil
-        }
-    }
-}
-
 // MARK: Rendering
 
 extension DemoWorkflow {
@@ -63,11 +44,15 @@ extension DemoWorkflow {
     private static let complimentaryColors: [UIColor] = [.blue, .green, .yellow, .purple]
 
     func render(state: State, context: RenderContext<DemoWorkflow>) -> Rendering {
-        let sink = context.makeSink(of: Action.self)
+        let sink = context.makeStateMutationSink()
 
         return SplitScreenContainerScreen(
             leadingScreen: leadingScreenFor(state: state, context: context),
-            trailingScreen: FooScreen(title: "Trailing screen", backgroundColor: .green, viewTapped: { sink.send(.viewTapped) }),
+            trailingScreen: FooScreen(
+                title: "Trailing screen",
+                backgroundColor: .green,
+                viewTapped: { sink.send(\State.self, value: state + 1) }
+            ),
             ratio: DemoWorkflow.sizes[state % DemoWorkflow.sizes.count],
             separatorColor: .black,
             separatorWidth: 1.0 * CGFloat(state)
@@ -75,7 +60,7 @@ extension DemoWorkflow {
     }
 
     private func leadingScreenFor(state: State, context: RenderContext<DemoWorkflow>) -> AnyScreen {
-        let sink = context.makeSink(of: Action.self)
+        let sink = context.makeStateMutationSink()
 
         let color = DemoWorkflow.colors[state % DemoWorkflow.colors.count]
 
@@ -84,7 +69,9 @@ extension DemoWorkflow {
                 FooScreen(
                     title: "Leading Foo screen",
                     backgroundColor: color,
-                    viewTapped: { sink.send(.viewTapped) }
+                    viewTapped: {
+                        sink.send(\State.self, value: state + 1)
+                    }
                 )
             )
         } else {
@@ -94,7 +81,9 @@ extension DemoWorkflow {
                 BarScreen(
                     title: "Leading Bar screen",
                     backgroundColors: [color, complimentaryColor],
-                    viewTapped: { sink.send(.viewTapped) }
+                    viewTapped: {
+                        sink.send(\State.self, value: state + 1)
+                    }
                 )
             )
         }

--- a/Workflow/Sources/AnyWorkflow.swift
+++ b/Workflow/Sources/AnyWorkflow.swift
@@ -80,6 +80,27 @@ extension AnyWorkflow {
 }
 
 extension AnyWorkflow {
+    public func applyOutputToState<Parent: Workflow>(in context: RenderContext<Parent>,
+                                                     stateMutation: @escaping ((inout Parent.State, Output) -> Void)) -> AnyWorkflow<Rendering, AnyWorkflowAction<Parent>> {
+        mapOutput { output in
+            AnyWorkflowAction { state in
+                stateMutation(&state, output)
+                return nil
+            }
+        }
+    }
+
+    public func applyOutputToState<Parent: Workflow, Path: WritableKeyPath<Parent.State, Output>>(
+        in context: RenderContext<Parent>,
+        keyPath: Path
+    ) -> AnyWorkflow<Rendering, AnyWorkflowAction<Parent>> {
+        applyOutputToState(in: context) { state, output in
+            state[keyPath: keyPath] = output
+        }
+    }
+}
+
+extension AnyWorkflow {
     /// This is the type erased outer API (referenced by the containing AnyWorkflow).
     ///
     /// This type is never used directly.

--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -148,3 +148,27 @@ extension RenderContext {
             }
     }
 }
+
+public struct StateMutationSink<WorkflowType: Workflow> {
+    let sink: Sink<AnyWorkflowAction<WorkflowType>>
+
+    public func send<Value>(_ keyPath: WritableKeyPath<WorkflowType.State, Value>, value: Value) {
+        sink.send(
+            AnyWorkflowAction<WorkflowType> { state in
+                state[keyPath: keyPath] = value
+                return nil
+            }
+        )
+    }
+
+    init(_ sink: Sink<AnyWorkflowAction<WorkflowType>>) {
+        self.sink = sink
+    }
+}
+
+extension RenderContext {
+    public func makeStateMutationSink() -> StateMutationSink<WorkflowType> {
+        let sink = makeSink(of: AnyWorkflowAction<WorkflowType>.self)
+        return StateMutationSink(sink)
+    }
+}


### PR DESCRIPTION
Explores introducing APIs to make State mutations easier.

## Proposal 1: 

Introduce:
```swift
extension AnyWorkflow {
    public func applyOutputToState<Parent: Workflow>(in context: RenderContext<Parent>,
                                                     stateMutation: @escaping ((inout Parent.State, Output) -> Void)) 
-> AnyWorkflow<Rendering, AnyWorkflowAction<Parent>>
}
```

that let's us do:
```swift
WelcomeWorkflow()
    .mapOutput { .demo(name: $0) }
    .applyOutputToState(in: context, keyPath: \State.self)
    .rendered(in: context)
```

## Proposal 2:

Introduce:
```swift
extension RenderContext {
    public func makeStateMutationSink() -> StateMutationSink<WorkflowType>
}
```

that let's us do:

```swift
let sink = context.makeStateMutationSink()

return FooScreen(
    title: "Leading Foo screen",
    viewTapped: {
        sink.send(\State.self, value: state + 1)
    }
)

```