### PR TITLE
Updates to make it easier to avoid using `DescribedViewController`, allowing flattening of VC hierarchies.

### DIFF
--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -25,6 +25,10 @@ Pod::Spec.new do |s|
     test_spec.framework = 'XCTest'
     test_spec.library = 'swiftos'
     test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
+
+    # Create an app host so that we can host
+    # view or view controller based tests in a real environment.
+    test_spec.requires_app_host = true
   end
 end
 

--- a/WorkflowUI/Sources/Screen/Screen.swift
+++ b/WorkflowUI/Sources/Screen/Screen.swift
@@ -16,6 +16,8 @@
 
 #if canImport(UIKit)
 
+    import UIKit
+
     /// Screens are the building blocks of an interactive application.
     ///
     /// Conforming types contain any information needed to populate a screen: data,
@@ -24,6 +26,30 @@
         /// A view controller description that acts as a recipe to either build
         /// or update a previously-built view controller to match this screen.
         func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription
+    }
+
+    extension Screen {
+        /// If the given view controller is of the correct type to be updated by this screen.
+        ///
+        /// If your view controller type can change between updates, call this method before invoking `update(viewController:with:)`.
+        public func canUpdate(viewController: UIViewController, with environment: ViewEnvironment) -> Bool {
+            viewControllerDescription(environment: environment).canUpdate(viewController: viewController)
+        }
+
+        /// Update the given view controller with the content from the screen.
+        ///
+        /// ### Note
+        /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
+        /// that passes `canUpdate(viewController:with:)`. Failure to do so will result in a fatal precondition.
+        public func update(viewController: UIViewController, with environment: ViewEnvironment) {
+            viewControllerDescription(environment: environment).update(viewController: viewController)
+        }
+
+        /// Construct and update a new view controller as described by this Screen.
+        /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
+        public func buildViewController(in environment: ViewEnvironment) -> UIViewController {
+            viewControllerDescription(environment: environment).buildViewController()
+        }
     }
 
 #endif

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -57,6 +57,8 @@
                 }
 
                 currentViewController.didMove(toParent: self)
+
+                updatePreferredContentSizeIfNeeded()
             }
         }
 
@@ -67,6 +69,7 @@
         override public func viewDidLoad() {
             super.viewDidLoad()
 
+            currentViewController.view.frame = view.bounds
             view.addSubview(currentViewController.view)
 
             updatePreferredContentSizeIfNeeded()
@@ -124,5 +127,4 @@
             preferredContentSize = newPreferredContentSize
         }
     }
-
 #endif

--- a/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+    import UIKit
+
+    extension UpdateChildScreenViewController where Self: UIViewController {
+        /// Updates the view controller at the given `child` key path with the
+        /// `ViewControllerDescription` from `screen`. If the type of the underlying view
+        /// controller changes between update passes, this method will remove
+        /// the old view controller, create a new one, update it, and insert it into the view controller hierarchy.
+        ///
+        /// The view controller at `child` must be a child of `self`.
+        ///
+        /// - Parameters:
+        /// - parameter child: The `KeyPath` which describes what view controller to update. This view controller must be a direct child of `self`.
+        /// - parameter screen: The `Screen` instance to apply to the view controller.
+        /// - parameter environment: The `environment` to used when updating the view controller.
+        /// - parameter onChange: A callback called if the view controller instance changed.
+        ///
+        public func update<VC: UIViewController, ScreenType: Screen>(
+            child: ReferenceWritableKeyPath<Self, VC>,
+            with screen: ScreenType,
+            in environment: ViewEnvironment,
+            onChange: (VC) -> Void = { _ in }
+        ) {
+            let description = screen.viewControllerDescription(environment: environment)
+
+            let existing = self[keyPath: child]
+
+            if description.canUpdate(viewController: existing) {
+                // Easy path: Just update the existing view controller if we can do that.
+                description.update(viewController: existing)
+            } else {
+                // If we can't update the view controller, that means its type changed.
+                // We'll need to make a new view controller and swap over to it.
+
+                let old = existing
+
+                // Make the new view controller.
+
+                let new = description.buildViewController() as! VC
+
+                // We already have a reference to the old vc above, update the keypath to the new one.
+
+                self[keyPath: child] = new
+
+                // We should only add the view controller if the old one was already within the parent.
+
+                if let parent = old.parent {
+                    precondition(
+                        parent == self,
+                        """
+                        The parent of the child view controller must be \(self). Instead, it was \(parent). \
+                        Please call `update(child:)` on the correct parent view controller.
+                        """
+                    )
+
+                    // Begin the transition: Signal the new vc will begin moving in, and the old one, out.
+
+                    parent.addChild(new)
+                    old.willMove(toParent: nil)
+
+                    if
+                        parent.isViewLoaded,
+                        old.isViewLoaded,
+                        let container = old.view.superview {
+                        // We will only add the view to the hierarchy if
+                        // the parent's view is loaded, and the existing view
+                        // is loaded, and the old view was in a superview.
+
+                        // We will only perform appearance transitions if we're visible.
+
+                        let isVisible = parent.view.window != nil
+
+                        // The view should end up with the same frame.
+
+                        new.view.frame = old.view.frame
+
+                        if isVisible {
+                            new.beginAppearanceTransition(true, animated: false)
+                            old.beginAppearanceTransition(false, animated: false)
+                        }
+
+                        container.insertSubview(new.view, aboveSubview: old.view)
+                        old.view.removeFromSuperview()
+
+                        if isVisible {
+                            new.endAppearanceTransition()
+                            old.endAppearanceTransition()
+                        }
+                    }
+
+                    // Finish the transition by signaling the vc they've fully moved in / out.
+
+                    new.didMove(toParent: parent)
+                    old.removeFromParent()
+                }
+
+                onChange(new)
+            }
+        }
+    }
+
+    public protocol UpdateChildScreenViewController {}
+
+    extension UIViewController: UpdateChildScreenViewController {}
+
+#endif

