### PR TITLE
Workflow concurrency support for workers

### DIFF
--- a/Development.podspec
+++ b/Development.podspec
@@ -14,6 +14,8 @@ Pod::Spec.new do |s|
   s.dependency 'WorkflowReactiveSwift'
   s.dependency 'WorkflowRxSwift'
   # s.dependency 'WorkflowCombine' # TODO: Disabled because app specs cannot increase the deployment target of the root
+  # s.dependency 'WorkflowConcurrency' # TODO: Disabled because app specs cannot increase the deployment target of the root
+  
   s.source_files = 'Samples/Dummy.swift'
 
   s.subspec 'Dummy' do |ss|
@@ -171,5 +173,12 @@ Pod::Spec.new do |s|
   #   test_spec.framework = 'XCTest'
   #   test_spec.dependency 'WorkflowTesting'
   #   test_spec.dependency 'WorkflowCombineTesting'
+  # end
+  
+  # s.test_spec 'WorkflowConcurrencyTests' do |test_spec|
+  #   test_spec.requires_app_host = true
+  #   test_spec.source_files = 'WorkflowConcurrency/Tests/**/*.swift'
+  #   test_spec.framework = 'XCTest'
+  #   test_spec.dependency 'WorkflowTesting'
   # end
 end

--- a/Package.swift
+++ b/Package.swift
@@ -119,7 +119,7 @@ let package = Package(
         ),
         .testTarget(
             name: "WorkflowConcurrencyTests",
-            dependencies: ["WorkflowConcurrency", "Workflow"],
+            dependencies: ["WorkflowConcurrency", "Workflow", "WorkflowTesting"],
             path: "WorkflowConcurrency/Tests"
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,10 @@ let package = Package(
             name: "WorkflowCombineTesting",
             targets: ["WorkflowCombineTesting"]
         ),
+        .library(
+            name: "WorkflowConcurrency",
+            targets: ["WorkflowConcurrency"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
@@ -107,6 +111,16 @@ let package = Package(
             name: "WorkflowCombineTesting",
             dependencies: ["WorkflowCombine", "WorkflowTesting"],
             path: "WorkflowCombine/Testing"
+        ),
+        .target(
+            name: "WorkflowConcurrency",
+            dependencies: ["Workflow"],
+            path: "WorkflowConcurrency/Sources"
+        ),
+        .testTarget(
+            name: "WorkflowConcurrencyTests",
+            dependencies: ["WorkflowConcurrency", "Workflow"],
+            path: "WorkflowConcurrency/Tests"
         ),
     ],
     swiftLanguageVersions: [.v5]

--- a/WorkflowConcurrency.podspec
+++ b/WorkflowConcurrency.podspec
@@ -1,0 +1,24 @@
+require_relative('version')
+
+Pod::Spec.new do |s|
+    s.name         = 'WorkflowConcurrency'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Infrastructure for Concurrency-powered Workers'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+  
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
+  
+    s.swift_versions = ['5.5']
+    s.ios.deployment_target = '13.0'
+    s.osx.deployment_target = '10.15'
+  
+    s.source_files = 'WorkflowConcurrency/Sources/*.swift'
+    
+    s.dependency 'Workflow', "#{s.version}"
+  
+  end
+  

--- a/WorkflowConcurrency/Sources/Logger.swift
+++ b/WorkflowConcurrency/Sources/Logger.swift
@@ -20,7 +20,7 @@ private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowConcurrency", category: "Worker")
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 // Logs Worker events to OSLog
 final class WorkerLogger<WorkerType: Worker> {
     init() {}

--- a/WorkflowConcurrency/Sources/Logger.swift
+++ b/WorkflowConcurrency/Sources/Logger.swift
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import os.signpost
+
+private extension OSLog {
+    static let worker = OSLog(subsystem: "com.squareup.WorkflowConcurrency", category: "Worker")
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+// Logs Worker events to OSLog
+final class WorkerLogger<WorkerType: Worker> {
+    init() {}
+
+    var signpostID: OSSignpostID { OSSignpostID(log: .worker, object: self) }
+
+    // MARK: - Workers
+
+    func logStarted() {
+        os_signpost(
+            .begin,
+            log: .worker,
+            name: "Running",
+            signpostID: signpostID,
+            "Worker: %{private}@",
+            String(describing: WorkerType.self)
+        )
+    }
+
+    func logFinished(status: StaticString) {
+        os_signpost(
+            .end,
+            log: .worker,
+            name: "Running",
+            signpostID: signpostID,
+            status
+        )
+    }
+
+    func logOutput() {
+        os_signpost(
+            .event,
+            log: .worker,
+            name: "Worker Event",
+            signpostID: signpostID,
+            "Event: %{private}@",
+            String(describing: WorkerType.self)
+        )
+    }
+}

--- a/WorkflowConcurrency/Sources/TaskWorkflow.swift
+++ b/WorkflowConcurrency/Sources/TaskWorkflow.swift
@@ -18,14 +18,14 @@ import Combine
 import Foundation
 import Workflow
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 extension Task: AnyWorkflowConvertible where Failure == Never {
     public func asAnyWorkflow() -> AnyWorkflow<Void, Success> {
         TaskWorkflow(taskProvider: { self }).asAnyWorkflow()
     }
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 struct TaskWorkflow<Value>: Workflow {
     public typealias Output = Value
     public typealias State = Void

--- a/WorkflowConcurrency/Sources/TaskWorkflow.swift
+++ b/WorkflowConcurrency/Sources/TaskWorkflow.swift
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import Foundation
+import Workflow
+
+@available(iOS 15.2, macOS 11.3, *)
+extension Task: AnyWorkflowConvertible where Failure == Never {
+    public func asAnyWorkflow() -> AnyWorkflow<Void, Success> {
+        TaskWorkflow(taskProvider: { self }).asAnyWorkflow()
+    }
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+struct TaskWorkflow<Value>: Workflow {
+    public typealias Output = Value
+    public typealias State = Void
+    public typealias Rendering = Void
+
+    var taskProvider: () -> Task<Value, Never>
+
+    public init(taskProvider: @escaping () -> Task<Value, Never>) {
+        self.taskProvider = taskProvider
+    }
+
+    public func render(state: State, context: RenderContext<TaskWorkflow>) -> Rendering {
+        let sink = context.makeSink(of: AnyWorkflowAction.self)
+        context.runSideEffect(key: "") { [taskProvider] lifetime in
+            DispatchQueue.main.async {
+                let task = Task {
+                    let output = await taskProvider().value
+                    let action = AnyWorkflowAction<TaskWorkflow>(sendingOutput: output)
+                    sink.send(action)
+                }
+
+                lifetime.onEnded {
+                    task.cancel()
+                }
+            }
+        }
+    }
+}

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Workflow
+
+/// Workers define a unit of asynchronous work.
+///
+/// During a render pass, a workflow can ask the context to await the result of a worker.
+///
+/// When this occurs, the context checks to see if there is already a running worker of the same type.
+/// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
+///
+/// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
+@available(iOS 15.2, macOS 11.3, *)
+public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+    /// The type of output events returned by this worker.
+    associatedtype Output
+//    associatedtype WorkerAsync: () async -> Output
+
+    /// Returns a publisher to execute the work represented by this worker.
+    func run() async -> Output
+    /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
+    /// account whatever data is meaningful to the task. For example, a worker that loads a user account from a server
+    /// would not be equivalent to another worker with a different user ID.
+    func isEquivalent(to otherWorker: Self) -> Bool
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+extension Worker {
+    public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
+        WorkerWorkflow(worker: self).asAnyWorkflow()
+    }
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+struct WorkerWorkflow<WorkerType: Worker>: Workflow {
+    let worker: WorkerType
+
+    typealias Output = WorkerType.Output
+    typealias Rendering = Void
+    typealias State = UUID
+
+    func makeInitialState() -> State { UUID() }
+
+    func workflowDidChange(from previousWorkflow: WorkerWorkflow<WorkerType>, state: inout UUID) {
+        if !worker.isEquivalent(to: previousWorkflow.worker) {
+            state = UUID()
+        }
+    }
+
+    func render(state: State, context: RenderContext<WorkerWorkflow>) -> Rendering {
+        let logger = WorkerLogger<WorkerType>()
+        Task.init { () -> AnyWorkflowAction in
+            logger.logStarted()
+            let output = await worker.run()
+            logger.logOutput()
+            logger.logFinished(status: "Finished")
+
+            if Task.isCancelled {
+                logger.logFinished(status: "Cancelled")
+                logger.logFinished(status: "Finished")
+            }
+
+            return AnyWorkflowAction<Self>(sendingOutput: output)
+        }
+        .running(in: context, key: state.uuidString)
+    }
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+extension Worker where Self: Equatable {
+    public func isEquivalent(to otherWorker: Self) -> Bool {
+        self == otherWorker
+    }
+}

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -25,7 +25,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
@@ -39,14 +39,14 @@ public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     func isEquivalent(to otherWorker: Self) -> Bool
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 extension Worker {
     public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
         WorkerWorkflow(worker: self).asAnyWorkflow()
     }
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     let worker: WorkerType
 
@@ -81,7 +81,7 @@ struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     }
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 extension Worker where Self: Equatable {
     public func isEquivalent(to otherWorker: Self) -> Bool {
         self == otherWorker

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -30,7 +30,7 @@ public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 
-    /// Returns a publisher to execute the work represented by this worker.
+    /// Execute the work represented by this worker asynchronously and return the result.
     func run() async -> Output
     /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
     /// account whatever data is meaningful to the task. For example, a worker that loads a user account from a server

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -29,7 +29,6 @@ import Workflow
 public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
-//    associatedtype WorkerAsync: () async -> Output
 
     /// Returns a publisher to execute the work represented by this worker.
     func run() async -> Output

--- a/WorkflowConcurrency/Tests/TaskTests.swift
+++ b/WorkflowConcurrency/Tests/TaskTests.swift
@@ -17,7 +17,6 @@
 import Combine
 import Foundation
 import Workflow
-// import WorkflowConcurrencyTesting
 import XCTest
 @testable import WorkflowConcurrency
 

--- a/WorkflowConcurrency/Tests/TaskTests.swift
+++ b/WorkflowConcurrency/Tests/TaskTests.swift
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import Foundation
+import Workflow
+// import WorkflowConcurrencyTesting
+import XCTest
+@testable import WorkflowConcurrency
+
+@available(iOS 15.2, macOS 11.3, *)
+class PublisherTests: XCTestCase {
+    func test_output() {
+        let host = WorkflowHost(
+            workflow: TaskWorkflow(taskProvider: {
+                Task { "hello world" }
+            })
+        )
+
+        let expectation = XCTestExpectation()
+        var outputValue: String?
+        let disposable = host.output.signal.observeValues { output in
+            outputValue = output
+            print(output)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual("hello world", outputValue)
+
+        disposable?.dispose()
+    }
+}

--- a/WorkflowConcurrency/Tests/TaskTests.swift
+++ b/WorkflowConcurrency/Tests/TaskTests.swift
@@ -21,7 +21,7 @@ import Workflow
 import XCTest
 @testable import WorkflowConcurrency
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 class PublisherTests: XCTestCase {
     func test_output() {
         let host = WorkflowHost(

--- a/WorkflowConcurrency/Tests/TaskTests.swift
+++ b/WorkflowConcurrency/Tests/TaskTests.swift
@@ -24,9 +24,9 @@ import XCTest
 class PublisherTests: XCTestCase {
     func test_output() {
         let host = WorkflowHost(
-            workflow: TaskWorkflow(taskProvider: {
+            workflow: TaskWorkflow(task:
                 Task { "hello world" }
-            })
+            )
         )
 
         let expectation = XCTestExpectation()

--- a/WorkflowConcurrency/Tests/WorkerTests.swift
+++ b/WorkflowConcurrency/Tests/WorkerTests.swift
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Workflow
+import XCTest
+@testable import WorkflowConcurrency
+
+@available(iOS 15.2, macOS 11.3, *)
+class WorkerTests: XCTestCase {
+    func testWorkerOutput() {
+        let host = WorkflowHost(
+            workflow: TaskTestWorkflow(key: "")
+        )
+
+        let expectation = XCTestExpectation()
+        let disposable = host.rendering.signal.observeValues { rendering in
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(0, host.rendering.value)
+
+        wait(for: [expectation], timeout: 5.0)
+        XCTAssertEqual(1, host.rendering.value)
+
+        disposable?.dispose()
+    }
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+private struct TaskTestWorkflow: Workflow {
+    typealias State = Int
+    typealias Rendering = Int
+
+    let key: String
+
+    func makeInitialState() -> Int { 0 }
+
+    func render(state: Int, context: RenderContext<TaskTestWorkflow>) -> Int {
+        TaskTestWorker()
+            .mapOutput { output in
+                AnyWorkflowAction { state in
+                    state = output
+                    return nil
+                }
+            }
+            .running(in: context, key: key)
+        return state
+    }
+}
+
+@available(iOS 15.2, macOS 11.3, *)
+private struct TaskTestWorker: Worker {
+    typealias Output = Int
+
+    func run() async -> Int {
+        do {
+            try await Task.sleep(nanoseconds: 3000000000)
+        } catch {}
+
+        return 1
+    }
+
+    func isEquivalent(to otherWorker: TaskTestWorker) -> Bool { true }
+}

--- a/WorkflowConcurrency/Tests/WorkerTests.swift
+++ b/WorkflowConcurrency/Tests/WorkerTests.swift
@@ -108,12 +108,12 @@ class WorkerTests: XCTestCase {
 
                 func run() async -> Void {
                     startExpectation.fulfill()
-                    for _ in 1 ... 4 {
+                    for _ in 1 ... 200 {
                         if Task.isCancelled {
                             endExpectation.fulfill()
                             return
                         }
-                        try? await Task.sleep(nanoseconds: 500000000)
+                        try? await Task.sleep(nanoseconds: 10000000)
                     }
                     endExpectation.fulfill()
                 }
@@ -153,7 +153,7 @@ private struct TaskTestWorkflow: Workflow {
     func render(state: Int, context: RenderContext<TaskTestWorkflow>) -> Int {
         Task { () -> AnyWorkflowAction in
             do {
-                try await Task.sleep(nanoseconds: 3000000000)
+                try await Task.sleep(nanoseconds: 10000000)
             } catch {}
 
             return AnyWorkflowAction { state in
@@ -194,7 +194,7 @@ private struct TaskTestWorker: Worker {
 
     func run() async -> Int {
         do {
-            try await Task.sleep(nanoseconds: 3000000000)
+            try await Task.sleep(nanoseconds: 10000000)
         } catch {}
 
         return 1

--- a/WorkflowConcurrency/Tests/WorkerTests.swift
+++ b/WorkflowConcurrency/Tests/WorkerTests.swift
@@ -18,7 +18,7 @@ import Workflow
 import XCTest
 @testable import WorkflowConcurrency
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 class WorkerTests: XCTestCase {
     func testWorkerOutput() {
         let host = WorkflowHost(
@@ -39,7 +39,7 @@ class WorkerTests: XCTestCase {
     }
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 private struct TaskTestWorkflow: Workflow {
     typealias State = Int
     typealias Rendering = Int
@@ -49,19 +49,29 @@ private struct TaskTestWorkflow: Workflow {
     func makeInitialState() -> Int { 0 }
 
     func render(state: Int, context: RenderContext<TaskTestWorkflow>) -> Int {
-        TaskTestWorker()
-            .mapOutput { output in
-                AnyWorkflowAction { state in
-                    state = output
-                    return nil
-                }
+        Task { () -> AnyWorkflowAction in
+            do {
+                try await Task.sleep(nanoseconds: 3000000000)
+            } catch {}
+
+            return AnyWorkflowAction { state in
+                state = 1
+                return nil
             }
-            .running(in: context, key: key)
+        }
+//        TaskTestWorker()
+//            .mapOutput { output in
+//                AnyWorkflowAction { state in
+//                    state = output
+//                    return nil
+//                }
+//            }
+        .running(in: context, key: key)
         return state
     }
 }
 
-@available(iOS 15.2, macOS 11.3, *)
+@available(iOS 13.0, macOS 10.15, *)
 private struct TaskTestWorker: Worker {
     typealias Output = Int
 

--- a/WorkflowConcurrency/Tests/WorkerTests.swift
+++ b/WorkflowConcurrency/Tests/WorkerTests.swift
@@ -33,7 +33,7 @@ class WorkerTests: XCTestCase {
 
         XCTAssertEqual(0, host.rendering.value)
 
-        wait(for: [expectation], timeout: 5.0)
+        wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(1, host.rendering.value)
 
         disposable?.dispose()
@@ -51,7 +51,7 @@ class WorkerTests: XCTestCase {
 
         XCTAssertEqual(0, host.rendering.value)
 
-        wait(for: [expectation], timeout: 5.0)
+        wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(1, host.rendering.value)
 
         disposable?.dispose()


### PR DESCRIPTION
Creating a PR for Soo's work on adding concurrency support for async workers.

This adds a WorkflowConcurrency module that defines a `Worker` protocol that can run an `async` function and allows `Task`'s to be run as a workflow.

## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
