### PR TITLE
Fixed issue 118 PublisherWorkflow forcing subscriptions to run on main run loop

### DIFF
--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -37,7 +37,7 @@
             context.runSideEffect(key: "") { [publisher] lifetime in
                 let cancellable = publisher
                     .map { AnyWorkflowAction(sendingOutput: $0) }
-                    .subscribe(on: RunLoop.main)
+                    .receive(on: DispatchQueue.main)
                     .sink { sink.send($0) }
 
                 lifetime.onEnded {


### PR DESCRIPTION
https://github.com/square/workflow-swift/issues/118

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
