### PR TITLE
[chore]: clarify some testing behaviors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,11 @@ let package = Package(
             dependencies: ["Workflow"],
             path: "Workflow/Tests"
         ),
+        .testTarget(
+            name: "WorkflowTestingTests",
+            dependencies: ["WorkflowTesting"],
+            path: "WorkflowTesting/Tests"
+        ),
         .target(
             name: "WorkflowUI",
             dependencies: ["Workflow"],
@@ -115,6 +120,11 @@ let package = Package(
             name: "WorkflowReactiveSwiftTesting",
             dependencies: ["WorkflowReactiveSwift", "WorkflowTesting"],
             path: "WorkflowReactiveSwift/Testing"
+        ),
+        .testTarget(
+            name: "WorkflowReactiveSwiftTestingTests",
+            dependencies: ["WorkflowReactiveSwiftTesting"],
+            path: "WorkflowReactiveSwift/TestingTests"
         ),
         .target(
             name: "WorkflowCombineTesting",

--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -25,6 +25,8 @@
         ///
         /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
         ///
+        ///  ⚠️ N.B. If you are testing a case in which multiple `SignalProducerWorkflow`s are expected, **only one of them** may have a non-nil `producingOutput` parameter.
+        ///
         /// - Parameters:
         ///   - producingOutput: An output that should be returned when this worker is requested, if any.
         ///   - key: Key to expect this `Workflow` to be rendered with.
@@ -38,6 +40,24 @@
                 key: key,
                 producingRendering: (),
                 producingOutput: output,
+                assertions: { _ in }
+            )
+        }
+
+        /// Expect a `SignalProducer` with the specified `outputType` that produces no `Output`.
+        ///
+        /// - Parameters:
+        ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`.
+        ///   - key: Key to expect this `Workflow` to be rendered with.
+        public func expectSignalProducer<OutputType>(
+            outputType: OutputType.Type,
+            key: String = "",
+            file: StaticString = #file, line: UInt = #line
+        ) -> RenderTester<WorkflowType> {
+            expectWorkflow(
+                type: SignalProducerWorkflow<OutputType>.self,
+                key: key,
+                producingRendering: (),
                 assertions: { _ in }
             )
         }

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -62,7 +62,9 @@
                     } else if sameKeyDifferentTypes.count > 1 {
                         diagnosticMessage = "Found expectations for types \(sameKeyDifferentTypes) with key \"\(key)\"."
                     } else {
-                        diagnosticMessage = ""
+                        diagnosticMessage = """
+                        If this child Workflow is expected, please add a call to `expectWorkflow(...)` with the appropriate parameters before invoking `render()`.
+                        """
                     }
                     XCTFail("Unexpected workflow of type \(Child.self) with key \"\(key)\". \(diagnosticMessage)", file: file, line: line)
 

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -53,7 +53,11 @@
     ///         type: ChildWorkflow.self,
     ///         key: "key",
     ///         rendering: "rendering",
-    ///         producingOutput: ChildWorkflow.Output.success
+    ///         // ⚠️ N.B. Only one output per call to `render` may be produced,
+    ///         // even if multiple child Workflows are expected in a call
+    ///         // to `render`. This is an invariant enforced by `RenderTester`
+    ///         // and the real runtime.
+    ///         producingOutput: nil
     ///     )
     ///     .render { rendering in
     ///         XCTAssertEqual("expected text on rendering", rendering.text)

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -127,7 +127,7 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         let tester = TestWorkflow()
             .renderTester(initialState: .voidWorkflow)
 
-        expectingFailure(#"Unexpected workflow of type VoidWorkflow with key """#) {
+        expectingFailure(#"Unexpected workflow of type VoidWorkflow with key "". If this child Workflow is expected, please add a call to `expectWorkflow(...)` with the appropriate parameters before invoking `render()`."#) {
             tester.render { _ in }
         }
     }


### PR DESCRIPTION
### Issue

- some behaviors in the testing facilities aren't particularly clear and may be confusing

### Description

- add clarification in comments that only a single output should be expected during a render test, and remove example code in comments suggesting this is possible.
- add a new SignalProducerWorkflow testing method for use when no output is expected
- add recovery suggestion to the diagnostic message produced when an unexpected child workflow is rendered in a test