### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# This file configures code owners (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), to automatically add reviewers to PRs.
+
+* @square/foundation-ios


### PR DESCRIPTION
As with [the `CODEOWNERS` in Blueprint](https://github.com/square/Blueprint/blob/main/.github/CODEOWNERS), this indicates the team in the @square that owns this repository.

Internal Slack discussion: https://square.slack.com/archives/CBZJ5V163/p1666287096932389?thread_ts=1666287004.904659&cid=CBZJ5V163