### PR TITLE
Add `AnyWorkflow(rendering:)` to make a constant-rendering workflow

### DIFF
--- a/Workflow/Sources/AnyWorkflow+Rendering.swift
+++ b/Workflow/Sources/AnyWorkflow+Rendering.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extension AnyWorkflow where Output == Never {
+    /// Creates an AnyWorkflow that does nothing but echo the given `rendering`.
+    ///
+    /// - Note: To use with `RenderTester`, use `expectRenderingWorkflow`
+    public init(rendering: Rendering) {
+        self = RenderingWorkflow(rendering: rendering).asAnyWorkflow()
+    }
+}
+
+struct RenderingWorkflow<Rendering>: Workflow {
+    var rendering: Rendering
+    typealias Output = Never
+    typealias State = Void
+
+    func render(state: State, context: RenderContext<Self>) -> Rendering {
+        return rendering
+    }
+}

--- a/Workflow/Tests/AnyWorkflowRenderingTests.swift
+++ b/Workflow/Tests/AnyWorkflowRenderingTests.swift
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Workflow
+
+public class AnyWorkflowRenderingTests: XCTestCase {
+    func testRenderingString() {
+        let workflow = AnyWorkflow(rendering: "Hello")
+        let node = WorkflowNode(workflow: PassthroughWorkflow(workflow))
+
+        XCTAssertEqual(node.render(), "Hello")
+    }
+
+    func testRenderingInt() {
+        let workflow = AnyWorkflow(rendering: 160)
+        let node = WorkflowNode(workflow: PassthroughWorkflow(workflow))
+
+        XCTAssertEqual(node.render(), 160)
+    }
+}
+
+private struct PassthroughWorkflow<Rendering>: Workflow {
+    var child: AnyWorkflow<Rendering, Never>
+    init(_ child: AnyWorkflow<Rendering, Never>) {
+        self.child = child
+    }
+
+    func render(state: Void, context: RenderContext<Self>) -> Rendering {
+        child.rendered(in: context)
+    }
+}

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -253,6 +253,25 @@
         }
     }
 
+    extension RenderTester {
+        /// Expect a constant rendering workflow as created with `AnyWorkflow(rendering:)`
+        ///
+        /// - Parameters:
+        ///   - key: The key of the expected workflow (if specified).
+        ///   - rendering: The rendering result that should be returned when this workflow is rendered.
+        public func expectRenderingWorkflow<Rendering>(
+            key: String = "",
+            producingRendering rendering: Rendering,
+            file: StaticString = #file, line: UInt = #line
+        ) -> RenderTester<WorkflowType> {
+            return expectWorkflow(
+                type: RenderingWorkflow<Rendering>.self,
+                producingRendering: rendering,
+                file: file, line: line
+            )
+        }
+    }
+
     extension Collection {
         fileprivate func appending(_ element: Element) -> [Element] {
             return self + [element]

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -115,6 +115,16 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 XCTAssertEqual("Failed", state.text)
             }
     }
+
+    func test_renderingWorkflow() {
+        WrappingWorkflow(child: AnyWorkflow(rendering: "not-called"))
+            .renderTester()
+            .expectRenderingWorkflow(producingRendering: "real")
+            .render { rendering in
+                XCTAssertEqual("->real<-", rendering)
+            }
+            .assertNoOutput()
+    }
 }
 
 private struct TestWorkflow: Workflow {
@@ -318,5 +328,15 @@ private struct ChildWorkflow: Workflow {
 
     func render(state: ChildWorkflow.State, context: RenderContext<ChildWorkflow>) -> String {
         String(text.reversed())
+    }
+}
+
+private struct WrappingWorkflow: Workflow {
+    var child: AnyWorkflow<String, Never>
+
+    typealias State = Void
+
+    func render(state: State, context: RenderContext<Self>) -> String {
+        "->" + child.rendered(in: context) + "<-"
     }
 }


### PR DESCRIPTION
[Kotlin has `Workflow.rendering()`](https://github.com/square/workflow-kotlin/blob/main/workflow-core/src/main/java/com/squareup/workflow1/StatelessWorkflow.kt#L114-L120). Seems like a handy convenience for fakes and testing (and dependency injection where you support dynamic content but some consumers just want static renderings).

## Checklist

- [X] Unit Tests
- [X] ~UI Tests~
- [X] ~Snapshot Tests (iOS only)~
- [X] I have made corresponding changes to the documentation
