### PR TITLE
[performance]: disable logging by default & add logging configuration

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -406,7 +406,7 @@ extension WorkflowNode.SubtreeManager {
         }
 
         func render() -> W.Rendering {
-            return node.render()
+            return node.render(isRootNode: false)
         }
 
         func update(workflow: W, outputMap: @escaping (W.Output) -> AnyWorkflowAction<WorkflowType>, eventPipe: EventPipe) {

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -54,7 +54,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
         self.rootNode = WorkflowNode(workflow: workflow)
 
-        self.mutableRendering = MutableProperty(rootNode.render())
+        self.mutableRendering = MutableProperty(rootNode.render(isRootNode: true))
         self.rendering = Property(mutableRendering)
         rootNode.enableEvents()
 
@@ -81,7 +81,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
     }
 
     private func handle(output: WorkflowNode<WorkflowType>.Output) {
-        mutableRendering.value = rootNode.render()
+        mutableRendering.value = rootNode.render(isRootNode: true)
 
         if let outputEvent = output.outputEvent {
             outputEventObserver.send(value: outputEvent)

--- a/Workflow/Sources/WorkflowLogger.swift
+++ b/Workflow/Sources/WorkflowLogger.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import OSLog
+import os.signpost
 
 private extension OSLog {
     /// Logging will use this log handle when enabled
@@ -27,9 +27,11 @@ private extension OSLog {
 // MARK: -
 
 /// Namespace for specifying logging configuration data.
-public enum WorkflowLogging {
+public enum WorkflowLogging {}
+
+extension WorkflowLogging {
     public struct Config {
-        /// Configuration
+        /// Configuration options to control logging during a render pass.
         public enum RenderLoggingMode {
             /// No data will be recorded for WorkflowNode render timings.
             case none
@@ -54,13 +56,19 @@ public enum WorkflowLogging {
     /// Global setting to enable or disable logging.
     /// Note, this is independent of the specified `config` value, and simply governs whether
     /// the runtime should emit any logs.
+    ///
+    /// To enable logging, at a minimum you must set:
+    /// `WorkflowLogging.enabled = true`
+    ///
+    /// If you wish for more control over what the runtime will log, you may additionally specify
+    /// a custom value for `WorkflowLogging.config`.
     public static var enabled: Bool {
         get { OSLog.active === OSLog.workflow }
         set { OSLog.active = newValue ? .workflow : .disabled }
     }
 
     /// Configuration options used to determine which activities are logged.
-    public static var config: Config = .debug
+    public static var config: Config = .rootRendersAndActions
 }
 
 extension WorkflowLogging.Config {
@@ -163,6 +171,8 @@ final class WorkflowLogger {
             os_signpost(.end, log: .active, name: "Render", signpostID: signpostID)
         }
     }
+
+    // MARK: - Utilities
 
     private static func shouldLogRenderTimingsForMode(
         _ renderLoggingMode: WorkflowLogging.Config.RenderLoggingMode,

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -74,6 +74,11 @@ final class WorkflowNode<WorkflowType: Workflow> {
         onOutput?(output)
     }
 
+    /// Internal method that forwards the render call through the underlying `subtreeManager`,
+    /// and eventually to the client-specified `Workflow` instance.
+    /// - Parameter isRootNode: whether or not this is the root node of the tree. Note, this
+    /// is currently only used as a hint for the logging infrastructure, and is up to callers to correctly specify.
+    /// - Returns: A `Rendering` of appropriate type
     func render(isRootNode: Bool = false) -> WorkflowType.Rendering {
         WorkflowLogger.logWorkflowStartedRendering(ref: self, isRootNode: isRootNode)
 

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -74,11 +74,11 @@ final class WorkflowNode<WorkflowType: Workflow> {
         onOutput?(output)
     }
 
-    func render() -> WorkflowType.Rendering {
-        WorkflowLogger.logWorkflowStartedRendering(ref: self)
+    func render(isRootNode: Bool = false) -> WorkflowType.Rendering {
+        WorkflowLogger.logWorkflowStartedRendering(ref: self, isRootNode: isRootNode)
 
         defer {
-            WorkflowLogger.logWorkflowFinishedRendering(ref: self)
+            WorkflowLogger.logWorkflowFinishedRendering(ref: self, isRootNode: isRootNode)
         }
 
         return subtreeManager.render { context in

--- a/Workflow/Tests/PerformanceTests.swift
+++ b/Workflow/Tests/PerformanceTests.swift
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+
+@testable import Workflow
+
+class PerformanceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        WorkflowLogging.enabled = false
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        WorkflowLogging.enabled = false
+    }
+
+    func test_render_shallowWideTree() throws {
+        measure {
+            let node = WorkflowNode(workflow: WideShallowParentWorkflow())
+            _ = node.render(isRootNode: true)
+        }
+    }
+
+    func test_render_narrowDeepTree() throws {
+        measure {
+            let node = WorkflowNode(workflow: NarrowDeepParentWorkflow())
+            _ = node.render(isRootNode: true)
+        }
+    }
+
+    func test_debugLogging_render_wideTree() throws {
+        WorkflowLogging.enabled = true
+        WorkflowLogging.config = .debug
+
+        measure {
+            let node = WorkflowNode(workflow: WideShallowParentWorkflow())
+            _ = node.render(isRootNode: true)
+        }
+    }
+
+    func test_rootNodeLogging_render_wideTree() throws {
+        WorkflowLogging.enabled = true
+        WorkflowLogging.config = .rootRendersAndActions
+
+        measure {
+            let node = WorkflowNode(workflow: WideShallowParentWorkflow())
+            _ = node.render(isRootNode: true)
+        }
+    }
+
+    func test_rootNodeLogging_render_narrowDeepTree() throws {
+        WorkflowLogging.enabled = true
+        WorkflowLogging.config = .rootRendersAndActions
+
+        measure {
+            let node = WorkflowNode(workflow: NarrowDeepParentWorkflow())
+            _ = node.render(isRootNode: true)
+        }
+    }
+}
+
+private extension PerformanceTests {
+    struct WideShallowParentWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Int
+
+        func render(state: Void, context: RenderContext<WideShallowParentWorkflow>) -> Int {
+            var sum = 0
+            for i in 1 ... 1000 {
+                sum += ChildWorkflow()
+                    .rendered(in: context, key: "child-\(i)")
+            }
+
+            return sum
+        }
+    }
+
+    struct NarrowDeepParentWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Int
+
+        func render(state: Void, context: RenderContext<NarrowDeepParentWorkflow>) -> Int {
+            var sum = 0
+            sum += ChildWorkflow(remainingChildren: 999)
+                .rendered(in: context)
+
+            return sum
+        }
+    }
+
+    struct ChildWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Int
+
+        var remainingChildren: UInt = 0
+
+        func render(state: Void, context: RenderContext<ChildWorkflow>) -> Int {
+            let rendering: Int
+
+            if remainingChildren > 0 {
+                rendering = ChildWorkflow(remainingChildren: remainingChildren - 1)
+                    .rendered(in: context)
+            } else {
+                rendering = 42
+            }
+
+            return rendering
+        }
+    }
+}

--- a/Workflow/Tests/PerformanceTests.swift
+++ b/Workflow/Tests/PerformanceTests.swift
@@ -29,7 +29,7 @@ class PerformanceTests: XCTestCase {
         WorkflowLogging.enabled = false
     }
 
-    func test_render_shallowWideTree() throws {
+    func test_render_wideShallowTree() throws {
         measure {
             let node = WorkflowNode(workflow: WideShallowParentWorkflow())
             _ = node.render(isRootNode: true)
@@ -43,7 +43,7 @@ class PerformanceTests: XCTestCase {
         }
     }
 
-    func test_debugLogging_render_wideTree() throws {
+    func test_debugLogging_render_wideShallowTree() throws {
         WorkflowLogging.enabled = true
         WorkflowLogging.config = .debug
 
@@ -53,7 +53,7 @@ class PerformanceTests: XCTestCase {
         }
     }
 
-    func test_rootNodeLogging_render_wideTree() throws {
+    func test_rootNodeLogging_render_wideShallowTree() throws {
         WorkflowLogging.enabled = true
         WorkflowLogging.config = .rootRendersAndActions
 

--- a/WorkflowRxSwift/Sources/Logger.swift
+++ b/WorkflowRxSwift/Sources/Logger.swift
@@ -16,8 +16,20 @@
 
 import os.signpost
 
+// Namespace for Worker logging
+public enum WorkerLogging {}
+
+extension WorkerLogging {
+    public static var enabled: Bool {
+        get { OSLog.active === OSLog.worker }
+        set { OSLog.active = newValue ? .worker : .disabled }
+    }
+}
+
 private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowRxSwift", category: "Worker")
+
+    static var active: OSLog = .disabled
 }
 
 // MARK: -
@@ -27,7 +39,7 @@ final class WorkerLogger<WorkerType: Worker> {
     init() {}
 
     @available(iOS 12.0, macOS 10.14, *)
-    var signpostID: OSSignpostID { OSSignpostID(log: .worker, object: self) }
+    var signpostID: OSSignpostID { OSSignpostID(log: .active, object: self) }
 
     // MARK: - Workers
 
@@ -35,7 +47,7 @@ final class WorkerLogger<WorkerType: Worker> {
         if #available(iOS 12.0, macOS 10.14, *) {
             os_signpost(
                 .begin,
-                log: .worker,
+                log: .active,
                 name: "Running",
                 signpostID: self.signpostID,
                 "Worker: %{private}@",
@@ -46,7 +58,7 @@ final class WorkerLogger<WorkerType: Worker> {
 
     func logFinished(status: StaticString) {
         if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(.end, log: .worker, name: "Running", signpostID: signpostID, status)
+            os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
         }
     }
 
@@ -54,7 +66,7 @@ final class WorkerLogger<WorkerType: Worker> {
         if #available(iOS 12.0, macOS 10.14, *) {
             os_signpost(
                 .event,
-                log: .worker,
+                log: .active,
                 name: "Worker Event",
                 signpostID: signpostID,
                 "Event: %{private}@",


### PR DESCRIPTION
## Background

- during some recent investigations into rendering performance, we found that leaving the runtime os logging enabled (the current implicit behavior) had a noticeable adverse effect.

## Changes

- logging is now opt-in, and disabled by default
- added additional configuration options to control which categories of runtime data are logged
- added synthetic performance tests to gut check execution time changes under various logging configurations

example XCTest run after disabling logging:
<img width="80%" alt="Screen Shot 2022-08-17 at 14 30 31" src="https://user-images.githubusercontent.com/2119834/185399327-bdbf9356-08fb-45eb-a68e-8f5d0a319011.png">

## Checklist

- [x] Unit Tests
- [x] I have made corresponding changes to the documentation
- [x] TODO: apply changes to assorted WorkerLogger implementations
