### PR TITLE
Make RenderContext.render(workflow:key:outputMap:) internal

### DIFF
--- a/MigrationGuide_v1.0.md
+++ b/MigrationGuide_v1.0.md
@@ -13,6 +13,7 @@
 ### Child `Workflow`s
 
 `Workflow.rendered(with:key:)` was deprecated in Workflow v1.0α and has been removed in the beta. See details in the alpha migration guide, [below](#render-child-workflow).
+`RenderContext.render(workflow:key:outputMap:)` has been made `internal` instead of `public`. Child `Workflow`s should be rendered via `ChildWorkflow().rendered(in: context)` instead.
 
 ---
 

--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -63,8 +63,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
     /// - Parameter key: A string that uniquely identifies this child.
     ///
     /// - Returns: The `Rendering` result of the child's `render` method.
-    @available(*, deprecated, message: "Use `rendered(in:outputMap:)` on Workflow itself.") // To remove this deprecation, mark this method `internal`
-    public func render<Child, Action>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Child: Workflow, Action: WorkflowAction, WorkflowType == Action.WorkflowType {
+    func render<Child, Action>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Child: Workflow, Action: WorkflowAction, WorkflowType == Action.WorkflowType {
         fatalError()
     }
 


### PR DESCRIPTION
This method was accidentally marked `public` a while back.

I think we have 3 usages of it (internally) that we'll need to migrate.

## Checklist

- [ ] Unit Tests
- [x] I have made corresponding changes to the documentation