### PR TITLE
[feat]: add primary associated types to `Workflow` protocol

### DIFF
--- a/Workflow/Sources/Workflow.swift
+++ b/Workflow/Sources/Workflow.swift
@@ -49,6 +49,39 @@
 /// }
 /// ```
 ///
+#if swift(>=5.7)
+public protocol Workflow<Rendering, Output>: AnyWorkflowConvertible {
+    /// Defines the state that is managed by this workflow.
+    associatedtype State
+
+    /// `Output` defines the type that can be emitted as output events.
+    associatedtype Output = Never
+
+    /// `Rendering` is the type that is produced by the `render` method: it
+    /// is commonly a view / screen model.
+    associatedtype Rendering
+
+    /// This method is invoked once when a workflow node comes into existence.
+    ///
+    /// - Returns: The initial state for the workflow.
+    func makeInitialState() -> State
+
+    /// Called when a new workflow is passed down from the parent to an existing workflow node.
+    ///
+    /// - Parameter previousWorkflow: The workflow before the update.
+    /// - Parameter state: The current state.
+    func workflowDidChange(from previousWorkflow: Self, state: inout State)
+
+    /// Called by the internal Workflow infrastructure to "render" the current state into `Rendering`.
+    /// A workflow's `Rendering` type is commonly a view or screen model.
+    ///
+    /// - Parameter state: The current state.
+    /// - Parameter context: The workflow context is the composition point for the workflow tree. To use a nested
+    ///                      workflow, instantiate it based on the current state, then call `rendered(in:key:outputMap:)`.
+    ///                      This will return the child's `Rendering` type after creating or updating the nested workflow.
+    func render(state: State, context: RenderContext<Self>) -> Rendering
+}
+#else
 public protocol Workflow: AnyWorkflowConvertible {
     /// Defines the state that is managed by this workflow.
     associatedtype State
@@ -80,6 +113,7 @@ public protocol Workflow: AnyWorkflowConvertible {
     ///                      This will return the child's `Rendering` type after creating or updating the nested workflow.
     func render(state: State, context: RenderContext<Self>) -> Rendering
 }
+#endif
 
 extension Workflow {
     public func workflowDidChange(from previousWorkflow: Self, state: inout State) {}


### PR DESCRIPTION
### Issue

- Workflow doesn't yet expose primary associated types, which makes some forms of type-erasure less useful or impossible

### Description

- adds `Rendering` and `Output` as the primary associated types of the `Workflow` protocol

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
