### PR TITLE
Add StateMutationSink

### DIFF
--- a/Workflow/Sources/StateMutationSink.swift
+++ b/Workflow/Sources/StateMutationSink.swift
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+extension RenderContext {
+    /// Creates `StateMutationSink`.
+    ///
+    /// To create a sink:
+    /// ```
+    /// let stateMutationSink = context.makeStateMutationSink()
+    /// ```
+    ///
+    /// To mutate `State` on an event:
+    /// ```
+    /// stateMutationSink.send(\State.value, value: 10)
+    /// ```
+    public func makeStateMutationSink() -> StateMutationSink<WorkflowType> {
+        let sink = makeSink(of: AnyWorkflowAction<WorkflowType>.self)
+        return StateMutationSink(sink)
+    }
+}
+
+/// StateMutationSink provides a `Sink` that helps mutate `State` using it's `KeyPath`.
+public struct StateMutationSink<WorkflowType: Workflow> {
+    let sink: Sink<AnyWorkflowAction<WorkflowType>>
+
+    /// Sends message to `StateMutationSink` to update `State`'s value using the provided closure.
+    ///
+    /// - Parameters:
+    ///   - update: The `State`` mutation to perform.
+    public func send(_ update: @escaping (inout WorkflowType.State) -> Void) {
+        sink.send(
+            AnyWorkflowAction<WorkflowType> { state in
+                update(&state)
+                return nil
+            }
+        )
+    }
+
+    /// Sends message to `StateMutationSink` to update `State`'s value at `KeyPath` with `Value`.
+    ///
+    /// - Parameters:
+    ///   - keyPath: Key path of `State` whose value needs to be mutated.
+    ///   - value: Value to update `State` with.
+    public func send<Value>(_ keyPath: WritableKeyPath<WorkflowType.State, Value>, value: Value) {
+        send { $0[keyPath: keyPath] = value }
+    }
+
+    init(_ sink: Sink<AnyWorkflowAction<WorkflowType>>) {
+        self.sink = sink
+    }
+}

--- a/Workflow/Tests/StateMutationSinkTests.swift
+++ b/Workflow/Tests/StateMutationSinkTests.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactiveSwift
+import Workflow
+import XCTest
+
+final class StateMutationSinkTests: XCTestCase {
+    var output: Signal<Int, Never>!
+    var input: Signal<Int, Never>.Observer!
+
+    override func setUp() {
+        (output, input) = Signal<Int, Never>.pipe()
+    }
+
+    func test_initialValue() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+        XCTAssertEqual(0, host.rendering.value)
+    }
+
+    func test_singleUpdate() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+
+        let gotValueExpectation = expectation(description: "Got expected value")
+        host.rendering.producer.startWithValues { val in
+            if val == 100 {
+                gotValueExpectation.fulfill()
+            }
+        }
+
+        input.send(value: 100)
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func test_multipleUpdates() {
+        let host = WorkflowHost(workflow: TestWorkflow(value: 100, signal: output))
+
+        let gotValueExpectation = expectation(description: "Got expected value")
+
+        var values: [Int] = []
+        host.rendering.producer.startWithValues { val in
+            values.append(val)
+            if val == 300 {
+                gotValueExpectation.fulfill()
+            }
+        }
+
+        input.send(value: 100)
+        input.send(value: 200)
+        input.send(value: 300)
+        XCTAssertEqual(values, [0, 100, 200, 300])
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    fileprivate struct TestWorkflow: Workflow {
+        typealias State = Int
+        typealias Rendering = Int
+
+        let value: Int
+        let signal: Signal<Int, Never>
+
+        func makeInitialState() -> Int {
+            0
+        }
+
+        func render(state: State, context: RenderContext<TestWorkflow>) -> Rendering {
+            let stateMutationSink = context.makeStateMutationSink()
+            context.runSideEffect(key: "") { lifetime in
+                let disposable = signal.observeValues { val in
+                    stateMutationSink.send(\State.self, value: val)
+                }
+                lifetime.onEnded {
+                    disposable?.dispose()
+                }
+            }
+            return state
+        }
+    }
+}


### PR DESCRIPTION
## Background

From @dhavalshreyas's [proposal in Notion](https://www.notion.so/sellermobile/Workflow-Boilerplate-Reduction-be0ccb80c5a044c0b564d09ddd1ff63f#62d55b4121aa428095b7370ebce43c9e) (with slightly updated examples):

`Sink`s are used to process `Action`s, either from `SideEffect`s or from user-interaction events.

We currently have `makeSink` to process any `Action` and `makeOutputSink`, which provides a `Sink` that sends the `Output`.

The proposal here is to introduce `makeStateMutationSink`, which would provide a `Sink` that automatically mutates `State` without an intermediate `Action`.

**Before:**

```swift
struct MyWorkflow: Workflow {
    enum Action: WorkflowAction {
        typealias WorkflowType = MyWorkflow

        case updateTapCount(Int)

        func apply(toState state: inout Int) -> MyWorkflow.Output? {
            switch self {
            case .updateTapCount(let count):
                state.tapCount = count
                return nil
            }
            return nil
        }
    }

    func render(state: State, context: RenderContext<Self>) -> Rendering {
        let sink = context.makeSink(of: Action.self)
        return Screen(onTap: { _ in
            sink.send(.updateTapCount(state.tapCount + 1))
        })
    }
}
```

**After:**

```swift
struct MyWorkflow: Workflow {
    func render(state: State, context: RenderContext<Self>) -> Rendering {
        let stateMutationSink = context.makeStateMutationSink()
        return Screen(onTap: { _ in
            stateMutationSink.send(\.tapCount, value: state.tapCount + 1)
        })
    }
}
```

---

This convenience has been baking in `ios-register`'s `WorkflowExperimental` framework for quite some time now and has proven useful to many.


## Additions to existing convenience

These changes area a direct port of that code (including the associated tests) with one additional convenience which would allow for mutating state with a closure rather than just the `KeyPath`/`Value` syntax:

```swift
struct MyWorkflow: Workflow {
    func render(state: State, context: RenderContext<Self>) -> Rendering {
        let stateMutationSink = context.makeStateMutationSink()
        return Screen(onTap: { _ in
            stateMutationSink.send { state in
               state.tapCount += 1
               state.tapped = true
            }
        })
    }
}
```

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
