### PR TITLE
Explicitly declare `APPLICATION_EXTENSION_API_ONLY` for CocoaPods

### DIFF
--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -1,29 +1,31 @@
 require_relative('version')
 
 Pod::Spec.new do |s|
-  s.name         = 'Workflow'
-  s.version      = WORKFLOW_VERSION
-  s.summary      = 'Reactive application architecture'
-  s.homepage     = 'https://www.github.com/square/workflow-swift'
-  s.license      = 'Apache License, Version 2.0'
-  s.author       = 'Square'
-  s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+    s.name         = 'Workflow'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Reactive application architecture'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
-  # 1.7 is needed for `swift_versions` support
-  s.cocoapods_version = '>= 1.7.0'
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
 
-  s.swift_versions = ['5.0']
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
+    s.swift_versions = ['5.0']
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
 
-  s.source_files = 'Workflow/Sources/*.swift'
+    s.source_files = 'Workflow/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 7.0.0'
+    s.dependency 'ReactiveSwift', '~> 7.1.1'
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'Workflow/Tests/**/*.swift'
-    test_spec.framework = 'XCTest'
-    test_spec.library = 'swiftos'
-  end
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
+    s.test_spec 'Tests' do |test_spec|
+        test_spec.source_files = 'Workflow/Tests/**/*.swift'
+        test_spec.framework = 'XCTest'
+        test_spec.library = 'swiftos'
+    end
 
 end

--- a/WorkflowCombine.podspec
+++ b/WorkflowCombine.podspec
@@ -8,17 +8,17 @@ Pod::Spec.new do |s|
     s.license      = 'Apache License, Version 2.0'
     s.author       = 'Square'
     s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
-  
+
     # 1.7 is needed for `swift_versions` support
     s.cocoapods_version = '>= 1.7.0'
-  
+
     s.swift_versions = ['5.1']
     s.ios.deployment_target = '13.0'
     s.osx.deployment_target = '10.15'
-  
+
     s.source_files = 'WorkflowCombine/Sources/*.swift'
-    
+
     s.dependency 'Workflow', "#{s.version}"
-  
-  end
-  
+
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+end

--- a/WorkflowCombineTesting.podspec
+++ b/WorkflowCombineTesting.podspec
@@ -24,6 +24,8 @@ Pod::Spec.new do |s|
 
     s.framework = 'XCTest'
 
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
     s.test_spec 'WorkflowCombineTestingTests' do |test_spec|
         test_spec.requires_app_host = true
         test_spec.source_files = 'WorkflowCombine/TestingTests/**/*.swift'

--- a/WorkflowConcurrency.podspec
+++ b/WorkflowConcurrency.podspec
@@ -9,17 +9,18 @@ Pod::Spec.new do |s|
     s.license      = 'Apache License, Version 2.0'
     s.author       = 'Square'
     s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{WORKFLOW_VERSION}" }
-  
+
     # 1.7 is needed for `swift_versions` support
     s.cocoapods_version = '>= 1.7.0'
-  
+
     s.swift_versions = ['5.5']
     s.ios.deployment_target = '13.0'
     s.osx.deployment_target = '10.15'
-  
+
     s.source_files = 'WorkflowConcurrency/Sources/*.swift'
-    
+
     s.dependency 'Workflow', "#{WORKFLOW_VERSION}"
-  
+
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
   end
-  

--- a/WorkflowConcurrencyTesting.podspec
+++ b/WorkflowConcurrencyTesting.podspec
@@ -24,6 +24,8 @@ Pod::Spec.new do |s|
 
     s.framework = 'XCTest'
 
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
     s.test_spec 'WorkflowConcurrencyTestingTests' do |test_spec|
         test_spec.requires_app_host = true
         test_spec.source_files = 'WorkflowConcurrency/TestingTests/**/*.swift'

--- a/WorkflowReactiveSwift.podspec
+++ b/WorkflowReactiveSwift.podspec
@@ -19,7 +19,6 @@ Pod::Spec.new do |s|
   s.source_files = 'WorkflowReactiveSwift/Sources/**/*.swift'
 
   s.dependency 'Workflow', "#{s.version}"
-  s.dependency 'ReactiveSwift', '~> 7.0.0'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'WorkflowReactiveSwift/Tests/**/*.swift'

--- a/WorkflowReactiveSwiftTesting.podspec
+++ b/WorkflowReactiveSwiftTesting.podspec
@@ -24,6 +24,8 @@ Pod::Spec.new do |s|
 
   s.framework = 'XCTest'
 
