### PR TITLE
Fix bugs related to view controller containment

### DIFF
--- a/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -78,6 +78,8 @@
             addChild(rootViewController)
             view.addSubview(rootViewController.view)
             rootViewController.didMove(toParent: self)
+
+            updatePreferredContentSizeIfNeeded()
         }
 
         override public func viewDidLayoutSubviews() {
@@ -103,6 +105,33 @@
 
         override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
             return rootViewController.supportedInterfaceOrientations
+        }
+
+        override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+            return rootViewController.preferredStatusBarUpdateAnimation
+        }
+
+        @available(iOS 14.0, *)
+        override public var childViewControllerForPointerLock: UIViewController? {
+            return rootViewController
+        }
+
+        override public func preferredContentSizeDidChange(
+            forChildContentContainer container: UIContentContainer
+        ) {
+            super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+            guard container === rootViewController else { return }
+
+            updatePreferredContentSizeIfNeeded()
+        }
+
+        private func updatePreferredContentSizeIfNeeded() {
+            let newPreferredContentSize = rootViewController.preferredContentSize
+
+            guard newPreferredContentSize != preferredContentSize else { return }
+
+            preferredContentSize = newPreferredContentSize
         }
     }
 

--- a/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -47,6 +47,9 @@
 
             super.init(nibName: nil, bundle: nil)
 
+            addChild(rootViewController)
+            rootViewController.didMove(toParent: self)
+
             workflowHost
                 .rendering
                 .signal
@@ -75,9 +78,7 @@
 
             view.backgroundColor = .white
 
-            addChild(rootViewController)
             view.addSubview(rootViewController.view)
-            rootViewController.didMove(toParent: self)
 
             updatePreferredContentSizeIfNeeded()
         }

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -24,6 +24,9 @@
         public init(description: ViewControllerDescription) {
             self.currentViewController = description.buildViewController()
             super.init(nibName: nil, bundle: nil)
+
+            addChild(currentViewController)
+            currentViewController.didMove(toParent: self)
         }
 
         public convenience init<S: Screen>(screen: S, environment: ViewEnvironment) {
@@ -62,9 +65,7 @@
         override public func viewDidLoad() {
             super.viewDidLoad()
 
-            addChild(currentViewController)
             view.addSubview(currentViewController.view)
-            currentViewController.didMove(toParent: self)
 
             updatePreferredContentSizeIfNeeded()
         }

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -50,7 +50,7 @@
                     view.addSubview(currentViewController.view)
                     currentViewController.view.frame = view.bounds
                     currentViewController.didMove(toParent: self)
-                    preferredContentSize = currentViewController.preferredContentSize
+                    updatePreferredContentSizeIfNeeded()
                 }
             }
         }
@@ -65,7 +65,8 @@
             addChild(currentViewController)
             view.addSubview(currentViewController.view)
             currentViewController.didMove(toParent: self)
-            preferredContentSize = currentViewController.preferredContentSize
+
+            updatePreferredContentSizeIfNeeded()
         }
 
         override public func viewDidLayoutSubviews() {
@@ -93,15 +94,31 @@
             return currentViewController.supportedInterfaceOrientations
         }
 
-        override public func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+            return currentViewController.preferredStatusBarUpdateAnimation
+        }
+
+        @available(iOS 14.0, *)
+        override public var childViewControllerForPointerLock: UIViewController? {
+            return currentViewController
+        }
+
+        override public func preferredContentSizeDidChange(
+            forChildContentContainer container: UIContentContainer
+        ) {
             super.preferredContentSizeDidChange(forChildContentContainer: container)
 
-            guard
-                (container as? UIViewController) == currentViewController,
-                container.preferredContentSize != preferredContentSize
-            else { return }
+            guard container === currentViewController else { return }
 
-            preferredContentSize = container.preferredContentSize
+            updatePreferredContentSizeIfNeeded()
+        }
+
+        private func updatePreferredContentSizeIfNeeded() {
+            let newPreferredContentSize = currentViewController.preferredContentSize
+
+            guard newPreferredContentSize != preferredContentSize else { return }
+
+            preferredContentSize = newPreferredContentSize
         }
     }
 

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -43,7 +43,7 @@
             XCTAssertEqual(currentViewController.count, 0)
             XCTAssertFalse(describedViewController.isViewLoaded)
             XCTAssertFalse(currentViewController.isViewLoaded)
-            XCTAssertNil(currentViewController.parent)
+            XCTAssertEqual(currentViewController.parent, describedViewController)
         }
 
         func test_viewDidLoad() {
@@ -75,7 +75,7 @@
             XCTAssertEqual((describedViewController.currentViewController as? CounterViewController)?.count, 1)
             XCTAssertFalse(describedViewController.isViewLoaded)
             XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
-            XCTAssertNil(describedViewController.currentViewController.parent)
+            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
         }
 
         func test_update_toCompatibleDescription_afterViewLoads() {


### PR DESCRIPTION
# Overview

- Adds additional view controller property forwarding to contained view controllers in `ContainerViewController` and `DescribedViewController`
- Fixes a missing preferred content size update and avoids updating the preferred content size in a few cases where it did not previously
- Adds contained child view controllers as children in the initializer for these containers. This allows consumers to inspect properties of the view controller before the view has loaded and get appropriate values—previously this would return a default value until the view was loaded even though the information was available.

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
