### PR TITLE
[fix]: minor storage lifetime optimization

### DIFF
--- a/Workflow/Sources/AnyWorkflow.swift
+++ b/Workflow/Sources/AnyWorkflow.swift
@@ -131,14 +131,18 @@ extension AnyWorkflow {
             return AnyWorkflow<Rendering, NewOutput>.Storage<T>(
                 workflow: workflow,
                 renderingTransform: renderingTransform,
-                outputTransform: { transform(self.outputTransform($0)) }
+                outputTransform: { [outputTransform] in
+                    transform(outputTransform($0))
+                }
             )
         }
 
         override func mapRendering<NewRendering>(transform: @escaping (Rendering) -> NewRendering) -> AnyWorkflow<NewRendering, Output>.AnyStorage {
             return AnyWorkflow<NewRendering, Output>.Storage<T>(
                 workflow: workflow,
-                renderingTransform: { transform(self.renderingTransform($0)) },
+                renderingTransform: { [renderingTransform] in
+                    transform(renderingTransform($0))
+                },
                 outputTransform: outputTransform
             )
         }


### PR DESCRIPTION
### Issue

- to support the `mapRendering` & `mapOutput` API, `AnyWorkflow` internally stores these transformations in a storage type
- the existing method implementations would retain the existing storage object unnecessarily, when only the existing transform need be retained

### Description

- removed the unnecessary captures of the full internal storage object when mapping outputs/renderings

## Checklist

- [x] Unit Tests (existing tests suffice)
- [x] ~UI Tests~ n/a
- [x] ~Snapshot Tests (iOS only)~ n/a
- [x] ~I have made corresponding changes to the documentation~ n/a
