### PR TITLE
Rename ContainerViewController to WorkflowHostingController

### DIFF
--- a/Samples/AsyncWorker/AsyncWorker/SceneDelegate.swift
+++ b/Samples/AsyncWorker/AsyncWorker/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ContainerViewController(workflow: AsyncWorkerWorkflow())
+        window.rootViewController = WorkflowHostingController(workflow: AsyncWorkerWorkflow())
         self.window = window
         window.makeKeyAndVisible()
     }

--- a/Samples/SampleApp/Sources/AppDelegate.swift
+++ b/Samples/SampleApp/Sources/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        window?.rootViewController = ContainerViewController(workflow: RootWorkflow())
+        window?.rootViewController = WorkflowHostingController(workflow: RootWorkflow())
 
         window?.makeKeyAndVisible()
 

--- a/Samples/SplitScreenContainer/DemoApp/AppDelegate.swift
+++ b/Samples/SplitScreenContainer/DemoApp/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let window = UIWindow(frame: UIScreen.main.bounds)
 
-        let container = ContainerViewController(
+        let container = WorkflowHostingController(
             workflow: DemoWorkflow()
         )
 

--- a/Samples/TicTacToe/Sources/AppDelegate.swift
+++ b/Samples/TicTacToe/Sources/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        window?.rootViewController = ContainerViewController(workflow: MainWorkflow())
+        window?.rootViewController = WorkflowHostingController(workflow: MainWorkflow())
 
         window?.makeKeyAndVisible()
 

--- a/Samples/Tutorial/AppHost/Sources/AppDelegate.swift
+++ b/Samples/Tutorial/AppHost/Sources/AppDelegate.swift
@@ -24,7 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        let viewController = TutorialContainerViewController()
+        let viewController = TutorialHostingViewController()
 
         window?.rootViewController = viewController
 

--- a/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/TutorialHostingViewController.swift
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import BackStackContainer
 import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow
-        self.containerViewController = ContainerViewController(workflow: RootWorkflow())
+        // Create a `WorkflowHostingController` with the `WelcomeWorkflow` as the root workflow
+        self.containerViewController = WorkflowHostingController(workflow: WelcomeWorkflow())
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/TutorialHostingViewController.swift
@@ -19,12 +19,12 @@ import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow
-        self.containerViewController = ContainerViewController(workflow: RootWorkflow())
+        // Create a `WorkflowHostingController` with the `RootWorkflow` as the root workflow
+        self.containerViewController = WorkflowHostingController(workflow: RootWorkflow())
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/TutorialHostingViewController.swift
@@ -19,12 +19,12 @@ import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow
-        self.containerViewController = ContainerViewController(workflow: RootWorkflow())
+        // Create a `WorkflowHostingController` with the `RootWorkflow` as the root workflow
+        self.containerViewController = WorkflowHostingController(workflow: RootWorkflow())
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/TutorialHostingViewController.swift
@@ -19,12 +19,12 @@ import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow
-        self.containerViewController = ContainerViewController(workflow: RootWorkflow())
+        // Create a `WorkflowHostingController` with the `RootWorkflow` as the root workflow
+        self.containerViewController = WorkflowHostingController(workflow: RootWorkflow())
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/TutorialHostingViewController.swift
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
+import BackStackContainer
 import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Show one of the sample view controllers, to demonstrate the provided views:
-        self.containerViewController = WelcomeSampleViewController()
+        // Create a `WorkflowHostingController` with the `RootWorkflow` as the root workflow
+        self.containerViewController = WorkflowHostingController(workflow: RootWorkflow())
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/Frameworks/TutorialBase/Sources/TutorialHostingViewController.swift
+++ b/Samples/Tutorial/Frameworks/TutorialBase/Sources/TutorialHostingViewController.swift
@@ -18,12 +18,12 @@ import UIKit
 import Workflow
 import WorkflowUI
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `WelcomeWorkflow` as the root workflow
-        self.containerViewController = ContainerViewController(workflow: WelcomeWorkflow())
+        // Show one of the sample view controllers, to demonstrate the provided views:
+        self.containerViewController = WelcomeSampleViewController()
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/Samples/Tutorial/README.md
+++ b/Samples/Tutorial/README.md
@@ -13,7 +13,7 @@ Nearly all of the code is in the `Frameworks` directory.
 To help with the setup, we have created a few helpers:
 - `TutorialViews`: A set of 3 views for the 3 screens we will be building, `Welcome`, `TodoList`, and `TodoEdit`.
 - `TutorialBase`: This is the starting point to build out the tutorial. It contains view controllers that host the views from `TutorialViews` to see how they display.
-    - Additionally, there is a `TutorialContainerViewController` that the AppDelegate sets as the root view controller. This will be our launching point for all of our workflows.
+    - Additionally, there is a `TutorialHostingViewController` that the AppDelegate sets as the root view controller. This will be our launching point for all of our workflows.
 - `TutorialFinal`: This is an example of the completed tutorial - could be used as a reference if you get stuck.
 
 ## Getting started

--- a/Samples/Tutorial/Tutorial.xcodeproj/xcshareddata/xcschemes/Tutorial.xcscheme
+++ b/Samples/Tutorial/Tutorial.xcodeproj/xcshareddata/xcschemes/Tutorial.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E85390A62314AF2D001B6313"
+            BuildableName = "Tutorial.app"
+            BlueprintName = "Tutorial"
+            ReferencedContainer = "container:Tutorial.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -69,17 +78,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E85390A62314AF2D001B6313"
-            BuildableName = "Tutorial.app"
-            BlueprintName = "Tutorial"
-            ReferencedContainer = "container:Tutorial.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -101,8 +99,6 @@
             ReferencedContainer = "container:Tutorial.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/Tutorial/Tutorial1.md
+++ b/Samples/Tutorial/Tutorial1.md
@@ -125,11 +125,11 @@ extension WelcomeWorkflow {
 }
 ```
 
-### Setting up the ContainerViewController
+### Setting up the WorkflowHostingController
 
 Now we have our `WelcomeWorkflow` rendering a `WelcomeScreen`, and have a view controller that knows how to display with a `WelcomeScreen`. It's time to bind this all together and actually show it on the screen!
 
-We'll update the `TutorialContainerViewController` to hold a child *ContainerViewController* that will host our workflow:
+We'll update the `TutorialContainerViewController` to hold a child *WorkflowHostingController* that will host our workflow:
 
 ```swift
 import UIKit
@@ -137,12 +137,12 @@ import Workflow
 import WorkflowUI
 
 
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `WelcomeWorkflow` as the root workflow.
-        containerViewController = ContainerViewController(
+        // Create a `WorkflowHostingController` with the `WelcomeWorkflow` as the root workflow.
+        containerViewController = WorkflowHostingController(
             workflow: WelcomeWorkflow()
         )
 
@@ -150,7 +150,7 @@ public final class TutorialContainerViewController: UIViewController {
     }
 ```
 
-Now, we've created our `ContainerViewController` with the `WelcomeWorkflow` as the root.
+Now, we've created our `WorkflowHostingController` with the `WelcomeWorkflow` as the root.
 
 We can finally run the app again! It will look exactly the same as before, but now it is powered by our workflow.
 
@@ -294,7 +294,7 @@ Here is what is happening on each keypress:
 
 # Summary
 
-In this tutorial, we covered creating a Screen, ScreenViewController, Workflow, and binding them together in a ContainerViewController. We also covered the Workflow being responsible for the state of the UI instead of the view controller being responsible.
+In this tutorial, we covered creating a Screen, ScreenViewController, Workflow, and binding them together in a `WorkflowHostingController`. We also covered the Workflow being responsible for the state of the UI instead of the view controller being responsible.
 
 Next, we will create a second screen and workflow, and the use composition to navigate between them.
 

--- a/Samples/Tutorial/Tutorial2.md
+++ b/Samples/Tutorial/Tutorial2.md
@@ -12,7 +12,7 @@ Start from the implementation of `Tutorial1` if you're skipping ahead. You can d
 
 ## Second Workflow
 
-Let's add a second screen and workflow so we have somewhere to land after we log in. Our next screen will be a list of "todo" items, as todo apps are the best apps. To see an example, modify the `TutorialContainerViewController` to show the `TodoListSampleViewController`. Once you're done looking around, the `TodoListSampleViewController` can be removed, as we will be replacing it with a screen and workflow.
+Let's add a second screen and workflow so we have somewhere to land after we log in. Our next screen will be a list of "todo" items, as todo apps are the best apps. To see an example, modify the `TutorialHostingViewController` to show the `TodoListSampleViewController`. Once you're done looking around, the `TodoListSampleViewController` can be removed, as we will be replacing it with a screen and workflow.
 
 Create a new Screen/ViewController pair called `TodoList`:
 
@@ -93,19 +93,19 @@ extension TodoListWorkflow {
 
 ### Showing the new screen and workflow
 
-For now, let's just show this new screen instead of the login screen/workflow. Update the `TutorialContainerViewController` to show the `TodoListWorkflow`:
+For now, let's just show this new screen instead of the login screen/workflow. Update the `TutorialHostingViewController` to show the `TodoListWorkflow`:
 
 ```swift
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
-        // Create a `ContainerViewController` with the `WelcomeWorkflow` as the root workflow.
-//        containerViewController = ContainerViewController(
+        // Create a `WorkflowHostingController` with the `WelcomeWorkflow` as the root workflow.
+//        containerViewController = WorkflowHostingController(
 //            workflow: WelcomeWorkflow()
 //        )
         // Show the TodoList Workflow instead:
-        containerViewController = ContainerViewController(
+        containerViewController = WorkflowHostingController(
             workflow: TodoListWorkflow()
         )
 
@@ -233,17 +233,17 @@ struct WelcomeWorkflow: Workflow {
 }
 ```
 
-Update the `TutorialContainerViewController` to start at the `RootWorkflow` and we'll see the welcome screen again:
+Update the `TutorialHostingViewController` to start at the `RootWorkflow` and we'll see the welcome screen again:
 
 ```swift
-public final class TutorialContainerViewController: UIViewController {
+public final class TutorialHostingViewController: UIViewController {
     let containerViewController: UIViewController
 
     public init() {
         // ...
 
-        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow.
-        containerViewController = ContainerViewController(
+        // Create a `WorkflowHostingController` with the `RootWorkflow` as the root workflow.
+        containerViewController = WorkflowHostingController(
             workflow: RootWorkflow()
         )
 

--- a/Samples/Tutorial/Tutorial5.md
+++ b/Samples/Tutorial/Tutorial5.md
@@ -652,7 +652,7 @@ class TodoWorkflowTests: XCTestCase {
 
 The `RenderTester` allows easy "mocking" of child workflows and workers. However, this means that we are not exercising the full infrastructure (even though we could get a fairly high confidence from the tests). Sometimes, it may be worth putting together integration tests that test a full tree of Workflows.
 
-Add another test to `RootWorkflowTests`. We will run the tree of workflows in a `WorkflowHost`, which is what the infrastructure uses for a `ContainerViewController`. This will be a "black box" test, as we can only test the behaviors from the rendering and will not be able to inspect the underlying states. This may be a useful test for validation when refactoring a tree of workflows to ensure they behave the same way.
+Add another test to `RootWorkflowTests`. We will run the tree of workflows in a `WorkflowHost`, which is what the infrastructure uses for a `WorkflowHostingController`. This will be a "black box" test, as we can only test the behaviors from the rendering and will not be able to inspect the underlying states. This may be a useful test for validation when refactoring a tree of workflows to ensure they behave the same way.
 
 ```swift
 // RootWorkflowTests.swift

--- a/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/AppDelegate.swift
+++ b/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.rootViewController = ContainerViewController(workflow: DemoWorkflow())
+        window?.rootViewController = WorkflowHostingController(workflow: DemoWorkflow())
         window?.makeKeyAndVisible()
 
         return true

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -21,7 +21,7 @@
     import Workflow
 
     /// Drives view controllers from a root Workflow.
-    public final class ContainerViewController<ScreenType, Output>: UIViewController where ScreenType: Screen {
+    public final class WorkflowHostingController<ScreenType, Output>: UIViewController where ScreenType: Screen {
         /// Emits output events from the bound workflow.
         public var output: Signal<Output, Never> {
             return workflowHost.output
@@ -145,7 +145,7 @@
     }
 
     /// Wrapper around an AnyWorkflow that allows us to have a concrete
-    /// WorkflowHost without ContainerViewController itself being generic
+    /// WorkflowHost without WorkflowHostingController itself being generic
     /// around a Workflow.
     fileprivate struct RootWorkflow<Rendering, Output>: Workflow {
         typealias State = Void
@@ -164,5 +164,8 @@
                 .rendered(in: context)
         }
     }
+
+    @available(*, deprecated, renamed: "WorkflowHostingController")
+    public typealias ContainerViewController = WorkflowHostingController
 
 #endif

--- a/WorkflowUI/Sources/Screen/ViewEnvironment/ViewEnvironment.swift
+++ b/WorkflowUI/Sources/Screen/ViewEnvironment/ViewEnvironment.swift
@@ -23,7 +23,7 @@
 /// appearing in).
 public struct ViewEnvironment {
     /// An empty view environment. This should only be used when setting up a
-    /// root workflow into a root ContainerViewController or when writing tests.
+    /// root workflow into a root WorkflowHostingController or when writing tests.
     /// In other scenarios, containers should pass down the ViewEnvironment
     /// value they get from above.
     public static let empty: ViewEnvironment = ViewEnvironment()

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -177,21 +177,21 @@
             let screenB = TestScreen.counter(2)
 
             let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let containerViewController = ContainerViewController(describedViewController: describedViewController)
+            let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
 
             // When
             let expectation = self.expectation(description: "did observe size changes")
             expectation.expectedFulfillmentCount = 2
 
             var observedSizes: [CGSize] = []
-            let disposable = containerViewController.preferredContentSizeSignal.observeValues {
+            let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
                 observedSizes.append($0)
                 expectation.fulfill()
             }
 
             defer { disposable?.dispose() }
 
-            _ = containerViewController.view
+            _ = WorkflowHostingController.view
             describedViewController.update(screen: screenB, environment: .empty)
 
             // Then
@@ -207,21 +207,21 @@
             let screenC = TestScreen.message("Testing")
 
             let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let containerViewController = ContainerViewController(describedViewController: describedViewController)
+            let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
 
             // When
             let expectation = self.expectation(description: "did observe size changes")
             expectation.expectedFulfillmentCount = 3
 
             var observedSizes: [CGSize] = []
-            let disposable = containerViewController.preferredContentSizeSignal.observeValues {
+            let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
                 observedSizes.append($0)
                 expectation.fulfill()
             }
 
             defer { disposable?.dispose() }
 
-            _ = containerViewController.view
+            _ = WorkflowHostingController.view
             describedViewController.update(screen: screenB, environment: .empty)
             describedViewController.update(screen: screenC, environment: .empty)
 
@@ -260,7 +260,7 @@
         }
     }
 
-    fileprivate class ContainerViewController: UIViewController {
+    fileprivate class WorkflowHostingController: UIViewController {
         let describedViewController: DescribedViewController
 
         var preferredContentSizeSignal: Signal<CGSize, Never> { return signal.skipRepeats() }

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -40,11 +40,11 @@
         }
     }
 
-    class ContainerViewControllerTests: XCTestCase {
+    class WorkflowHostingControllerTests: XCTestCase {
         func test_initialization_renders_workflow() {
             let (signal, _) = Signal<Int, Never>.pipe()
             let workflow = SubscribingWorkflow(subscription: signal)
-            let container = ContainerViewController(workflow: workflow)
+            let container = WorkflowHostingController(workflow: workflow)
 
             withExtendedLifetime(container) {
                 let vc = container.rootViewController as! TestScreenViewController
@@ -55,7 +55,7 @@
         func test_workflow_update_causes_rerender() {
             let (signal, observer) = Signal<Int, Never>.pipe()
             let workflow = SubscribingWorkflow(subscription: signal)
-            let container = ContainerViewController(workflow: workflow)
+            let container = WorkflowHostingController(workflow: workflow)
 
             withExtendedLifetime(container) {
                 let expectation = XCTestExpectation(description: "View Controller updated")
@@ -76,7 +76,7 @@
         func test_workflow_output_causes_container_output() {
             let (signal, observer) = Signal<Int, Never>.pipe()
             let workflow = SubscribingWorkflow(subscription: signal)
-            let container = ContainerViewController(workflow: workflow)
+            let container = WorkflowHostingController(workflow: workflow)
 
             let expectation = XCTestExpectation(description: "Output")
 
@@ -95,7 +95,7 @@
         func test_container_with_anyworkflow() {
             let (signal, observer) = Signal<Int, Never>.pipe()
             let workflow = SubscribingWorkflow(subscription: signal)
-            let container = ContainerViewController(workflow: workflow.asAnyWorkflow())
+            let container = WorkflowHostingController(workflow: workflow.asAnyWorkflow())
 
             let expectation = XCTestExpectation(description: "Output")
 
@@ -113,7 +113,7 @@
 
         func test_container_update_causes_rerender() {
             let firstWorkflow = PassthroughWorkflow(value: "first")
-            let container = ContainerViewController(workflow: firstWorkflow)
+            let container = WorkflowHostingController(workflow: firstWorkflow)
 
             withExtendedLifetime(container) {
                 let expectation = XCTestExpectation(description: "View Controller updated")
@@ -137,7 +137,7 @@
 
         func test_container_update_updates_output() {
             let firstWorkflow = EchoWorkflow(value: 1)
-            let container = ContainerViewController(workflow: firstWorkflow)
+            let container = WorkflowHostingController(workflow: firstWorkflow)
 
             let expectation = XCTestExpectation(description: "Second output")
 


### PR DESCRIPTION
This renames `ContainerViewController` to `WorkflowHostingController` to (a) be a less generic name (basically _any_ parent view controller is a "container") / explain what the VC is containing/hosting, and (b) aligns us more closely with SwiftUI's `UIHostingController` naming.

I've left the old name as a deprecated name – we can remove it in a 2.0 (assuming we follow proper semver?) in perhaps a couple months. I'll migrate POS / etc.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
