### PR TITLE
Tutorial Formatting Fixes

### DIFF
--- a/Samples/Tutorial/Tutorial4.md
+++ b/Samples/Tutorial/Tutorial4.md
@@ -413,3 +413,9 @@ Is the code better after this refactor? It's debatable - having the logic in the
 Additionally, now the `TodoList` and `TodoEdit` workflows are completely decoupled - there is no longer a requirement that the `TodoEdit` workflow is displayed after the list. For instance, we could change the list to have "viewing" or "editing" modes, where tapping on an item might only allow it to be viewed, but another mode would allow editing.
 
 It comes down to the individual judgement of the developer to decide how a tree of workflows should be shaped - this was intended to provide two examples of how this _could_ be structured, but not specify how it _should_.
+
+## Up Next
+
+We now have a pretty fully formed app. However, if we want to keep adding features, we'll want to validate that existing features don't break while we're make improvements. In the next tutorial, we'll cover a couple of techniques for testing workflows.
+
+[Tutorial 5](Tutorial5.md)

--- a/Samples/Tutorial/Tutorial4.md
+++ b/Samples/Tutorial/Tutorial4.md
@@ -416,6 +416,6 @@ It comes down to the individual judgement of the developer to decide how a tree 
 
 ## Up Next
 
-We now have a pretty fully formed app. However, if we want to keep adding features, we'll want to validate that existing features don't break while we're make improvements. In the next tutorial, we'll cover a couple of techniques for testing workflows.
+We now have a pretty fully formed app. However, if we want to keep adding features, we'll want to validate that existing features don't break while we're making improvements. In the next tutorial, we'll cover a couple of techniques for testing workflows.
 
 [Tutorial 5](Tutorial5.md)

--- a/Samples/Tutorial/Tutorial5.md
+++ b/Samples/Tutorial/Tutorial5.md
@@ -578,24 +578,24 @@ class TodoWorkflowTests: XCTestCase {
                 step: .list
             ))
             // We only expect the TodoListWorkflow to be rendered.
-        .expectWorkflow(
-            type: TodoListWorkflow.self,
-            producingRendering: BackStackScreen<AnyScreen>.Item(
-                screen: TodoListScreen(todoTitles: ["Title"], onTodoSelected: { _ in }).asAnyScreen()
-            ),
-            // Simulate selecting the first todo.
-            producingOutput: .selectTodo(index: 0)
-        )
-        .render { items in
-            // Just validate that there is one item in the back stack.
-            // Additional validation could be done on the screens returned, if desired.
-            XCTAssertEqual(1, items.count)
-        }
-        // Assert that the state was updated after the render pass with the output from the TodoListWorkflow.
-        .assert(state: TodoWorkflow.State(
-            todos: [TodoModel(title: "Title", note: "Note")],
-            step: .edit(index: 0)
-        ))
+            .expectWorkflow(
+                type: TodoListWorkflow.self,
+                producingRendering: BackStackScreen<AnyScreen>.Item(
+                    screen: TodoListScreen(todoTitles: ["Title"], onTodoSelected: { _ in }).asAnyScreen()
+                ),
+                // Simulate selecting the first todo.
+                producingOutput: .selectTodo(index: 0)
+            )
+            .render { items in
+                // Just validate that there is one item in the back stack.
+                // Additional validation could be done on the screens returned, if desired.
+                XCTAssertEqual(1, items.count)
+            }
+            // Assert that the state was updated after the render pass with the output from the TodoListWorkflow.
+            .assert(state: TodoWorkflow.State(
+                todos: [TodoModel(title: "Title", note: "Note")],
+                step: .edit(index: 0)
+            ))
     }
 
     func testSavingTodo() throws {


### PR DESCRIPTION
This is just a minor fix to some documentation in the Tutorials.

While going through the tutorials, I noticed that Tutorial 4 didn't link to Tutorial 5 like the others do which was a little jarring. Definitely open to rewording the snippet. I also noticed some minor formatting issues in Tutorial 5. 

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
