### PR TITLE
[fix]: modify testing podspecs to address validation errors

### DIFF
--- a/WorkflowCombineTesting.podspec
+++ b/WorkflowCombineTesting.podspec
@@ -32,5 +32,7 @@ Pod::Spec.new do |s|
         test_spec.framework = 'XCTest'
         test_spec.dependency 'WorkflowTesting'
         test_spec.library = 'swiftos'
+
+        test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
     end
 end

--- a/WorkflowConcurrencyTesting.podspec
+++ b/WorkflowConcurrencyTesting.podspec
@@ -32,5 +32,7 @@ Pod::Spec.new do |s|
         test_spec.framework = 'XCTest'
         test_spec.dependency 'WorkflowTesting'
         test_spec.library = 'swiftos'
+
+        test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
     end
 end

--- a/WorkflowReactiveSwiftTesting.podspec
+++ b/WorkflowReactiveSwiftTesting.podspec
@@ -32,5 +32,7 @@ Pod::Spec.new do |s|
     test_spec.framework = 'XCTest'
     test_spec.library = 'swiftos'
     test_spec.dependency 'WorkflowTesting'
+
+    test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
   end
 end

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -31,5 +31,7 @@ Pod::Spec.new do |s|
         # Create an app host so that we can host
         # view or view controller based tests in a real environment.
         test_spec.requires_app_host = true
+
+        test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
     end
 end


### PR DESCRIPTION
### Issue

- WorkflowUI podspec failed validation, so publishing 1.3.0 failed

### Description

- fix the underlying issue, by allowing test specs which use an app host to unset the `APPLICATION_EXTENSION_API_ONLY` config

