### PR TITLE
Revert RxSwift Bump to 6.5.0

### DIFF
--- a/WorkflowRxSwift.podspec
+++ b/WorkflowRxSwift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files = 'WorkflowRxSwift/Sources/**/*.swift'
 
   s.dependency 'Workflow', "#{s.version}"
-  s.dependency 'RxSwift', '~> 6.5'
+  s.dependency 'RxSwift', '~> 6.2'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'WorkflowRxSwift/Tests/**/*.swift'


### PR DESCRIPTION
## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
