### PR TITLE
Add helper method to ignore output

### DIFF
--- a/Workflow/Sources/AnyWorkflowConvertible.swift
+++ b/Workflow/Sources/AnyWorkflowConvertible.swift
@@ -99,3 +99,26 @@ extension AnyWorkflowConvertible {
             }
     }
 }
+
+extension AnyWorkflowConvertible {
+    /// Wraps this workflow in a workflow that ignores all outputs.
+    ///
+    /// - Returns: An `AnyWorkflow` with the same rendering and no output.
+    public func ignoringOutput() -> AnyWorkflow<Rendering, Never> {
+        OutputBlockingWorkflow(child: self).asAnyWorkflow()
+    }
+}
+
+private struct OutputBlockingWorkflow<Child: AnyWorkflowConvertible>: Workflow {
+    typealias Output = Never
+    typealias Rendering = Child.Rendering
+    typealias State = Void
+
+    var child: Child
+
+    func render(state: Void, context: RenderContext<OutputBlockingWorkflow<Child>>) -> Child.Rendering {
+        return child
+            .mapOutput { (_) in AnyWorkflowAction.noAction }
+            .rendered(in: context)
+    }
+}

--- a/Workflow/Sources/AnyWorkflowConvertible.swift
+++ b/Workflow/Sources/AnyWorkflowConvertible.swift
@@ -109,7 +109,7 @@ extension AnyWorkflowConvertible {
     }
 }
 
-private struct OutputBlockingWorkflow<Child: AnyWorkflowConvertible>: Workflow {
+struct OutputBlockingWorkflow<Child: AnyWorkflowConvertible>: Workflow {
     typealias Output = Never
     typealias Rendering = Child.Rendering
     typealias State = Void

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -170,6 +170,31 @@
             )
         }
 
+        /// Expect the given workflow type in the next rendering, with its output being ignored by a call to `ignoringOutput()`.
+        ///
+        /// - Parameters:
+        ///   - type: The type of the expected workflow.
+        ///   - key: The key of the expected workflow (if specified).
+        ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
+        ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
+        public func expectWorkflowIgnoringOutput<ExpectedWorkflowType: Workflow>(
+            type: ExpectedWorkflowType.Type,
+            key: String = "",
+            producingRendering rendering: ExpectedWorkflowType.Rendering,
+            file: StaticString = #file,
+            line: UInt = #line,
+            assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
+        ) -> RenderTester<WorkflowType> {
+            return expectWorkflow(
+                type: OutputBlockingWorkflow<ExpectedWorkflowType>.self,
+                key: key,
+                producingRendering: rendering,
+                file: file,
+                line: line,
+                assertions: { assertions($0.child) }
+            )
+        }
+
         /// Expect a side-effect for the given key.
         ///
         /// - Parameter key: The key to expect.

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -85,6 +85,19 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .assert(output: .success)
     }
 
+    func test_ignoredOutput() {
+        OutputIgnoringWorkflow(text: "hello")
+            .renderTester()
+            .expectWorkflowIgnoringOutput(
+                type: ChildWorkflow.self,
+                producingRendering: "olleh"
+            )
+            .render { rendering in
+                XCTAssertEqual("olleh", rendering)
+            }
+            .assertNoOutput()
+    }
+
     func test_childWorkflow() {
         ParentWorkflow(initialText: "hello")
             .renderTester()
@@ -224,6 +237,17 @@ private struct OutputWorkflow: Workflow {
         return TestScreen(text: "value", tapped: {
             sink.send(.emit)
         })
+    }
+}
+
+private struct OutputIgnoringWorkflow: Workflow {
+    typealias State = Void
+    typealias Rendering = ChildWorkflow.Rendering
+
+    var text: String
+
+    func render(state: Void, context: RenderContext<OutputIgnoringWorkflow>) -> Rendering {
+        ChildWorkflow(text: text).ignoringOutput().rendered(in: context)
     }
 }
 


### PR DESCRIPTION
This PR adds a helper method to `AnyWorkflowConvertible` to ignore outputs.

I'm not sure if this is testable, but happy to add tests if someone has an idea how!

## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
