### PR TITLE
Fixed Swift 5.6+ compiler crash in TaskWorkflow

### DIFF
--- a/WorkflowConcurrency/Tests/TaskTests.swift
+++ b/WorkflowConcurrency/Tests/TaskTests.swift
@@ -24,9 +24,9 @@ import XCTest
 class PublisherTests: XCTestCase {
     func test_output() {
         let host = WorkflowHost(
-            workflow: TaskWorkflow(taskProvider: {
+            workflow: TaskWorkflow(task:
                 Task { "hello world" }
-            })
+            )
         )
 
         let expectation = XCTestExpectation()


### PR DESCRIPTION
Removing the closure to a Task and just passing in the Task to the TaskWorkflow fixes the compiler crash.


## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