+  s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
   s.test_spec 'WorkflowReactiveSwiftTestingTests' do |test_spec|
     test_spec.requires_app_host = true
     test_spec.source_files = 'WorkflowReactiveSwift/TestingTests/**/*.swift'

--- a/WorkflowRxSwift.podspec
+++ b/WorkflowRxSwift.podspec
@@ -1,31 +1,34 @@
 require_relative('version')
 
 Pod::Spec.new do |s|
-  s.name         = 'WorkflowRxSwift'
-  s.version      = WORKFLOW_VERSION
-  s.summary      = 'Infrastructure for Workflow-powered Swift'
-  s.homepage     = 'https://www.github.com/square/workflow-swift'
-  s.license      = 'Apache License, Version 2.0'
-  s.author       = 'Square'
-  s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+    s.name         = 'WorkflowRxSwift'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Infrastructure for Workflow-powered Swift'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
-  # 1.7 is needed for `swift_versions` support
-  s.cocoapods_version = '>= 1.7.0'
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
 
-  s.swift_versions = ['5.0']
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
+    s.swift_versions = ['5.0']
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
 
-  s.source_files = 'WorkflowRxSwift/Sources/**/*.swift'
+    s.source_files = 'WorkflowRxSwift/Sources/**/*.swift'
 
-  s.dependency 'Workflow', "#{s.version}"
-  s.dependency 'RxSwift', '~> 6.2'
+    s.dependency 'Workflow', "#{s.version}"
+    s.dependency 'RxSwift', '~> 6.2'
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'WorkflowRxSwift/Tests/**/*.swift'
-    test_spec.framework = 'XCTest'
-    test_spec.library = 'swiftos'
-    test_spec.dependency 'WorkflowTesting', "#{s.version}"
-    test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
-  end
+    # https://github.com/ReactiveX/RxSwift/pull/2475
+    # s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
+    s.test_spec 'Tests' do |test_spec|
+        test_spec.source_files = 'WorkflowRxSwift/Tests/**/*.swift'
+        test_spec.framework = 'XCTest'
+        test_spec.library = 'swiftos'
+        test_spec.dependency 'WorkflowTesting', "#{s.version}"
+        test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
+    end
 end

--- a/WorkflowRxSwiftTesting.podspec
+++ b/WorkflowRxSwiftTesting.podspec
@@ -1,35 +1,38 @@
 require_relative('version')
 
 Pod::Spec.new do |s|
-  s.name         = 'WorkflowRxSwiftTesting'
-  s.version      = WORKFLOW_VERSION
-  s.summary      = 'Infrastructure for Workflow-powered Swift'
-  s.homepage     = 'https://www.github.com/square/workflow-swift'
-  s.license      = 'Apache License, Version 2.0'
-  s.author       = 'Square'
-  s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+    s.name         = 'WorkflowRxSwiftTesting'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Infrastructure for Workflow-powered Swift'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
-  # 1.7 is needed for `swift_versions` support
-  s.cocoapods_version = '>= 1.7.0'
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
 
-  s.swift_versions = ['5.0']
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
+    s.swift_versions = ['5.0']
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
 
-  s.source_files = 'WorkflowRxSwift/Testing/**/*.swift'
+    s.source_files = 'WorkflowRxSwift/Testing/**/*.swift'
 
-  s.dependency 'Workflow', "#{s.version}"
-  s.dependency 'WorkflowRxSwift', "#{s.version}"
-  s.dependency 'WorkflowTesting', "#{s.version}"
-  s.dependency 'RxSwift'
+    s.dependency 'Workflow', "#{s.version}"
+    s.dependency 'WorkflowRxSwift', "#{s.version}"
+    s.dependency 'WorkflowTesting', "#{s.version}"
+    s.dependency 'RxSwift'
 
-  s.framework = 'XCTest'
+    s.framework = 'XCTest'
 
-  s.test_spec 'WorkflowRxSwiftTestingTests' do |test_spec|
-    test_spec.requires_app_host = true
-    test_spec.source_files = 'WorkflowRxSwift/TestingTests/**/*.swift'
-    test_spec.framework = 'XCTest'
-    test_spec.dependency 'WorkflowTesting'
-    test_spec.library = 'swiftos'
-  end
+    # https://github.com/ReactiveX/RxSwift/pull/2475
+    # s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
+    s.test_spec 'WorkflowRxSwiftTestingTests' do |test_spec|
+        test_spec.requires_app_host = true
+        test_spec.source_files = 'WorkflowRxSwift/TestingTests/**/*.swift'
+        test_spec.framework = 'XCTest'
+        test_spec.dependency 'WorkflowTesting'
+        test_spec.library = 'swiftos'
+    end
 end

