### PR TITLE
[WorkflowTests] Support assertions which throw

### DIFF
--- a/WorkflowTesting/Sources/Internal/AppliedAction.swift
+++ b/WorkflowTesting/Sources/Internal/AppliedAction.swift
@@ -24,11 +24,11 @@ struct AppliedAction<WorkflowType: Workflow> {
         self.erasedAction = action
     }
 
-    func assert<ActionType: WorkflowAction>(type: ActionType.Type = ActionType.self, file: StaticString, line: UInt, assertions: (ActionType) -> Void) where ActionType.WorkflowType == WorkflowType {
+    func assert<ActionType: WorkflowAction>(type: ActionType.Type = ActionType.self, file: StaticString, line: UInt, assertions: (ActionType) throws -> Void) rethrows where ActionType.WorkflowType == WorkflowType {
         guard let action = erasedAction as? ActionType else {
             XCTFail("Expected action of type \(ActionType.self), got \(erasedAction)", file: file, line: line)
             return
         }
-        assertions(action)
+        try assertions(action)
     }
 }

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -35,9 +35,9 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
     public func verifyState(
         file: StaticString = #file,
         line: UInt = #line,
-        assertions: (WorkflowType.State) -> Void
-    ) -> RenderTesterResult<WorkflowType> {
-        assertions(state)
+        assertions: (WorkflowType.State) throws -> Void
+    ) rethrows -> RenderTesterResult<WorkflowType> {
+        try assertions(state)
         return self
     }
 
@@ -59,13 +59,13 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         type: ActionType.Type = ActionType.self,
         file: StaticString = #file,
         line: UInt = #line,
-        assertions: (ActionType) -> Void
-    ) -> RenderTesterResult<WorkflowType> where ActionType.WorkflowType == WorkflowType {
+        assertions: (ActionType) throws -> Void
+    ) rethrows -> RenderTesterResult<WorkflowType> where ActionType.WorkflowType == WorkflowType {
         guard let appliedAction = appliedAction else {
             XCTFail("No action was produced", file: file, line: line)
             return self
         }
-        appliedAction.assert(file: file, line: line, assertions: assertions)
+        try appliedAction.assert(file: file, line: line, assertions: assertions)
         return self
     }
 
@@ -98,13 +98,13 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
     public func verifyOutput(
         file: StaticString = #file,
         line: UInt = #line,
-        assertions: (WorkflowType.Output) -> Void
-    ) -> RenderTesterResult<WorkflowType> {
+        assertions: (WorkflowType.Output) throws -> Void
+    ) rethrows -> RenderTesterResult<WorkflowType> {
         guard let output = output else {
             XCTFail("No output was produced", file: file, line: line)
             return self
         }
-        assertions(output)
+        try assertions(output)
         return self
     }
 }

--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -106,13 +106,13 @@ public struct WorkflowActionTester<WorkflowType, Action> where Action: WorkflowA
     public func verifyOutput(
         file: StaticString = #file,
         line: UInt = #line,
-        _ assertions: (WorkflowType.Output) -> Void
-    ) -> WorkflowActionTester<WorkflowType, Action> {
+        _ assertions: (WorkflowType.Output) throws -> Void
+    ) rethrows -> WorkflowActionTester<WorkflowType, Action> {
         guard let output = output else {
             XCTFail("No output was produced", file: file, line: line)
             return self
         }
-        assertions(output)
+        try assertions(output)
         return self
     }
 
@@ -122,8 +122,8 @@ public struct WorkflowActionTester<WorkflowType, Action> where Action: WorkflowA
     ///
     /// - returns: A tester containing the current state and output.
     @discardableResult
-    public func verifyState(_ assertions: (WorkflowType.State) -> Void) -> WorkflowActionTester<WorkflowType, Action> {
-        assertions(state)
+    public func verifyState(_ assertions: (WorkflowType.State) throws -> Void) rethrows -> WorkflowActionTester<WorkflowType, Action> {
+        try assertions(state)
         return self
     }
 

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -229,8 +229,8 @@
         @discardableResult
         public func render(
             file: StaticString = #file, line: UInt = #line,
-            assertions: (WorkflowType.Rendering) -> Void
-        ) -> RenderTesterResult<WorkflowType> {
+            assertions: (WorkflowType.Rendering) throws -> Void
+        ) rethrows -> RenderTesterResult<WorkflowType> {
             let contextImplementation = TestContext(
                 state: state,
                 expectedWorkflows: expectedWorkflows,
@@ -243,7 +243,7 @@
 
             contextImplementation.assertNoLeftOverExpectations()
 
-            assertions(rendering)
+            try assertions(rendering)
 
             return RenderTesterResult<WorkflowType>(
                 state: contextImplementation.state,

--- a/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
@@ -26,6 +26,16 @@ final class WorkflowActionTesterTests: XCTestCase {
             .verifyState { XCTAssertTrue($0) }
     }
 
+    func test_stateTransitions_throw() throws {
+        try TestAction
+            .tester(withState: false)
+            .send(action: .toggleTapped)
+            .verifyState {
+                try throwingNoop()
+                XCTAssertTrue($0)
+            }
+    }
+
     func test_stateTransitions_equatable() {
         TestAction
             .tester(withState: false)
@@ -45,6 +55,16 @@ final class WorkflowActionTesterTests: XCTestCase {
             .tester(withState: false)
             .send(action: .exitTapped)
             .verifyOutput { output in
+                XCTAssertEqual(output, .finished)
+            }
+    }
+
+    func test_outputs_throw() throws {
+        try TestAction
+            .tester(withState: false)
+            .send(action: .exitTapped)
+            .verifyOutput { output in
+                try throwingNoop()
                 XCTAssertEqual(output, .finished)
             }
     }
@@ -107,3 +127,5 @@ private struct TestWorkflow: Workflow {
         ()
     }
 }
+
+private func throwingNoop() throws {}

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -48,6 +48,17 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .assertNoAction()
     }
 
+    func test_simple_render_throw() throws {
+        let renderTester = TestWorkflow(initialText: "initial").renderTester()
+
+        try renderTester
+            .render { screen in
+                let text = try XCTUnwrap(screen.text)
+                XCTAssertEqual("initial", text)
+            }
+            .assertNoAction()
+    }
+
     func test_action() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
 
@@ -265,7 +276,7 @@ private struct SideEffectWorkflow: Workflow {
 }
 
 private struct TestScreen {
-    var text: String
+    var text: String?
     var tapped: () -> Void
 }
 


### PR DESCRIPTION
## Summary

This PR makes allowances for throwing assertions in `ActionTester.verify` and `RenderTester.render`. These changes are meant to support tests which take advantage of XCTest's expanding API for test cases which throw.

Example of the impact of this change:

**Old:**
```swift
func test_saveEvents() {
    Action
        .tester(withState: state)
        .send(action: .beginSave)
        .verifyOutput { output in
            XCTAssertEqual(output.events[0], .startedSave)
        }
}
```

**New:**
```swift
func test_saveEvents() throws {
    try Action
        .tester(withState: state)
        .send(action: .beginSave)
        .verifyOutput { output in
            let first = try XCTUnwrap(output.events.first)
            XCTAssertEqual(first, .startedSave)
        }
}
```

## Checklist

- [x] Unit Tests
- [x] **N/A** UI Tests 
- [x] **N/A** Snapshot Tests (iOS only)
- [x] **N/A** I have made corresponding changes to the documentation