--- a/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -47,7 +47,7 @@
             let container = ContainerViewController(workflow: workflow)
 
             withExtendedLifetime(container) {
-                let vc = container.rootViewController.currentViewController as! TestScreenViewController
+                let vc = container.rootViewController as! TestScreenViewController
                 XCTAssertEqual("0", vc.screen.string)
             }
         }
@@ -60,7 +60,7 @@
             withExtendedLifetime(container) {
                 let expectation = XCTestExpectation(description: "View Controller updated")
 
-                let vc = container.rootViewController.currentViewController as! TestScreenViewController
+                let vc = container.rootViewController as! TestScreenViewController
                 vc.onScreenChange = {
                     expectation.fulfill()
                 }
@@ -118,7 +118,7 @@
             withExtendedLifetime(container) {
                 let expectation = XCTestExpectation(description: "View Controller updated")
 
-                let vc = container.rootViewController.currentViewController as! TestScreenViewController
+                let vc = container.rootViewController as! TestScreenViewController
 
                 XCTAssertEqual("first", vc.screen.string)
 

--- a/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
+++ b/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+    import UIKit
+    import XCTest
+    @testable import WorkflowUI
+
+    class UIViewControllerExtensionTests: XCTestCase {
+        func test_update_viewNotLoaded() {
+            let fixture = TestFixture(loadView: false, screen: Screen1(), environment: .empty)
+
+            // Update to the same screen type should do nothing.
+
+            XCTAssertFalse(fixture.root.isViewLoaded)
+            XCTAssertFalse(fixture.root.content.isViewLoaded)
+
+            fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
+            XCTAssertFalse(fixture.root.isViewLoaded)
+            XCTAssertFalse(fixture.root.content.isViewLoaded)
+            XCTAssertEqual(fixture.events, [])
+
+            // Update to a new screen type should swap out the screen and send the correct events.
+
+            fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+            XCTAssertFalse(fixture.root.isViewLoaded)
+            XCTAssertFalse(fixture.root.content.isViewLoaded)
+            XCTAssertEqual(fixture.events, [
+                .child_willMoveTo(identifier: "2", parent: fixture.root),
+                .child_willMoveTo(identifier: "1", parent: nil),
+                .child_didMoveTo(identifier: "2", parent: fixture.root),
+                .child_didMoveTo(identifier: "1", parent: nil),
+            ])
+        }
+
+        func test_update_viewLoaded() {
+            let fixture = TestFixture(screen: Screen1(), environment: .empty)
+            fixture.root.loadViewIfNeeded()
+
+            // Update to the same screen type should do nothing.
+
+            fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
+            XCTAssertEqual(fixture.events, [])
+
+            // Update to a new screen type should swap out the screen and send the correct events.
+
+            fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+            XCTAssertEqual(fixture.events, [
+                .child_willMoveTo(identifier: "2", parent: fixture.root),
+                .child_willMoveTo(identifier: "1", parent: nil),
+                .child_view_loadView(identifier: "2"),
+                .child_didMoveTo(identifier: "2", parent: fixture.root),
+                .child_didMoveTo(identifier: "1", parent: nil),
+            ])
+        }
+
+        func test_update_hostedView() {
+            let fixture = TestFixture(screen: Screen1(), environment: .empty)
+
+            show(vc: fixture.root) { root in
+
+                fixture.clearAllEvents()
+
+                // Update to the same screen type should do nothing.
+
+                root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
+                XCTAssertEqual(fixture.events, [])
+
+                // Update to a new screen type should swap out the screen and send the correct events.
+
+                root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+                XCTAssertEqual(fixture.events, [
+                    .child_willMoveTo(identifier: "2", parent: fixture.root),
+                    .child_willMoveTo(identifier: "1", parent: nil),
+                    .child_view_loadView(identifier: "2"),
+                    .child_viewWillAppear(identifier: "2", animated: false),
+                    .child_viewWillDisappear(identifier: "1", animated: false),
+                    .child_viewDidAppear(identifier: "2", animated: false),
+                    .child_viewDidDisappear(identifier: "1", animated: false),
+                    .child_didMoveTo(identifier: "2", parent: fixture.root),
+                    .child_didMoveTo(identifier: "1", parent: nil),
+                ])
+            }
+        }
+    }
+
+    fileprivate enum TestingEvent: Equatable {
+        // View Controller Events
+
+        case child_viewWillAppear(identifier: String, animated: Bool)
+        case child_viewWillDisappear(identifier: String, animated: Bool)
+        case child_viewDidAppear(identifier: String, animated: Bool)
+        case child_viewDidDisappear(identifier: String, animated: Bool)
+
+        case child_willMoveTo(identifier: String, parent: UIViewController?)
+        case child_didMoveTo(identifier: String, parent: UIViewController?)
+
+        // View Events
+
+        case child_view_loadView(identifier: String)
+    }
+
+    private final class RootVC: UIViewController {
+        var content: VCBase
+
+        init(screen: Screen, environment: ViewEnvironment) {
+            self.content = screen
+                .viewControllerDescription(environment: environment)
+                .buildViewController() as! VCBase
+
+            super.init(nibName: nil, bundle: nil)
+
+            addChild(content)
+            content.didMove(toParent: self)
+        }
+
+        required init?(coder: NSCoder) { fatalError() }
+
+        override func loadView() {
+            super.loadView()
+
+            content.view.frame = view.bounds
+
+            view.addSubview(content.view)
+        }
+
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+
+            content.view.frame = view.bounds
+        }
+
+        func update(with screen: Screen, environment: ViewEnvironment) {
+            update(child: \.content, with: screen.asAnyScreen(), in: environment)
+        }
+    }
+
+    private struct Screen1: Screen {
+        var recordEvent: (TestingEvent) -> Void = { _ in }
+
+        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+            ViewControllerDescription(
+                type: VC1.self,
+                build: { VC1(identifier: "1", recordEvent: recordEvent) },
+                update: { $0.recordEvent = recordEvent }
+            )
+        }
+    }
+
+    private struct Screen2: Screen {
+        var recordEvent: (TestingEvent) -> Void = { _ in }
+
+        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+            ViewControllerDescription(
+                type: VC2.self,
+                build: { VC2(identifier: "2", recordEvent: recordEvent) },
+                update: { $0.recordEvent = recordEvent }
+            )
+        }
+    }
+
+    private final class TestFixture {
+        public let root: RootVC
+
+        private(set) var events: [TestingEvent] = []
+
+        public func clearAllEvents() {
+            events.removeAll()
+        }
+
+        public init(
+            loadView: Bool = true,
+            screen: Screen,
+            environment: ViewEnvironment
+        ) {
+            self.root = .init(
+                screen: screen,
+                environment: environment
+            )
+
+            root.content.recordEvent = recordEvent
+
+            if loadView {
+                root.loadViewIfNeeded()
+            }
+
+            clearAllEvents()
+        }
+
+        var recordEvent: (TestingEvent) -> Void {
+            { [weak self] in self?.events.append($0) }
+        }
+    }
+
+    private final class VC1: VCBase {}
+    private final class VC2: VCBase {}
+
+    private class VCBase: UIViewController {
+        let identifier: String
+
+        var recordEvent: (TestingEvent) -> Void = { _ in }
+
+        public init(
+            identifier: String,
+            recordEvent: @escaping (TestingEvent) -> Void
+        ) {
+            self.identifier = identifier
+            self.recordEvent = recordEvent
+
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) { fatalError() }
+
+        override public func loadView() {
+            super.loadView()
+
+            recordEvent(.child_view_loadView(identifier: identifier))
+        }
+
+        override public func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            recordEvent(.child_viewWillAppear(identifier: identifier, animated: animated))
+
+            /// Ensure that as we're appearing, our frame is the correct final size.
+
+            XCTAssertEqual(view.bounds.size, parent?.view.bounds.size)
+        }
+
+        override public func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            recordEvent(.child_viewDidAppear(identifier: identifier, animated: animated))
+        }
+
+        override public func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            recordEvent(.child_viewWillDisappear(identifier: identifier, animated: animated))
+        }
+
+        override public func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+            recordEvent(.child_viewDidDisappear(identifier: identifier, animated: animated))
+        }
+
+        override public func willMove(toParent parent: UIViewController?) {
+            super.willMove(toParent: parent)
+            recordEvent(.child_willMoveTo(identifier: identifier, parent: parent))
+        }
+
+        override public func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            recordEvent(.child_didMoveTo(identifier: identifier, parent: parent))
+        }
+    }
+
+#endif

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -148,4 +148,23 @@
         }
     }
 
