### PR TITLE
Always remove child view controller from DescribedViewController

### DIFF
--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -42,19 +42,21 @@
             if description.canUpdate(viewController: currentViewController) {
                 description.update(viewController: currentViewController)
             } else {
-                if isViewLoaded {
-                    currentViewController.willMove(toParent: nil)
-                    currentViewController.view.removeFromSuperview()
-                    currentViewController.removeFromParent()
-                }
+                currentViewController.willMove(toParent: nil)
+                currentViewController.viewIfLoaded?.removeFromSuperview()
+                currentViewController.removeFromParent()
+
                 currentViewController = description.buildViewController()
+
+                addChild(currentViewController)
+
                 if isViewLoaded {
-                    addChild(currentViewController)
-                    view.addSubview(currentViewController.view)
                     currentViewController.view.frame = view.bounds
-                    currentViewController.didMove(toParent: self)
+                    view.addSubview(currentViewController.view)
                     updatePreferredContentSizeIfNeeded()
                 }
+
+                currentViewController.didMove(toParent: self)
             }
         }
 

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -108,10 +108,11 @@
 
             // Then
             XCTAssertNotEqual(initialChildViewController, describedViewController.currentViewController)
+            XCTAssertNil(initialChildViewController.parent)
             XCTAssertEqual((describedViewController.currentViewController as? MessageViewController)?.message, "Test")
             XCTAssertFalse(describedViewController.isViewLoaded)
             XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
-            XCTAssertNil(describedViewController.currentViewController.parent)
+            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
         }
 
         func test_update_toIncompatibleDescription_afterViewLoads() {


### PR DESCRIPTION
Fixes an issue where the child of a `DescribedViewController` wasn't removed even when the `currentViewController` was replaced. This issue was introduced in https://github.com/square/workflow-swift/pull/108 - we started setting up the parent-child relationship in the init, but only remove the child if our view is loaded. In the case where an update happens before the view is loaded, that initial child is never removed.

The left-behind relationship and view was causing issues where (correct) assumptions about the view and view controller hierarchy were invalid, causing this crash: https://square.slack.com/archives/CTJ4UNLHF/p1641510705024100

Thanks @tyten and @kyleve for helping debug!

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
