### PR TITLE
Allow type conformance in ViewControllerDescription

### DIFF
--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -36,6 +36,7 @@
     public struct ViewControllerDescription {
         private let viewControllerType: UIViewController.Type
         private let build: () -> UIViewController
+        private let checkViewControllerType: (UIViewController) -> Bool
         private let update: (UIViewController) -> Void
 
         /// Constructs a view controller description by providing closures used to
@@ -51,6 +52,7 @@
         public init<VC: UIViewController>(type: VC.Type = VC.self, build: @escaping () -> VC, update: @escaping (VC) -> Void) {
             self.viewControllerType = type
             self.build = build
+            self.checkViewControllerType = { $0 is VC }
             self.update = { untypedViewController in
                 guard let viewController = untypedViewController as? VC else {
                     fatalError("Unable to update \(untypedViewController), expecting a \(VC.self)")
@@ -77,7 +79,7 @@
         /// ### Note
         /// Failure to confirm the view controller is updatable will result in a fatal `precondition`.
         public func canUpdate(viewController: UIViewController) -> Bool {
-            return type(of: viewController) == viewControllerType
+            return checkViewControllerType(viewController)
         }
 
         /// Update the given view controller with the content from the view controller description.

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -96,7 +96,7 @@
                 """
                 `ViewControllerDescription` was provided a view controller it cannot update: (\(viewController).
 
-                The view controller type (\(type(of: viewController)) is not exactly \(viewControllerType)).
+                The view controller type (\(type(of: viewController)) is a compatible type to the expected type \(viewControllerType)).
                 """
             )
 

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -54,9 +54,9 @@
 
             final class SubclassViewController: BlankViewController {}
 
-            // We only update exact type matches, not subclasses
+            // We can update subclasses too, as long as they pass an "is/as?" check.
             let subclassViewController = SubclassViewController()
-            XCTAssertFalse(description.canUpdate(viewController: subclassViewController))
+            XCTAssertTrue(description.canUpdate(viewController: subclassViewController))
         }
 
         func test_update() {

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -24,6 +24,10 @@
 
     fileprivate class BlankViewController: UIViewController {}
 
+    @objc fileprivate protocol MyProtocol {
+        func update()
+    }
+
     class ViewControllerDescriptionTests: XCTestCase {
         func test_build() {
             let description = ViewControllerDescription(
@@ -57,6 +61,25 @@
             // We can update subclasses too, as long as they pass an "is/as?" check.
             let subclassViewController = SubclassViewController()
             XCTAssertTrue(description.canUpdate(viewController: subclassViewController))
+        }
+
+        func test_canUpdate_abstractViewController() {
+            func makeAbstractViewController() -> UIViewController & MyProtocol {
+                class ConcreteViewController: UIViewController, MyProtocol {
+                    func update() {}
+                }
+                return ConcreteViewController()
+            }
+
+            let viewController = makeAbstractViewController()
+
+            let description = ViewControllerDescription(
+                build: { viewController },
+                update: { $0.update() }
+            )
+
+            XCTAssertTrue(description.canUpdate(viewController: viewController))
+            XCTAssertFalse(description.canUpdate(viewController: UIViewController()))
         }
 
         func test_update() {


### PR DESCRIPTION
Currently the view controller passed into ViewControllerDescription at build time must be of a concrete type. `canUpdate(viewController:)` does a type equality check, which fails if the view controller's concrete type does not match the inferred type at initialization. In this case, the program will crash.

This change allows for type conformance, which means that subclasses or abstract view controller types can be used at initialization.


## Checklist

- [x] Unit Tests
- [x] UI Tests
  - N/A 
- [x] Snapshot Tests (iOS only)
  - N/A 
- [x] I have made corresponding changes to the documentation
  - N/A 