### PR TITLE
Introduce renderLatestOutput API

### DIFF
--- a/Development.podspec
+++ b/Development.podspec
@@ -35,6 +35,14 @@ Pod::Spec.new do |s|
     app_spec.resources = 'Samples/SampleApp/Resources/**/*.swift'
   end
 
+  s.test_spec 'SampleAppTests' do |test_spec|
+    test_spec.dependency 'Development/SampleApp'
+    test_spec.dependency 'WorkflowTesting'
+    test_spec.requires_app_host = true
+    test_spec.app_host_name = 'Development/SampleApp'
+    test_spec.source_files = 'Samples/SampleApp/Tests/**/*.swift'
+  end
+
   s.test_spec 'WorkflowTesting' do |test_spec|
     test_spec.requires_app_host = true
     test_spec.dependency 'WorkflowTesting'

--- a/Samples/SampleApp/Tests/Info.plist
+++ b/Samples/SampleApp/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Samples/SampleApp/Tests/SampleAppTests.swift
+++ b/Samples/SampleApp/Tests/SampleAppTests.swift
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import Development_SampleApp
+
+class SampleAppTests: XCTestCase {
+    func testDemoWorkflow() {
+        DemoWorkflow(name: "Test")
+            .renderTester(initialState: .init(
+                signal: .init(),
+                colorState: .blue,
+                shouldLoad: true,
+                subscriptionState: .not
+            ))
+            .expectLatestOutputRenderingWorkflow(producing: DemoWorkflow.LoadingState.idle("Hello"))
+            .expectWorkflow(type: ReversingWorkflow.self, producingRendering: "")
+            .render { rendering in
+            }
+    }
+}

--- a/Workflow/Sources/RenderLatestOutputWorkflow.swift
+++ b/Workflow/Sources/RenderLatestOutputWorkflow.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// `RenderLatestOutputWorkflow` accepts a `Workflow` with `Void` Rendering
+/// and projects the latest `Output` from the `Workflow` as a `Rendering` of the `Workflow`.
+///
+/// This can be used to consume the `Output` of a `Workflow` without having to update `State` with the value.
+///
+/// ex:
+/// ```
+/// let data = DataFetchWorker()
+///     .renderLatestOutput(initialValue: .loading)
+///     .rendered(in: context)
+/// ```
+///
+public struct RenderLatestOutputWorkflow<Output>: Workflow {
+    public typealias State = Output
+    public typealias Rendering = Output
+    public typealias Output = Never
+
+    private let initialValue: Output
+    private let childWorkflow: AnyWorkflow<Void, Output>
+
+    /// Initialize `RenderLatestOutputWorkflow`
+    /// - Parameters:
+    ///   - workflow: Type conforming to `AnyWorkflowConvertible`, with `Void` Rendering.
+    ///   - initialValue: Value to start with. This will be rendered until an `Output` is emitted.
+    init<WorkflowType: AnyWorkflowConvertible>(workflow: WorkflowType, initialValue: Output) where WorkflowType.Rendering == Void, WorkflowType.Output == Output {
+        self.childWorkflow = workflow.asAnyWorkflow()
+        self.initialValue = initialValue
+    }
+
+    public func makeInitialState() -> State {
+        initialValue
+    }
+
+    public func render(state: State, context: RenderContext<Self>) -> Rendering {
+        childWorkflow
+            .onOutput { state, output in
+                state = output
+                return nil
+            }.rendered(in: context)
+        return state
+    }
+}
+
+public extension AnyWorkflowConvertible where Rendering == Void {
+    /// Convenience to initialize `RenderLatestOutputWorkflow`
+    /// - Parameter startingWith: Value to start with. This will be rendered until an `Output` is emitted.
+    /// - Returns: `RenderLatestOutputWorkflow`
+    ///
+    /// Note: To test using `RenderTester`, you can use the `expectLatestOutputRenderingWorkflow` API.
+    func renderLatestOutput(startingWith: Output) -> RenderLatestOutputWorkflow<Output> {
+        RenderLatestOutputWorkflow(workflow: self, initialValue: startingWith)
+    }
+}

