### PR TITLE
[Gardening] Polish documentation

### DIFF
--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -168,7 +168,7 @@ extension WorkflowActionTester {
         return self
     }
 
-    @available(*, deprecated, message: "use `send(action:)` followed by `verifyOutput(_:)`, `verify(outpit:)` or `assertNoOutput()`")
+    @available(*, deprecated, message: "use `send(action:)` followed by `verifyOutput(_:)`, `verify(output:)` or `assertNoOutput()`")
     @discardableResult
     public func send(action: Action, outputAssertions: (WorkflowType.Output?) -> Void = { _ in }) -> WorkflowActionTester<WorkflowType, Action> {
         return send(action: action)

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -47,13 +47,13 @@
     ///     .renderTester(initialState: TestWorkflow.State())
     ///     .expect(
     ///         worker: TestWorker(),
-    ///         output: TestWorker.Output.success
+    ///         producingOutput: TestWorker.Output.success
     ///     )
     ///     .expectWorkflow(
     ///         type: ChildWorkflow.self,
     ///         key: "key",
     ///         rendering: "rendering",
-    ///         output: ChildWorkflow.Output.success
+    ///         producingOutput: ChildWorkflow.Output.success
     ///     )
     ///     .render { rendering in
     ///         XCTAssertEqual("expected text on rendering", rendering.text)
@@ -114,7 +114,7 @@
     ///     .expectWorkflow(
     ///         type: ChildWorkflow.self,
     ///         rendering: "rendering",
-    ///         output: ChildWorkflow.Output.success
+    ///         producingOutput: ChildWorkflow.Output.success
     ///     )
     ///     .render { _ in }
     /// ```


### PR DESCRIPTION
## Summary

This PR corrects a minor typo in a `WorkflowActionTester` deprecation warning. Additionally, it updates `RenderTester` documentation to track recent changes to testing APIs.

## Checklist

(NA)

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