+    class ViewControllerDescription_KindIdentifierTests: XCTestCase {
+        private final class VC1: UIViewController {}
+        private final class VC2: UIViewController {}
+
+        func test_kind() {
+            let kind1 = ViewControllerDescription.KindIdentifier(VC1.self)
+            let kind2 = ViewControllerDescription.KindIdentifier(VC2.self)
+
+            XCTAssertEqual(kind1, kind1)
+            XCTAssertNotEqual(kind1, kind2)
+
+            let vc1 = VC1()
+            let vc2 = VC2()
+
+            XCTAssertTrue(kind1.canUpdate(viewController: vc1))
+            XCTAssertFalse(kind1.canUpdate(viewController: vc2))
+        }
+    }
+
 #endif

--- a/WorkflowUI/Tests/XCTestCase+Extensions.swift
+++ b/WorkflowUI/Tests/XCTestCase+Extensions.swift
@@ -1,0 +1,66 @@
+//
+//  XCTestCase+Extensions.swift
+//  WorkflowUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 9/1/22.
+//
+
+#if canImport(UIKit)
+
+    import Foundation
+    import UIKit
+    import XCTest
+
+    extension XCTestCase {
+        ///
+        /// Call this method to show a view controller in the test host application
+        /// during a unit test. The view controller will be the size of host application's device.
+        ///
+        /// After the test runs, the view controller will be removed from the view hierarchy.
+        ///
+        /// A test failure will occur if the host application does not exist, or does not have a root view controller.
+        ///
+        public func show<ViewController: UIViewController>(
+            vc viewController: ViewController,
+            loadAndPlaceView: Bool = true,
+            test: (ViewController) throws -> Void
+        ) rethrows {
+            guard let rootVC = UIApplication.shared.delegate?.window??.rootViewController else {
+                #if SWIFT_PACKAGE
+                    print("WARNING: Test cannot run in SPM, it requires an app host. Please run WorkflowUI.podspec's tests.")
+                #else
+                    XCTFail("Cannot present a view controller in a test host that does not have a root window.")
+                #endif
+                return
+            }
+
+            rootVC.addChild(viewController)
+            viewController.didMove(toParent: rootVC)
+
+            if loadAndPlaceView {
+                viewController.view.frame = rootVC.view.bounds
+                viewController.view.layoutIfNeeded()
+
+                rootVC.beginAppearanceTransition(true, animated: false)
+                rootVC.view.addSubview(viewController.view)
+                rootVC.endAppearanceTransition()
+            }
+
+            defer {
+                if loadAndPlaceView {
+                    viewController.beginAppearanceTransition(false, animated: false)
+                    viewController.view.removeFromSuperview()
+                    viewController.endAppearanceTransition()
+                }
+
+                viewController.willMove(toParent: nil)
+                viewController.removeFromParent()
+            }
+
+            try autoreleasepool {
+                try test(viewController)
+            }
+        }
+    }
+
+#endif


### PR DESCRIPTION
This change makes it easier to avoid using `DescribedViewController`, which adds a (largely needless) layer to view controller hierarchies. I'll leave comments inline on relevant additions with comments.

For Square folks, I recommend seeing how this is used in context in https://github.com/squareup/market/pull/4559.

## Before
![image](https://user-images.githubusercontent.com/327847/187312927-7f448f2f-d186-4753-8d17-871d28dc0959.png)

## After
![image](https://user-images.githubusercontent.com/327847/187312950-d25b349c-25ae-4182-b367-2312d5b94421.png)

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
