### PR TITLE
Remove deprecated rendered(with:key:)

### DIFF
--- a/MigrationGuide_v1.0.md
+++ b/MigrationGuide_v1.0.md
@@ -10,6 +10,10 @@
 
 `context.awaitResult` was deprecated in Workflow v1.0α and has been removed in the beta. See details in the alpha migration guide, [below](#run-worker).
 
+### Child `Workflow`s
+
+`Workflow.rendered(with:key:)` was deprecated in Workflow v1.0α and has been removed in the beta. See details in the alpha migration guide, [below](#render-child-workflow).
+
 ---
 
 # Workflow v1.0α Migration Guide

--- a/Workflow/Sources/AnyWorkflowConvertible.swift
+++ b/Workflow/Sources/AnyWorkflowConvertible.swift
@@ -84,26 +84,7 @@ extension AnyWorkflowConvertible where Rendering == Void, Output: WorkflowAction
     }
 }
 
-// MARK: - Deprecated
-
-extension AnyWorkflowConvertible {
-    @available(*, deprecated, renamed: "rendered(in:key:)")
-    public func rendered<Parent>(with context: RenderContext<Parent>, key: String = "") -> Rendering where Output: WorkflowAction, Output.WorkflowType == Parent {
-        return rendered(in: context, key: key)
-    }
-
-    @available(*, deprecated, renamed: "rendered(in:key:)")
-    public func rendered<Parent>(with context: RenderContext<Parent>, key: String = "") -> Rendering where Output == AnyWorkflowAction<Parent> {
-        return rendered(in: context, key: key)
-    }
-}
-
-extension AnyWorkflowConvertible where Output == Never {
-    @available(*, deprecated, renamed: "rendered(in:key:)")
-    public func rendered<T>(with context: RenderContext<T>, key: String = "") -> Rendering {
-        return rendered(in: context, key: key)
-    }
-}
+// MARK: -
 
 extension AnyWorkflowConvertible {
     /// Process an `Output`


### PR DESCRIPTION
This was replaced by `rendered(in:key:)`.

## Checklist

- [ ] Unit Tests
- [X] I have made corresponding changes to the documentation