### PR TITLE
Introduce  'makeOutputSink' convenience on 'RenderContext'

### DIFF
--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -148,4 +148,11 @@ extension RenderContext {
                 }
             }
     }
+
+    /// Generates a sink that allows sending the Workflow's output wrapped in an AnyWorkflowAction, allowing bypassing an
+    /// intermediate action.
+    public func makeOutputSink() -> Sink<WorkflowType.Output> {
+        return makeSink(of: AnyWorkflowAction.self)
+            .contraMap { AnyWorkflowAction<WorkflowType>(sendingOutput: $0) }
+    }
 }


### PR DESCRIPTION
## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
