### PR TITLE
Start sectioning off ReactiveSwift

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        scheme: 
+        scheme:
         - Development-Unit-WorkflowTesting
         - Development-Unit-WorkflowTests
         - Development-Unit-WorkflowUITests
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-        
+
     - name: Cache gems
       uses: actions/cache@v3
       with:
@@ -52,6 +52,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Switch Xcode
+      run: sudo xcode-select -s /Applications/Xcode_13.3.1.app
 
     - name: Swift Package Manager - iOS
       run: |
@@ -102,7 +105,7 @@ jobs:
       run: |
         bundle check || bundle install --path .bundle
         brew install sourcedocs
-        
+
     - name: Swiftdocs
       run: |
         .buildscript/build_swift_docs.sh ${{ runner.temp }}/swiftdocs

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,17 @@ let package = Package(
         .macOS("10.13"),
     ],
     products: [
+        // MARK: Workflow
         .library(
             name: "Workflow",
             targets: ["Workflow"]
         ),
+        .library(
+            name: "WorkflowTesting",
+            targets: ["WorkflowTesting"]
+        ),
+
+        // MARK: WorkflowUI
         .library(
             name: "WorkflowUI",
             targets: ["WorkflowUI"]
@@ -22,26 +29,38 @@ let package = Package(
             name: "WorkflowSwiftUI",
             targets: ["WorkflowSwiftUI"]
         ),
+
+        // MARK: WorkflowReactiveSwift
         .library(
             name: "WorkflowReactiveSwift",
             targets: ["WorkflowReactiveSwift"]
         ),
         .library(
-            name: "WorkflowCombine",
-            targets: ["WorkflowCombine"]
-        ),
-        .library(
-            name: "WorkflowTesting",
-            targets: ["WorkflowTesting"]
-        ),
-        .library(
             name: "WorkflowReactiveSwiftTesting",
             targets: ["WorkflowReactiveSwiftTesting"]
+        ),
+
+        // MARK: WorkflowRxSwift
+        .library(
+            name: "WorkflowRxSwift",
+            targets: ["WorkflowReactiveSwift"]
+        ),
+        .library(
+            name: "WorkflowRxSwiftTesting",
+            targets: ["WorkflowRxSwiftTesting"]
+        ),
+
+        // MARK: WorkflowCombine
+        .library(
+            name: "WorkflowCombine",
+            targets: ["WorkflowCombine"]
         ),
         .library(
             name: "WorkflowCombineTesting",
             targets: ["WorkflowCombineTesting"]
         ),
+
+        // MARK: WorkflowConcurrency
         .library(
             name: "WorkflowConcurrency",
             targets: ["WorkflowConcurrency"]
@@ -53,12 +72,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.44.14")),
     ],
     targets: [
+        // MARK: Workflow
         .target(
             name: "Workflow",
-            dependencies: ["ReactiveSwift"],
             path: "Workflow/Sources"
         ),
         .testTarget(
@@ -66,11 +86,18 @@ let package = Package(
             dependencies: ["Workflow"],
             path: "Workflow/Tests"
         ),
+        .target(
+            name: "WorkflowTesting",
+            dependencies: ["Workflow"],
+            path: "WorkflowTesting/Sources"
+        ),
         .testTarget(
             name: "WorkflowTestingTests",
             dependencies: ["WorkflowTesting"],
             path: "WorkflowTesting/Tests"
         ),
+
+        // MARK: WorkflowUI
         .target(
             name: "WorkflowUI",
             dependencies: ["Workflow"],
@@ -83,9 +110,11 @@ let package = Package(
         ),
         .target(
             name: "WorkflowSwiftUI",
-            dependencies: ["ReactiveSwift", "Workflow"],
+            dependencies: ["Workflow"],
             path: "WorkflowSwiftUI/Sources"
         ),
+
+        // MARK: WorkflowReactiveSwift
         .target(
             name: "WorkflowReactiveSwift",
             dependencies: ["ReactiveSwift", "Workflow"],
@@ -97,26 +126,6 @@ let package = Package(
             path: "WorkflowReactiveSwift/Tests"
         ),
         .target(
-            name: "WorkflowCombine",
-            dependencies: ["Workflow"],
-            path: "WorkflowCombine/Sources"
-        ),
-        .testTarget(
-            name: "WorkflowCombineTests",
-            dependencies: ["WorkflowCombineTesting"],
-            path: "WorkflowCombine/Tests"
-        ),
-        .testTarget(
-            name: "WorkflowCombineTestingTests",
-            dependencies: ["WorkflowCombineTesting"],
-            path: "WorkflowCombine/TestingTests"
-        ),
-        .target(
-            name: "WorkflowTesting",
-            dependencies: ["Workflow"],
-            path: "WorkflowTesting/Sources"
-        ),
-        .target(
             name: "WorkflowReactiveSwiftTesting",
             dependencies: ["WorkflowReactiveSwift", "WorkflowTesting"],
             path: "WorkflowReactiveSwift/Testing"
@@ -126,11 +135,52 @@ let package = Package(
             dependencies: ["WorkflowReactiveSwiftTesting"],
             path: "WorkflowReactiveSwift/TestingTests"
         ),
+
+        // MARK: WorkflowRxSwift
+        .target(
+            name: "WorkflowRxSwift",
+            dependencies: ["RxSwift", "Workflow"],
+            path: "WorkflowRxSwift/Sources"
+        ),
+        .testTarget(
+            name: "WorkflowRxSwiftTests",
+            dependencies: ["WorkflowRxSwiftTesting"],
+            path: "WorkflowRxSwift/Tests"
+        ),
+        .target(
+            name: "WorkflowRxSwiftTesting",
+            dependencies: ["WorkflowRxSwift", "WorkflowTesting"],
+            path: "WorkflowRxSwift/Testing"
+        ),
+        .testTarget(
+            name: "WorkflowRxSwiftTestingTests",
+            dependencies: ["WorkflowRxSwiftTesting"],
+            path: "WorkflowRxSwift/TestingTests"
+        ),
+
+        // MARK: WorkflowCombine
+        .target(
+            name: "WorkflowCombine",
+            dependencies: ["Workflow"],
+            path: "WorkflowCombine/Sources"
+        ),
+        .testTarget(
+            name: "WorkflowCombineTests",
+            dependencies: ["WorkflowCombineTesting"],
+            path: "WorkflowCombine/Tests"
+        ),
         .target(
             name: "WorkflowCombineTesting",
             dependencies: ["WorkflowCombine", "WorkflowTesting"],
             path: "WorkflowCombine/Testing"
         ),
+        .testTarget(
+            name: "WorkflowCombineTestingTests",
+            dependencies: ["WorkflowCombineTesting"],
+            path: "WorkflowCombine/TestingTests"
+        ),
+
+        // MARK: WorkflowConcurrency
         .target(
             name: "WorkflowConcurrency",
             dependencies: ["Workflow"],

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ],
     products: [
         // MARK: Workflow
+
         .library(
             name: "Workflow",
             targets: ["Workflow"]
@@ -21,6 +22,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowUI
+
         .library(
             name: "WorkflowUI",
             targets: ["WorkflowUI"]
@@ -31,6 +33,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowReactiveSwift
+
         .library(
             name: "WorkflowReactiveSwift",
             targets: ["WorkflowReactiveSwift"]
@@ -41,6 +44,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowRxSwift
+
         .library(
             name: "WorkflowRxSwift",
             targets: ["WorkflowReactiveSwift"]
@@ -51,6 +55,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowCombine
+
         .library(
             name: "WorkflowCombine",
             targets: ["WorkflowCombine"]
@@ -61,6 +66,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowConcurrency
+
         .library(
             name: "WorkflowConcurrency",
             targets: ["WorkflowConcurrency"]
@@ -72,11 +78,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.44.14")),
     ],
     targets: [
         // MARK: Workflow
+
         .target(
             name: "Workflow",
             path: "Workflow/Sources"
@@ -98,6 +105,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowUI
+
         .target(
             name: "WorkflowUI",
             dependencies: ["Workflow"],
@@ -115,6 +123,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowReactiveSwift
+
         .target(
             name: "WorkflowReactiveSwift",
             dependencies: ["ReactiveSwift", "Workflow"],
@@ -137,6 +146,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowRxSwift
+
         .target(
             name: "WorkflowRxSwift",
             dependencies: ["RxSwift", "Workflow"],
@@ -159,6 +169,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowCombine
+
         .target(
             name: "WorkflowCombine",
             dependencies: ["Workflow"],
@@ -181,6 +192,7 @@ let package = Package(
         ),
 
         // MARK: WorkflowConcurrency
+
         .target(
             name: "WorkflowConcurrency",
             dependencies: ["Workflow"],

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
 
         .library(
             name: "WorkflowRxSwift",
-            targets: ["WorkflowReactiveSwift"]
+            targets: ["WorkflowRxSwift"]
         ),
         .library(
             name: "WorkflowRxSwiftTesting",

--- a/Package.swift
+++ b/Package.swift
@@ -155,7 +155,7 @@ let package = Package(
         ),
         .testTarget(
             name: "WorkflowRxSwiftTests",
-            dependencies: ["WorkflowRxSwiftTesting"],
+            dependencies: ["WorkflowRxSwiftTesting", "WorkflowReactiveSwift"],
             path: "WorkflowRxSwift/Tests"
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.3.0"),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.0.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.44.14")),
     ],
@@ -86,6 +86,7 @@ let package = Package(
 
         .target(
             name: "Workflow",
+            dependencies: ["ReactiveSwift"],
             path: "Workflow/Sources"
         ),
         .testTarget(

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -18,6 +18,8 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Workflow/Sources/*.swift'
 
+  s.dependency 'ReactiveSwift', '~> 7.0.0'
+
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Workflow/Tests/**/*.swift'
     test_spec.framework = 'XCTest'

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Workflow/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 7.0.0'
-
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Workflow/Tests/**/*.swift'
     test_spec.framework = 'XCTest'

--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import ReactiveSwift
+import Foundation
 
 /// `RenderContext` is the composition point for the workflow tree.
 ///

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Foundation
+import ReactiveSwift
 
 /// Defines a type that receives debug information about a running workflow hierarchy.
 public protocol WorkflowDebugger {

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import ReactiveSwift
+import Foundation
 
 /// Defines a type that receives debug information about a running workflow hierarchy.
 public protocol WorkflowDebugger {

--- a/WorkflowReactiveSwift/Sources/QueueScheduler+Workflow.swift
+++ b/WorkflowReactiveSwift/Sources/QueueScheduler+Workflow.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Square Inc.
+ * Copyright 2023 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/WorkflowReactiveSwift/Sources/QueueScheduler+Workflow.swift
+++ b/WorkflowReactiveSwift/Sources/QueueScheduler+Workflow.swift
@@ -15,8 +15,14 @@
  */
 
 import Foundation
+import ReactiveSwift
 
-extension DispatchQueue {
-    @_spi(WorkflowInternals)
-    public static let workflowExecution: DispatchQueue = .main
+@_spi(WorkflowInternals) import Workflow
+
+extension QueueScheduler {
+    static let workflowExecution: QueueScheduler = QueueScheduler(
+        qos: .userInteractive,
+        name: "com.squareup.workflow",
+        targeting: DispatchQueue.workflowExecution
+    )
 }


### PR DESCRIPTION
Re-do of https://github.com/square/workflow-swift/pull/173 within the repo (deleted my fork too soon)

I want to wean the core off of ReactiveSwift. 

This PR does two things:
* Update Package.swift
    * Reorganize the file
    * Expose the RxSwift flavors
    * Update ReactiveSwift to be consistent with the Podspec
* Remove `import ReactiveSwift` for anything that didn't really need it

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