--- a/Workflow/Tests/RenderLatestOutputWorkflowTests.swift
+++ b/Workflow/Tests/RenderLatestOutputWorkflowTests.swift
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactiveSwift
+import Workflow
+import XCTest
+
+final class RenderLatestOutputWorkflowTests: XCTestCase {
+    var output: Signal<Int, Never>!
+    var input: Signal<Int, Never>.Observer!
+
+    override func setUp() {
+        (output, input) = Signal<Int, Never>.pipe()
+    }
+
+    func test_intialValue() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+        XCTAssertEqual(0, host.rendering.value)
+    }
+
+    func test_rendersOutput() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+
+        let gotValueExpectation = expectation(description: "Got expected value")
+        host.rendering.producer.startWithValues { val in
+            if val == 100 {
+                gotValueExpectation.fulfill()
+            }
+        }
+
+        input.send(value: 100)
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func test_rendersLatestOutput() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+
+        let gotValueExpectation = expectation(description: "Got expected value")
+
+        var values: [Int] = []
+        host.rendering.producer.startWithValues { val in
+            values.append(val)
+            if val == 300 {
+                gotValueExpectation.fulfill()
+            }
+        }
+
+        input.send(value: 100)
+        input.send(value: 200)
+        input.send(value: 300)
+        XCTAssertEqual(values, [0, 100, 200, 300])
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    fileprivate struct TestWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Int
+
+        let value: Int
+        let signal: Signal<Int, Never>
+
+        func render(state: State, context: RenderContext<TestWorkflow>) -> Rendering {
+            ChildWorkflow(value: value, signal: signal)
+                .renderLatestOutput(startingWith: 0)
+                .rendered(in: context)
+        }
+    }
+
+    fileprivate struct ChildWorkflow: Workflow {
+        typealias State = Void
+        typealias Output = Int
+        typealias Rendering = Void
+
+        let value: Int
+        let signal: Signal<Int, Never>
+
+        func render(state: State, context: RenderContext<Self>) {
+            let sink = context.makeOutputSink()
+            context.runSideEffect(key: "") { lifetime in
+                let disposable = self.signal.observeValues { val in
+                    sink.send(val)
+                }
+                lifetime.onEnded {
+                    disposable?.dispose()
+                }
+            }
+        }
+    }
+}

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -20,7 +20,7 @@
     @testable import Workflow
 
     extension RenderTester {
-        internal final class TestContext: RenderContextType {
+        final class TestContext: RenderContextType {
             var state: WorkflowType.State
             var expectedWorkflows: [AnyExpectedWorkflow]
             var expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>]
@@ -53,7 +53,9 @@
 
                     let diagnosticMessage: String
 
-                    if sameTypeDifferentKeys.count == 1 {
+                    if "\(Child.self)".contains("RenderLatestOutputWorkflow") {
+                        diagnosticMessage = "Needs a `expectLatestOutputRenderingWorkflow`?"
+                    } else if sameTypeDifferentKeys.count == 1 {
                         diagnosticMessage = "Expecting key \"\(sameTypeDifferentKeys[0])\"."
                     } else if sameTypeDifferentKeys.count > 1 {
                         diagnosticMessage = "Expecting key in \"\(sameTypeDifferentKeys)\"."

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -22,14 +22,14 @@
     import XCTest
     @testable import Workflow
 
-    extension Workflow {
+    public extension Workflow {
         /// Returns a `RenderTester` with a specified initial state.
-        public func renderTester(initialState: Self.State) -> RenderTester<Self> {
+        func renderTester(initialState: Self.State) -> RenderTester<Self> {
             return RenderTester(workflow: self, state: initialState)
         }
 
         /// Returns a `RenderTester` with an initial state provided by `self.makeInitialState()`
-        public func renderTester() -> RenderTester<Self> {
+        func renderTester() -> RenderTester<Self> {
             return renderTester(initialState: makeInitialState())
         }
     }
@@ -253,18 +253,27 @@
         }
     }
 
-    extension Collection {
-        fileprivate func appending(_ element: Element) -> [Element] {
+    fileprivate extension Collection {
+        func appending(_ element: Element) -> [Element] {
             return self + [element]
         }
     }
 
-    extension Dictionary {
-        fileprivate func setting(key: Key, value: Value) -> [Key: Value] {
+    fileprivate extension Dictionary {
+        func setting(key: Key, value: Value) -> [Key: Value] {
             var newDictionary = self
             newDictionary[key] = value
             return newDictionary
         }
     }
 
+    public extension RenderTester {
+        /// Convenience to add expectation for `RenderLatestOutputWorkflow`
+        /// - Parameters:
+        ///   - producing: Value to return as `Rendering`
+        ///   - key: The key of the expected workflow (if specified).
+        func expectLatestOutputRenderingWorkflow<Value>(producing: Value, key: String = "") -> RenderTester<WorkflowType> {
+            expectWorkflow(type: RenderLatestOutputWorkflow<Value>.self, key: key, producingRendering: producing)
+        }
+    }
 #endif

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -367,6 +367,7 @@ private struct TestWorkflow: Workflow {
         case workflow(param: String, key: String = "")
         case voidWorkflow
         case sideEffect(key: String)
+        case renderLatestOutput
     }
 
     func makeInitialState() -> State {
@@ -377,6 +378,11 @@ private struct TestWorkflow: Workflow {
         switch state {
         case .idle:
             break
+        case .renderLatestOutput:
+            _ = TestWorkflow()
+                .mapRendering { _ in () }
+                .renderLatestOutput(startingWith: .string(""))
+                .rendered(in: context)
         case .workflow(let param, let key):
             _ = TestChildWorkflow(input: param)
                 .rendered(in: context, key: key)

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -128,6 +128,15 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 XCTAssertEqual("Failed", state.text)
             }
     }
+
+    func test_renderLatestOutput() {
+        TestRenderLatestOutputWorkflow()
+            .renderTester()
+            .expectLatestOutputRenderingWorkflow(producing: 10)
+            .render { val in
+                XCTAssertEqual(val, 10)
+            }
+    }
 }
 
 private struct TestWorkflow: Workflow {
@@ -331,5 +340,18 @@ private struct ChildWorkflow: Workflow {
 
     func render(state: ChildWorkflow.State, context: RenderContext<ChildWorkflow>) -> String {
         String(text.reversed())
+    }
+}
+
+private struct TestRenderLatestOutputWorkflow: Workflow {
+    typealias State = Void
+    typealias Rendering = Int
+
+    func render(state: State, context: RenderContext<Self>) -> Rendering {
+        ChildWorkflow(text: "")
+            .mapRendering { _ in () }
+            .mapOutput { _ in 1 }
+            .renderLatestOutput(startingWith: 100)
+            .rendered(in: context)
     }
 }


### PR DESCRIPTION
A common pattern in our codebase is to mutate `State` based on `Worker` output and then consume that `State` value in the `render` method. 

Here we introduce a way to convert the latest `Output` as a `Rendering` of the `Worker`. This lets us skip the intermediate value in `State` to hold this result and the `Action`s needed to mutate it.

**Before:**

```swift
struct MyWorkflow: Workflow {
    enum Action: WorkflowAction {
        typealias WorkflowType = MyWorkflow

        case update(Int)

        func apply(toState state: inout State) -> MyWorkflow.Output? {
            switch self {
            case .update(let value):
                state.fetchedData = value
            }
            return nil
        }
    }

    func render(state: State, context: RenderContext<Self>) -> Rendering {
        DataFetchWorker()
            .mapOutput { Action.update($0) }
            .rendered(in: context)

        switch state.fetchedData {
        case .loading:
            return LoadingScreen()
        case .data(let data):
            return Screen(data: data)
        }
    }
}
```

**After:**

```swift
struct MyWorkflow: Workflow {
    func render(state: State, context: RenderContext<Self>) -> Rendering {
        let data = DataFetchWorker()
            .renderLatestOutput(startingWith: .loading)
            .rendered(in: context)

        switch data {
        case .loading:
            return LoadingScreen()
        case .data(let data):
            return Screen(data: data)
        }
    }
}
```