--- a/WorkflowSwiftUI.podspec
+++ b/WorkflowSwiftUI.podspec
@@ -8,17 +8,18 @@ Pod::Spec.new do |s|
     s.license      = 'Apache License, Version 2.0'
     s.author       = 'Square'
     s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
-  
+
     # 1.7 is needed for `swift_versions` support
     s.cocoapods_version = '>= 1.7.0'
-  
+
     s.swift_versions = ['5.1']
     s.ios.deployment_target = '13.0'
     s.osx.deployment_target = '10.15'
-  
+
     s.source_files = 'WorkflowSwiftUI/Sources/*.swift'
-  
+
     s.dependency 'Workflow', "#{s.version}"
-  
+
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
   end
-  

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -1,30 +1,31 @@
 require_relative('version')
 
 Pod::Spec.new do |s|
-  s.name         = 'WorkflowTesting'
-  s.version      = WORKFLOW_VERSION
-  s.summary      = 'Reactive application architecture'
-  s.homepage     = 'https://www.github.com/square/workflow-swift'
-  s.license      = 'Apache License, Version 2.0'
-  s.author       = 'Square'
-  s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+    s.name         = 'WorkflowTesting'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Reactive application architecture'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
-  # 1.7 is needed for `swift_versions` support
-  s.cocoapods_version = '>= 1.7.0'
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
 
-  s.swift_versions = ['5.0']
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
+    s.swift_versions = ['5.0']
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
 
-  s.source_files = 'WorkflowTesting/Sources/**/*.swift'
+    s.source_files = 'WorkflowTesting/Sources/**/*.swift'
 
-  s.dependency 'Workflow', "#{s.version}"
-  s.framework = 'XCTest'
+    s.dependency 'Workflow', "#{s.version}"
+    s.framework = 'XCTest'
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'WorkflowTesting/Tests/**/*.swift'
-    test_spec.framework = 'XCTest'
-    test_spec.libraries = 'swiftDispatch', 'swiftFoundation', 'swiftos'
-  end
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
+    s.test_spec 'Tests' do |test_spec|
+        test_spec.source_files = 'WorkflowTesting/Tests/**/*.swift'
+        test_spec.framework = 'XCTest'
+        test_spec.libraries = 'swiftDispatch', 'swiftFoundation', 'swiftos'
+    end
 end
-

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -1,34 +1,35 @@
 require_relative('version')
 
 Pod::Spec.new do |s|
-  s.name         = 'WorkflowUI'
-  s.version      = WORKFLOW_VERSION
-  s.summary      = 'Infrastructure for Workflow-powered UI'
-  s.homepage     = 'https://www.github.com/square/workflow-swift'
-  s.license      = 'Apache License, Version 2.0'
-  s.author       = 'Square'
-  s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
+    s.name         = 'WorkflowUI'
+    s.version      = WORKFLOW_VERSION
+    s.summary      = 'Infrastructure for Workflow-powered UI'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
-  # 1.7 is needed for `swift_versions` support
-  s.cocoapods_version = '>= 1.7.0'
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
 
-  s.swift_versions = ['5.0']
-  s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.13'
+    s.swift_versions = ['5.0']
+    s.ios.deployment_target = '11.0'
+    s.osx.deployment_target = '10.13'
 
-  s.source_files = 'WorkflowUI/Sources/**/*.swift'
+    s.source_files = 'WorkflowUI/Sources/**/*.swift'
 
-  s.dependency 'Workflow', "#{s.version}"
+    s.dependency 'Workflow', "#{s.version}"
 
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'WorkflowUI/Tests/**/*.swift'
-    test_spec.framework = 'XCTest'
-    test_spec.library = 'swiftos'
-    test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
-    # Create an app host so that we can host
-    # view or view controller based tests in a real environment.
-    test_spec.requires_app_host = true
-  end
+    s.test_spec 'Tests' do |test_spec|
+        test_spec.source_files = 'WorkflowUI/Tests/**/*.swift'
+        test_spec.framework = 'XCTest'
+        test_spec.library = 'swiftos'
+        test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
+
+        # Create an app host so that we can host
+        # view or view controller based tests in a real environment.
+        test_spec.requires_app_host = true
+    end
 end
-


### PR DESCRIPTION
## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
