### PR TITLE
Hooks in Workflow [Idea] [RFC]

### DIFF
--- a/Workflow/Sources/HookWorkflow.swift
+++ b/Workflow/Sources/HookWorkflow.swift
@@ -1,0 +1,35 @@
+//
+//  HookWorkflow.swift
+//  Workflow
+//
+//  Created by Dhaval Shreyas on 10/26/20.
+//
+
+import Foundation
+
+public struct HookWorkflow<Value>: Workflow {
+    public typealias State = Value
+    public typealias Rendering = (Value, (Value) -> Void)
+
+    let defaultValue: Value
+    public init(defaultValue: Value) {
+        self.defaultValue = defaultValue
+    }
+
+    public func makeInitialState() -> Value {
+        defaultValue
+    }
+
+    public func render(state: Value, context: RenderContext<HookWorkflow<Value>>) -> Rendering {
+        let sink = context.makeSink(of: AnyWorkflowAction.self).contraMap { (val: Value) in
+            .init { state in
+                state = val
+                return nil
+            }
+        }
+        let updater: (Value) -> Void = { val in
+            sink.send(val)
+        }
+        return (state, updater)
+    }
+}


### PR DESCRIPTION
Introducing `HooksWorkflow`, this allows Workflows to use stateful data without using the Workflow's `State`. Similar to React's [hooks](https://reactjs.org/docs/hooks-intro.html).

To use a stateful property:
```swift
let (color, colorUpdater) = HookWorkflow(defaultValue: ColorState.red)
            .rendered(in: context)
```

To update:
```swift
colorUpdater(.green)
```