### PR TITLE
[chore]: update swiftformat ifdef indent rule to no-indent

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -34,7 +34,7 @@
 --fragment false
 --hexgrouping none
 --hexliteralcase uppercase
---ifdef indent
+--ifdef no-indent
 --indentcase false
 --linebreaks lf
 --maxwidth none

--- a/Workflow/Tests/WorkflowNodeTests.swift
+++ b/Workflow/Tests/WorkflowNodeTests.swift
@@ -365,5 +365,5 @@ private struct StateTransitioningWorkflow: Workflow {
 #if compiler(>=5.0)
 // Never gains Equatable and Hashable conformance in Swift 5
 #else
-    extension Never: Equatable {}
+extension Never: Equatable {}
 #endif

--- a/WorkflowCombine/Sources/Publisher+Extensions.swift
+++ b/WorkflowCombine/Sources/Publisher+Extensions.swift
@@ -7,28 +7,28 @@
 
 #if canImport(Combine) && swift(>=5.1)
 
-    import Combine
-    import Foundation
-    import Workflow
+import Combine
+import Foundation
+import Workflow
 
-    @available(iOS 13.0, macOS 10.15, *)
-    /// This is a workaround to the fact you extensions of protocols cannot have an inheritance clause.
-    /// a previous solution had extending the `AnyPublisher` to conform to `AnyWorkflowConvertible`,
-    /// but was limited in the fact that rendering was only available to `AnyPublisher`s.
-    /// this solutions makes it so that all publishers can render its view.
-    extension Publisher where Failure == Never {
-        public func running<Parent>(in context: RenderContext<Parent>, key: String = "") where
-            Output == AnyWorkflowAction<Parent> {
-            asAnyWorkflow().rendered(in: context, key: key, outputMap: { $0 })
-        }
-
-        public func mapOutput<NewOutput>(_ transform: @escaping (Output) -> NewOutput) -> AnyWorkflow<Void, NewOutput> {
-            asAnyWorkflow().mapOutput(transform)
-        }
-
-        func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
-            PublisherWorkflow(publisher: self).asAnyWorkflow()
-        }
+@available(iOS 13.0, macOS 10.15, *)
+/// This is a workaround to the fact you extensions of protocols cannot have an inheritance clause.
+/// a previous solution had extending the `AnyPublisher` to conform to `AnyWorkflowConvertible`,
+/// but was limited in the fact that rendering was only available to `AnyPublisher`s.
+/// this solutions makes it so that all publishers can render its view.
+extension Publisher where Failure == Never {
+    public func running<Parent>(in context: RenderContext<Parent>, key: String = "") where
+        Output == AnyWorkflowAction<Parent> {
+        asAnyWorkflow().rendered(in: context, key: key, outputMap: { $0 })
     }
+
+    public func mapOutput<NewOutput>(_ transform: @escaping (Output) -> NewOutput) -> AnyWorkflow<Void, NewOutput> {
+        asAnyWorkflow().mapOutput(transform)
+    }
+
+    func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
+        PublisherWorkflow(publisher: self).asAnyWorkflow()
+    }
+}
 
 #endif

--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -16,35 +16,35 @@
 
 #if canImport(Combine) && swift(>=5.1)
 
-    import Combine
-    import Foundation
-    import Workflow
+import Combine
+import Foundation
+import Workflow
 
-    @available(iOS 13.0, macOS 10.15, *)
-    struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowPublisher.Failure == Never {
-        public typealias Output = WorkflowPublisher.Output
-        public typealias State = Void
-        public typealias Rendering = Void
+@available(iOS 13.0, macOS 10.15, *)
+struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowPublisher.Failure == Never {
+    public typealias Output = WorkflowPublisher.Output
+    public typealias State = Void
+    public typealias Rendering = Void
 
-        let publisher: WorkflowPublisher
+    let publisher: WorkflowPublisher
 
-        public init(publisher: WorkflowPublisher) {
-            self.publisher = publisher
-        }
+    public init(publisher: WorkflowPublisher) {
+        self.publisher = publisher
+    }
 
-        public func render(state: State, context: RenderContext<Self>) -> Rendering {
-            let sink = context.makeSink(of: AnyWorkflowAction.self)
-            context.runSideEffect(key: "") { [publisher] lifetime in
-                let cancellable = publisher
-                    .map { AnyWorkflowAction(sendingOutput: $0) }
-                    .receive(on: DispatchQueue.main)
-                    .sink { sink.send($0) }
+    public func render(state: State, context: RenderContext<Self>) -> Rendering {
+        let sink = context.makeSink(of: AnyWorkflowAction.self)
+        context.runSideEffect(key: "") { [publisher] lifetime in
+            let cancellable = publisher
+                .map { AnyWorkflowAction(sendingOutput: $0) }
+                .receive(on: DispatchQueue.main)
+                .sink { sink.send($0) }
 
-                lifetime.onEnded {
-                    cancellable.cancel()
-                }
+            lifetime.onEnded {
+                cancellable.cancel()
             }
         }
     }
+}
 
 #endif

--- a/WorkflowCombine/Sources/Worker.swift
+++ b/WorkflowCombine/Sources/Worker.swift
@@ -16,87 +16,87 @@
 
 #if canImport(Combine) && swift(>=5.1)
 
-    import Combine
-    import Foundation
-    import Workflow
+import Combine
+import Foundation
+import Workflow
 
-    /// Workers define a unit of asynchronous work.
-    ///
-    /// During a render pass, a workflow can ask the context to await the result of a worker.
-    ///
-    /// When this occurs, the context checks to see if there is already a running worker of the same type.
-    /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
-    ///
-    /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-    @available(iOS 13.0, macOS 10.15, *)
-    public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
-        /// The type of output events returned by this worker.
-        associatedtype Output
-        associatedtype WorkerPublisher: Publisher where
-            WorkerPublisher.Output == Output, WorkerPublisher.Failure == Never
+/// Workers define a unit of asynchronous work.
+///
+/// During a render pass, a workflow can ask the context to await the result of a worker.
+///
+/// When this occurs, the context checks to see if there is already a running worker of the same type.
+/// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
+///
+/// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
+@available(iOS 13.0, macOS 10.15, *)
+public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+    /// The type of output events returned by this worker.
+    associatedtype Output
+    associatedtype WorkerPublisher: Publisher where
+        WorkerPublisher.Output == Output, WorkerPublisher.Failure == Never
 
-        /// Returns a publisher to execute the work represented by this worker.
-        func run() -> WorkerPublisher
-        /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
-        /// account whatever data is meaningful to the task. For example, a worker that loads a user account from a server
-        /// would not be equivalent to another worker with a different user ID.
-        func isEquivalent(to otherWorker: Self) -> Bool
+    /// Returns a publisher to execute the work represented by this worker.
+    func run() -> WorkerPublisher
+    /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
+    /// account whatever data is meaningful to the task. For example, a worker that loads a user account from a server
+    /// would not be equivalent to another worker with a different user ID.
+    func isEquivalent(to otherWorker: Self) -> Bool
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+extension Worker {
+    public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
+        WorkerWorkflow(worker: self).asAnyWorkflow()
     }
+}
 
-    @available(iOS 13.0, macOS 10.15, *)
-    extension Worker {
-        public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
-            WorkerWorkflow(worker: self).asAnyWorkflow()
+@available(iOS 13.0, macOS 10.15, *)
+struct WorkerWorkflow<WorkerType: Worker>: Workflow {
+    let worker: WorkerType
+
+    typealias Output = WorkerType.Output
+    typealias Rendering = Void
+    typealias State = UUID
+
+    func makeInitialState() -> State { UUID() }
+
+    func workflowDidChange(from previousWorkflow: WorkerWorkflow<WorkerType>, state: inout UUID) {
+        if !worker.isEquivalent(to: previousWorkflow.worker) {
+            state = UUID()
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
-    struct WorkerWorkflow<WorkerType: Worker>: Workflow {
-        let worker: WorkerType
+    func render(state: State, context: RenderContext<WorkerWorkflow>) -> Rendering {
+        let logger = WorkerLogger<WorkerType>()
 
-        typealias Output = WorkerType.Output
-        typealias Rendering = Void
-        typealias State = UUID
-
-        func makeInitialState() -> State { UUID() }
-
-        func workflowDidChange(from previousWorkflow: WorkerWorkflow<WorkerType>, state: inout UUID) {
-            if !worker.isEquivalent(to: previousWorkflow.worker) {
-                state = UUID()
-            }
+        Deferred {
+            worker.run()
+                .handleEvents(
+                    receiveSubscription: { _ in
+                        logger.logStarted()
+                    },
+                    receiveOutput: { output in
+                        logger.logOutput()
+                    },
+                    receiveCompletion: { completion in
+                        // no need to switch completion since Failure is hardcoded to Never
+                        logger.logFinished(status: "Finished")
+                    },
+                    receiveCancel: {
+                        logger.logFinished(status: "Cancelled")
+                    }
+                )
+                .map { AnyWorkflowAction<Self>(sendingOutput: $0) }
         }
-
-        func render(state: State, context: RenderContext<WorkerWorkflow>) -> Rendering {
-            let logger = WorkerLogger<WorkerType>()
-
-            Deferred {
-                worker.run()
-                    .handleEvents(
-                        receiveSubscription: { _ in
-                            logger.logStarted()
-                        },
-                        receiveOutput: { output in
-                            logger.logOutput()
-                        },
-                        receiveCompletion: { completion in
-                            // no need to switch completion since Failure is hardcoded to Never
-                            logger.logFinished(status: "Finished")
-                        },
-                        receiveCancel: {
-                            logger.logFinished(status: "Cancelled")
-                        }
-                    )
-                    .map { AnyWorkflowAction<Self>(sendingOutput: $0) }
-            }
-            .running(in: context, key: state.uuidString)
-        }
+        .running(in: context, key: state.uuidString)
     }
+}
 
-    @available(iOS 13.0, macOS 10.15, *)
-    extension Worker where Self: Equatable {
-        public func isEquivalent(to otherWorker: Self) -> Bool {
-            self == otherWorker
-        }
+@available(iOS 13.0, macOS 10.15, *)
+extension Worker where Self: Equatable {
+    public func isEquivalent(to otherWorker: Self) -> Bool {
+        self == otherWorker
     }
+}
 
 #endif

--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -16,35 +16,35 @@
 
 #if DEBUG
 
-    import Combine
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowCombine
+import Combine
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowCombine
 
-    @available(macOS 10.15, *)
-    @available(iOS 13.0, *)
-    extension RenderTester {
-        /// Expect a `Publisher`s.
-        ///
-        /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
-        ///
-        /// - Parameters:
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<PublisherType: Publisher>(
-            publisher: PublisherType.Type,
-            output: PublisherType.Output,
-            key: String = ""
-        ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
-            expectWorkflow(
-                type: PublisherWorkflow<PublisherType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { _ in }
-            )
-        }
+@available(macOS 10.15, *)
+@available(iOS 13.0, *)
+extension RenderTester {
+    /// Expect a `Publisher`s.
+    ///
+    /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
+    ///
+    /// - Parameters:
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expect<PublisherType: Publisher>(
+        publisher: PublisherType.Type,
+        output: PublisherType.Output,
+        key: String = ""
+    ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
+        expectWorkflow(
+            type: PublisherWorkflow<PublisherType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { _ in }
+        )
     }
+}
 
 #endif

--- a/WorkflowCombine/Testing/WorkerTesting.swift
+++ b/WorkflowCombine/Testing/WorkerTesting.swift
@@ -15,42 +15,42 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowCombine
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowCombine
 
 @available(macOS 10.15, *)
 @available(iOS 13.0, *)
 extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
-        ///
-        /// - Parameters:
-        ///   - worker: The worker to be expected
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
+    /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+    ///
+    /// - Parameters:
+    ///   - worker: The worker to be expected
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expect<ExpectedWorkerType: Worker>(
+        worker: ExpectedWorkerType,
+        producingOutput output: ExpectedWorkerType.Output? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: WorkerWorkflow<ExpectedWorkerType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { workflow in
+                guard !workflow.worker.isEquivalent(to: worker) else {
+                    return
                 }
-            )
-        }
+                XCTFail(
+                    "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
+                    file: file,
+                    line: line
+                )
+            }
+        )
     }
+}
 #endif

--- a/WorkflowCombine/TestingTests/TestingTests.swift
+++ b/WorkflowCombine/TestingTests/TestingTests.swift
@@ -127,25 +127,25 @@ class WorkflowCombineTestingTests: XCTestCase {
 
     #if swift(>=5.3)
 
-        // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
-        override func record(_ issue: XCTIssue) {
-            if removeFailure(withDescription: issue.compactDescription) {
-                // Don’t forward the issue, it was expected
-            } else {
-                super.record(issue)
-            }
+    // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
+    override func record(_ issue: XCTIssue) {
+        if removeFailure(withDescription: issue.compactDescription) {
+            // Don’t forward the issue, it was expected
+        } else {
+            super.record(issue)
         }
+    }
 
     #else
 
-        // Otherwise, use old API
-        override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-            if removeFailure(withDescription: description) {
-                // Don’t forward the failure, it was expected
-            } else {
-                super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-            }
+    // Otherwise, use old API
+    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
+        if removeFailure(withDescription: description) {
+            // Don’t forward the failure, it was expected
+        } else {
+            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
         }
+    }
 
     #endif
 }

--- a/WorkflowConcurrency/Testing/WorkerTesting.swift
+++ b/WorkflowConcurrency/Testing/WorkerTesting.swift
@@ -15,42 +15,42 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowConcurrency
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowConcurrency
 
-    @available(macOS 10.15, *)
-    @available(iOS 13.0, *)
-    extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
-        ///
-        /// - Parameters:
-        ///   - worker: The worker to be expected
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
+@available(macOS 10.15, *)
+@available(iOS 13.0, *)
+extension RenderTester {
+    /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+    ///
+    /// - Parameters:
+    ///   - worker: The worker to be expected
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expect<ExpectedWorkerType: Worker>(
+        worker: ExpectedWorkerType,
+        producingOutput output: ExpectedWorkerType.Output? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: WorkerWorkflow<ExpectedWorkerType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { workflow in
+                guard !workflow.worker.isEquivalent(to: worker) else {
+                    return
                 }
-            )
-        }
+                XCTFail(
+                    "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
+                    file: file,
+                    line: line
+                )
+            }
+        )
     }
+}
 #endif

--- a/WorkflowConcurrency/TestingTests/TestingTests.swift
+++ b/WorkflowConcurrency/TestingTests/TestingTests.swift
@@ -126,25 +126,25 @@ class WorkflowConcurrencyTestingTests: XCTestCase {
 
     #if swift(>=5.3)
 
-        // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
-        override func record(_ issue: XCTIssue) {
-            if removeFailure(withDescription: issue.compactDescription) {
-                // Don’t forward the issue, it was expected
-            } else {
-                super.record(issue)
-            }
+    // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
+    override func record(_ issue: XCTIssue) {
+        if removeFailure(withDescription: issue.compactDescription) {
+            // Don’t forward the issue, it was expected
+        } else {
+            super.record(issue)
         }
+    }
 
     #else
 
-        // Otherwise, use old API
-        override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-            if removeFailure(withDescription: description) {
-                // Don’t forward the failure, it was expected
-            } else {
-                super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-            }
+    // Otherwise, use old API
+    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
+        if removeFailure(withDescription: description) {
+            // Don’t forward the failure, it was expected
+        } else {
+            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
         }
+    }
 
     #endif
 }

--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -15,51 +15,51 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowReactiveSwift
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowReactiveSwift
 
-    extension RenderTester {
-        /// Expect a `SignalProducer`.
-        ///
-        /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
-        ///
-        ///  ⚠️ N.B. If you are testing a case in which multiple `SignalProducerWorkflow`s are expected, **only one of them** may have a non-nil `producingOutput` parameter.
-        ///
-        /// - Parameters:
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expectSignalProducer<OutputType>(
-            producingOutput output: OutputType? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: SignalProducerWorkflow<OutputType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { _ in }
-            )
-        }
-
-        /// Expect a `SignalProducer` with the specified `outputType` that produces no `Output`.
-        ///
-        /// - Parameters:
-        ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expectSignalProducer<OutputType>(
-            outputType: OutputType.Type,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: SignalProducerWorkflow<OutputType>.self,
-                key: key,
-                producingRendering: (),
-                assertions: { _ in }
-            )
-        }
+extension RenderTester {
+    /// Expect a `SignalProducer`.
+    ///
+    /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
+    ///
+    ///  ⚠️ N.B. If you are testing a case in which multiple `SignalProducerWorkflow`s are expected, **only one of them** may have a non-nil `producingOutput` parameter.
+    ///
+    /// - Parameters:
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expectSignalProducer<OutputType>(
+        producingOutput output: OutputType? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: SignalProducerWorkflow<OutputType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { _ in }
+        )
     }
+
+    /// Expect a `SignalProducer` with the specified `outputType` that produces no `Output`.
+    ///
+    /// - Parameters:
+    ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expectSignalProducer<OutputType>(
+        outputType: OutputType.Type,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: SignalProducerWorkflow<OutputType>.self,
+            key: key,
+            producingRendering: (),
+            assertions: { _ in }
+        )
+    }
+}
 #endif

--- a/WorkflowReactiveSwift/Testing/WorkerTesting.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting.swift
@@ -15,40 +15,40 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowReactiveSwift
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowReactiveSwift
 
-    extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
-        ///
-        /// - Parameters:
-        ///   - worker: The worker to be expected
-        ///   - producingOutput: An output that should be returned when this worker is requested, if any.
-        ///   - key: Key to expect this `Workflow` to be rendered with.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
+extension RenderTester {
+    /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+    ///
+    /// - Parameters:
+    ///   - worker: The worker to be expected
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    public func expect<ExpectedWorkerType: Worker>(
+        worker: ExpectedWorkerType,
+        producingOutput output: ExpectedWorkerType.Output? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: WorkerWorkflow<ExpectedWorkerType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { workflow in
+                guard !workflow.worker.isEquivalent(to: worker) else {
+                    return
                 }
-            )
-        }
+                XCTFail(
+                    "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
+                    file: file,
+                    line: line
+                )
+            }
+        )
     }
+}
 #endif

--- a/WorkflowReactiveSwift/TestingTests/TestingTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/TestingTests.swift
@@ -126,25 +126,25 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
 
     #if swift(>=5.3)
 
-        // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
-        override func record(_ issue: XCTIssue) {
-            if removeFailure(withDescription: issue.compactDescription) {
-                // Don’t forward the issue, it was expected
-            } else {
-                super.record(issue)
-            }
+    // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
+    override func record(_ issue: XCTIssue) {
+        if removeFailure(withDescription: issue.compactDescription) {
+            // Don’t forward the issue, it was expected
+        } else {
+            super.record(issue)
         }
+    }
 
     #else
 
-        // Otherwise, use old API
-        override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-            if removeFailure(withDescription: description) {
-                // Don’t forward the failure, it was expected
-            } else {
-                super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-            }
+    // Otherwise, use old API
+    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
+        if removeFailure(withDescription: description) {
+            // Don’t forward the failure, it was expected
+        } else {
+            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
         }
+    }
 
     #endif
 }

--- a/WorkflowRxSwift/Testing/ObservableTesting.swift
+++ b/WorkflowRxSwift/Testing/ObservableTesting.swift
@@ -15,29 +15,29 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowRxSwift
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowRxSwift
 
-    extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+extension RenderTester {
+    /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
 
-        /// - Parameters:
-        ///   - worker: The worker to be expected
-        ///   - output: An output that should be returned when this worker is requested, if any.
-        public func expectObservable<OutputType>(
-            producingOutput output: OutputType? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: ObservableWorkflow<OutputType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { _ in }
-            )
-        }
+    /// - Parameters:
+    ///   - worker: The worker to be expected
+    ///   - output: An output that should be returned when this worker is requested, if any.
+    public func expectObservable<OutputType>(
+        producingOutput output: OutputType? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: ObservableWorkflow<OutputType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { _ in }
+        )
     }
+}
 #endif

--- a/WorkflowRxSwift/Testing/WorkerTesting.swift
+++ b/WorkflowRxSwift/Testing/WorkerTesting.swift
@@ -15,39 +15,39 @@
  */
 
 #if DEBUG
-    import Workflow
-    import WorkflowTesting
-    import XCTest
-    @testable import WorkflowRxSwift
+import Workflow
+import WorkflowTesting
+import XCTest
+@testable import WorkflowRxSwift
 
-    extension RenderTester {
-        /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
+extension RenderTester {
+    /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
 
-        /// - Parameters:
-        ///   - worker: The worker to be expected
-        ///   - output: An output that should be returned when this worker is requested, if any.
-        public func expect<ExpectedWorkerType: Worker>(
-            worker: ExpectedWorkerType,
-            producingOutput output: ExpectedWorkerType.Output? = nil,
-            key: String = "",
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            expectWorkflow(
-                type: WorkerWorkflow<ExpectedWorkerType>.self,
-                key: key,
-                producingRendering: (),
-                producingOutput: output,
-                assertions: { workflow in
-                    guard !workflow.worker.isEquivalent(to: worker) else {
-                        return
-                    }
-                    XCTFail(
-                        "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                        file: file,
-                        line: line
-                    )
+    /// - Parameters:
+    ///   - worker: The worker to be expected
+    ///   - output: An output that should be returned when this worker is requested, if any.
+    public func expect<ExpectedWorkerType: Worker>(
+        worker: ExpectedWorkerType,
+        producingOutput output: ExpectedWorkerType.Output? = nil,
+        key: String = "",
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        expectWorkflow(
+            type: WorkerWorkflow<ExpectedWorkerType>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { workflow in
+                guard !workflow.worker.isEquivalent(to: worker) else {
+                    return
                 }
-            )
-        }
+                XCTFail(
+                    "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
+                    file: file,
+                    line: line
+                )
+            }
+        )
     }
+}
 #endif

--- a/WorkflowRxSwift/TestingTests/TestingTests.swift
+++ b/WorkflowRxSwift/TestingTests/TestingTests.swift
@@ -117,25 +117,25 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
 
     #if swift(>=5.3)
 
-        // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
-        override func record(_ issue: XCTIssue) {
-            if removeFailure(withDescription: issue.compactDescription) {
-                // Don’t forward the issue, it was expected
-            } else {
-                super.record(issue)
-            }
+    // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
+    override func record(_ issue: XCTIssue) {
+        if removeFailure(withDescription: issue.compactDescription) {
+            // Don’t forward the issue, it was expected
+        } else {
+            super.record(issue)
         }
+    }
 
     #else
 
-        // Otherwise, use old API
-        override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-            if removeFailure(withDescription: description) {
-                // Don’t forward the failure, it was expected
-            } else {
-                super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-            }
+    // Otherwise, use old API
+    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
+        if removeFailure(withDescription: description) {
+            // Don’t forward the failure, it was expected
+        } else {
+            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
         }
+    }
 
     #endif
 }

--- a/WorkflowSwiftUI/Sources/WorkflowView.swift
+++ b/WorkflowSwiftUI/Sources/WorkflowView.swift
@@ -16,283 +16,283 @@
 
 #if canImport(SwiftUI) && canImport(Combine) && swift(>=5.1)
 
-    import Combine
-    import ReactiveSwift
-    import SwiftUI
-    import Workflow
+import Combine
+import ReactiveSwift
+import SwiftUI
+import Workflow
 
-    /// Hosts a Workflow-powered view hierarchy.
-    ///
-    /// Example:
-    ///
-    /// ```
-    /// var body: some View {
-    ///     WorkflowView(workflow: MyWorkflow(), onOutput: { self.handleOutput($0) }) { rendering in
-    ///         VStack {
-    ///
-    ///             Text("The value is \(rendering.value)")
-    ///
-    ///             Button(action: rendering.onIncrement) {
-    ///                 Text("+")
-    ///             }
-    ///
-    ///             Button(action: rendering.onDecrement) {
-    ///                 Text("-")
-    ///             }
-    ///
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    @available(iOS 13.0, macOS 10.15, *)
-    public struct WorkflowView<T: Workflow, Content: View>: View {
-        /// The workflow implementation to use
-        public var workflow: T
+/// Hosts a Workflow-powered view hierarchy.
+///
+/// Example:
+///
+/// ```
+/// var body: some View {
+///     WorkflowView(workflow: MyWorkflow(), onOutput: { self.handleOutput($0) }) { rendering in
+///         VStack {
+///
+///             Text("The value is \(rendering.value)")
+///
+///             Button(action: rendering.onIncrement) {
+///                 Text("+")
+///             }
+///
+///             Button(action: rendering.onDecrement) {
+///                 Text("-")
+///             }
+///
+///         }
+///     }
+/// }
+/// ```
+@available(iOS 13.0, macOS 10.15, *)
+public struct WorkflowView<T: Workflow, Content: View>: View {
+    /// The workflow implementation to use
+    public var workflow: T
 
-        /// A handler for any output events emitted by the workflow
-        public var onOutput: (T.Output) -> Void
+    /// A handler for any output events emitted by the workflow
+    public var onOutput: (T.Output) -> Void
 
-        /// A closure that maps the workflow's rendering type into a view of type `Content`.
-        public var content: (T.Rendering) -> Content
+    /// A closure that maps the workflow's rendering type into a view of type `Content`.
+    public var content: (T.Rendering) -> Content
 
-        public init(workflow: T, onOutput: @escaping (T.Output) -> Void, content: @escaping (T.Rendering) -> Content) {
-            self.onOutput = onOutput
-            self.content = content
-            self.workflow = workflow
-        }
-
-        public var body: some View {
-            IntermediateView(
-                workflow: workflow,
-                onOutput: onOutput,
-                content: content
-            )
-        }
+    public init(workflow: T, onOutput: @escaping (T.Output) -> Void, content: @escaping (T.Rendering) -> Content) {
+        self.onOutput = onOutput
+        self.content = content
+        self.workflow = workflow
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
-    extension WorkflowView where T.Output == Never {
-        /// Convenience initializer for workflows with no output.
-        public init(workflow: T, content: @escaping (T.Rendering) -> Content) {
-            self.init(workflow: workflow, onOutput: { _ in }, content: content)
-        }
+    public var body: some View {
+        IntermediateView(
+            workflow: workflow,
+            onOutput: onOutput,
+            content: content
+        )
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+extension WorkflowView where T.Output == Never {
+    /// Convenience initializer for workflows with no output.
+    public init(workflow: T, content: @escaping (T.Rendering) -> Content) {
+        self.init(workflow: workflow, onOutput: { _ in }, content: content)
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+extension WorkflowView where T.Rendering == Content {
+    /// Convenience initializer for workflows whose rendering type conforms to `View`.
+    public init(workflow: T, onOutput: @escaping (T.Output) -> Void) {
+        self.init(workflow: workflow, onOutput: onOutput, content: { $0 })
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+extension WorkflowView where T.Output == Never, T.Rendering == Content {
+    /// Convenience initializer for workflows with no output whose rendering type conforms to `View`.
+    public init(workflow: T) {
+        self.init(workflow: workflow, onOutput: { _ in }, content: { $0 })
+    }
+}
+
+// We use a `UIViewController/UIViewControllerRepresentable` here to drop back to UIKit because it gives us a predictable
+// update mechanism via `updateUIViewController(_:context:)`. If we were to manage a `WorkflowHost` instance directly
+// within a SwiftUI view we would need to update the host with the updated workflow from our implementation of `body`.
+// Performing work within the body accessor is strongly discouraged, so we jump back into UIKit for a second here.
+@available(iOS 13.0, macOS 10.15, *)
+fileprivate struct IntermediateView<T: Workflow, Content: View> {
+    var workflow: T
+    var onOutput: (T.Output) -> Void
+    var content: (T.Rendering) -> Content
+}
+
+#if canImport(UIKit)
+
+import UIKit
+
+@available(iOS 13.0, *)
+extension IntermediateView: UIViewControllerRepresentable {
+    func makeUIViewController(context: UIViewControllerRepresentableContext<IntermediateView<T, Content>>) -> WorkflowHostingViewController<T, Content> {
+        WorkflowHostingViewController(workflow: workflow, content: content)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
-    extension WorkflowView where T.Rendering == Content {
-        /// Convenience initializer for workflows whose rendering type conforms to `View`.
-        public init(workflow: T, onOutput: @escaping (T.Output) -> Void) {
-            self.init(workflow: workflow, onOutput: onOutput, content: { $0 })
-        }
+    func updateUIViewController(_ uiViewController: WorkflowHostingViewController<T, Content>, context: UIViewControllerRepresentableContext<IntermediateView<T, Content>>) {
+        uiViewController.content = content
+        uiViewController.onOutput = onOutput
+        uiViewController.update(to: workflow)
+    }
+}
+
+@available(iOS 13.0, *)
+fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View>: UIViewController {
+    private let workflowHost: WorkflowHost<T>
+    private let hostingController: UIHostingController<RootView<Content>>
+    private let rootViewProvider: RootViewProvider<Content>
+
+    var content: (T.Rendering) -> Content
+    var onOutput: (T.Output) -> Void
+
+    private let (lifetime, token) = Lifetime.make()
+
+    init(workflow: T, content: @escaping (T.Rendering) -> Content) {
+        self.content = content
+        self.onOutput = { _ in }
+
+        self.workflowHost = WorkflowHost(workflow: workflow)
+        self.rootViewProvider = RootViewProvider(view: content(workflowHost.rendering.value))
+        self.hostingController = UIHostingController(rootView: RootView(provider: rootViewProvider))
+
+        super.init(nibName: nil, bundle: nil)
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.didMove(toParent: self)
+
+        workflowHost
+            .rendering
+            .signal
+            .take(during: lifetime)
+            .observeValues { [weak self] rendering in
+                self?.didEmit(rendering: rendering)
+            }
+
+        workflowHost
+            .output
+            .take(during: lifetime)
+            .observeValues { [weak self] output in
+                self?.didEmit(output: output)
+            }
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
-    extension WorkflowView where T.Output == Never, T.Rendering == Content {
-        /// Convenience initializer for workflows with no output whose rendering type conforms to `View`.
-        public init(workflow: T) {
-            self.init(workflow: workflow, onOutput: { _ in }, content: { $0 })
-        }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    // We use a `UIViewController/UIViewControllerRepresentable` here to drop back to UIKit because it gives us a predictable
-    // update mechanism via `updateUIViewController(_:context:)`. If we were to manage a `WorkflowHost` instance directly
-    // within a SwiftUI view we would need to update the host with the updated workflow from our implementation of `body`.
-    // Performing work within the body accessor is strongly discouraged, so we jump back into UIKit for a second here.
-    @available(iOS 13.0, macOS 10.15, *)
-    fileprivate struct IntermediateView<T: Workflow, Content: View> {
-        var workflow: T
-        var onOutput: (T.Output) -> Void
-        var content: (T.Rendering) -> Content
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        hostingController.view.frame = view.bounds
     }
 
-    #if canImport(UIKit)
-
-        import UIKit
-
-        @available(iOS 13.0, *)
-        extension IntermediateView: UIViewControllerRepresentable {
-            func makeUIViewController(context: UIViewControllerRepresentableContext<IntermediateView<T, Content>>) -> WorkflowHostingViewController<T, Content> {
-                WorkflowHostingViewController(workflow: workflow, content: content)
-            }
-
-            func updateUIViewController(_ uiViewController: WorkflowHostingViewController<T, Content>, context: UIViewControllerRepresentableContext<IntermediateView<T, Content>>) {
-                uiViewController.content = content
-                uiViewController.onOutput = onOutput
-                uiViewController.update(to: workflow)
-            }
-        }
-
-        @available(iOS 13.0, *)
-        fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View>: UIViewController {
-            private let workflowHost: WorkflowHost<T>
-            private let hostingController: UIHostingController<RootView<Content>>
-            private let rootViewProvider: RootViewProvider<Content>
-
-            var content: (T.Rendering) -> Content
-            var onOutput: (T.Output) -> Void
-
-            private let (lifetime, token) = Lifetime.make()
-
-            init(workflow: T, content: @escaping (T.Rendering) -> Content) {
-                self.content = content
-                self.onOutput = { _ in }
-
-                self.workflowHost = WorkflowHost(workflow: workflow)
-                self.rootViewProvider = RootViewProvider(view: content(workflowHost.rendering.value))
-                self.hostingController = UIHostingController(rootView: RootView(provider: rootViewProvider))
-
-                super.init(nibName: nil, bundle: nil)
-
-                addChild(hostingController)
-                view.addSubview(hostingController.view)
-                hostingController.didMove(toParent: self)
-
-                workflowHost
-                    .rendering
-                    .signal
-                    .take(during: lifetime)
-                    .observeValues { [weak self] rendering in
-                        self?.didEmit(rendering: rendering)
-                    }
-
-                workflowHost
-                    .output
-                    .take(during: lifetime)
-                    .observeValues { [weak self] output in
-                        self?.didEmit(output: output)
-                    }
-            }
-
-            required init?(coder: NSCoder) {
-                fatalError("init(coder:) has not been implemented")
-            }
-
-            override func viewDidLayoutSubviews() {
-                super.viewDidLayoutSubviews()
-                hostingController.view.frame = view.bounds
-            }
-
-            private func didEmit(rendering: T.Rendering) {
-                rootViewProvider.view = content(rendering)
-            }
-
-            private func didEmit(output: T.Output) {
-                onOutput(output)
-            }
-
-            func update(to workflow: T) {
-                workflowHost.update(workflow: workflow)
-            }
-        }
-
-    #elseif canImport(AppKit)
-
-        import AppKit
-
-        @available(OSX 10.15, *)
-        extension IntermediateView: NSViewControllerRepresentable {
-            func makeNSViewController(context: NSViewControllerRepresentableContext<IntermediateView<T, Content>>) -> WorkflowHostingViewController<T, Content> {
-                WorkflowHostingViewController(workflow: workflow, content: content)
-            }
-
-            func updateNSViewController(_ nsViewController: WorkflowHostingViewController<T, Content>, context: NSViewControllerRepresentableContext<IntermediateView<T, Content>>) {
-                nsViewController.content = content
-                nsViewController.onOutput = onOutput
-                nsViewController.update(to: workflow)
-            }
-        }
-
-        @available(macOS 10.15, *)
-        fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View>: NSViewController {
-            private let workflowHost: WorkflowHost<T>
-            private let hostingController: NSHostingController<RootView<Content>>
-            private let rootViewProvider: RootViewProvider<Content>
-
-            var content: (T.Rendering) -> Content
-            var onOutput: (T.Output) -> Void
-
-            private let (lifetime, token) = Lifetime.make()
-
-            init(workflow: T, content: @escaping (T.Rendering) -> Content) {
-                self.content = content
-                self.onOutput = { _ in }
-
-                self.workflowHost = WorkflowHost(workflow: workflow)
-                self.rootViewProvider = RootViewProvider(view: content(workflowHost.rendering.value))
-                self.hostingController = NSHostingController(rootView: RootView(provider: rootViewProvider))
-
-                super.init(nibName: nil, bundle: nil)
-
-                addChild(hostingController)
-
-                workflowHost
-                    .rendering
-                    .signal
-                    .take(during: lifetime)
-                    .observeValues { [weak self] rendering in
-                        self?.didEmit(rendering: rendering)
-                    }
-
-                workflowHost
-                    .output
-                    .take(during: lifetime)
-                    .observeValues { [weak self] output in
-                        self?.didEmit(output: output)
-                    }
-            }
-
-            required init?(coder: NSCoder) {
-                fatalError("init(coder:) has not been implemented")
-            }
-
-            override func loadView() {
-                view = NSView()
-            }
-
-            override func viewDidLoad() {
-                super.viewDidLoad()
-                view.addSubview(hostingController.view)
-            }
-
-            override func viewDidLayout() {
-                super.viewDidLayout()
-                hostingController.view.frame = view.bounds
-            }
-
-            private func didEmit(rendering: T.Rendering) {
-                rootViewProvider.view = content(rendering)
-            }
-
-            private func didEmit(output: T.Output) {
-                onOutput(output)
-            }
-
-            func update(to workflow: T) {
-                workflowHost.update(workflow: workflow)
-            }
-        }
-
-    #endif
-
-    // Assigning `rootView` on a `UIHostingController` causes unwanted animated transitions.
-    // To avoid this, we never change the root view, but we pass down an `ObservableObject`
-    // so that we can still update the hierarchy as the workflow emits new renderings.
-    @available(iOS 13.0, macOS 10.15, *)
-    fileprivate final class RootViewProvider<T: View>: ObservableObject {
-        @Published var view: T
-
-        init(view: T) {
-            self.view = view
-        }
+    private func didEmit(rendering: T.Rendering) {
+        rootViewProvider.view = content(rendering)
     }
 
-    @available(iOS 13.0, macOS 10.15, *)
-    fileprivate struct RootView<T: View>: View {
-        @ObservedObject var provider: RootViewProvider<T>
-
-        var body: some View {
-            provider.view
-        }
+    private func didEmit(output: T.Output) {
+        onOutput(output)
     }
+
+    func update(to workflow: T) {
+        workflowHost.update(workflow: workflow)
+    }
+}
+
+#elseif canImport(AppKit)
+
+import AppKit
+
+@available(OSX 10.15, *)
+extension IntermediateView: NSViewControllerRepresentable {
+    func makeNSViewController(context: NSViewControllerRepresentableContext<IntermediateView<T, Content>>) -> WorkflowHostingViewController<T, Content> {
+        WorkflowHostingViewController(workflow: workflow, content: content)
+    }
+
+    func updateNSViewController(_ nsViewController: WorkflowHostingViewController<T, Content>, context: NSViewControllerRepresentableContext<IntermediateView<T, Content>>) {
+        nsViewController.content = content
+        nsViewController.onOutput = onOutput
+        nsViewController.update(to: workflow)
+    }
+}
+
+@available(macOS 10.15, *)
+fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View>: NSViewController {
+    private let workflowHost: WorkflowHost<T>
+    private let hostingController: NSHostingController<RootView<Content>>
+    private let rootViewProvider: RootViewProvider<Content>
+
+    var content: (T.Rendering) -> Content
+    var onOutput: (T.Output) -> Void
+
+    private let (lifetime, token) = Lifetime.make()
+
+    init(workflow: T, content: @escaping (T.Rendering) -> Content) {
+        self.content = content
+        self.onOutput = { _ in }
+
+        self.workflowHost = WorkflowHost(workflow: workflow)
+        self.rootViewProvider = RootViewProvider(view: content(workflowHost.rendering.value))
+        self.hostingController = NSHostingController(rootView: RootView(provider: rootViewProvider))
+
+        super.init(nibName: nil, bundle: nil)
+
+        addChild(hostingController)
+
+        workflowHost
+            .rendering
+            .signal
+            .take(during: lifetime)
+            .observeValues { [weak self] rendering in
+                self?.didEmit(rendering: rendering)
+            }
+
+        workflowHost
+            .output
+            .take(during: lifetime)
+            .observeValues { [weak self] output in
+                self?.didEmit(output: output)
+            }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = NSView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(hostingController.view)
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        hostingController.view.frame = view.bounds
+    }
+
+    private func didEmit(rendering: T.Rendering) {
+        rootViewProvider.view = content(rendering)
+    }
+
+    private func didEmit(output: T.Output) {
+        onOutput(output)
+    }
+
+    func update(to workflow: T) {
+        workflowHost.update(workflow: workflow)
+    }
+}
+
+#endif
+
+// Assigning `rootView` on a `UIHostingController` causes unwanted animated transitions.
+// To avoid this, we never change the root view, but we pass down an `ObservableObject`
+// so that we can still update the hierarchy as the workflow emits new renderings.
+@available(iOS 13.0, macOS 10.15, *)
+fileprivate final class RootViewProvider<T: View>: ObservableObject {
+    @Published var view: T
+
+    init(view: T) {
+        self.view = view
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, *)
+fileprivate struct RootView<T: View>: View {
+    @ObservedObject var provider: RootViewProvider<T>
+
+    var body: some View {
+        provider.view
+    }
+}
 
 #endif

--- a/WorkflowTesting/Sources/Internal/RenderExpectations.swift
+++ b/WorkflowTesting/Sources/Internal/RenderExpectations.swift
@@ -16,65 +16,65 @@
 
 #if DEBUG
 
-    @testable import Workflow
+@testable import Workflow
 
-    extension RenderTester {
-        internal class AnyExpectedWorkflow {
-            let workflowType: Any.Type
-            let key: String
-            let file: StaticString
-            let line: UInt
+extension RenderTester {
+    internal class AnyExpectedWorkflow {
+        let workflowType: Any.Type
+        let key: String
+        let file: StaticString
+        let line: UInt
 
-            fileprivate init(workflowType: Any.Type, key: String, file: StaticString, line: UInt) {
-                self.workflowType = workflowType
-                self.key = key
-                self.file = file
-                self.line = line
-            }
-        }
-
-        internal class ExpectedWorkflow<ExpectedWorkflowType: Workflow>: AnyExpectedWorkflow {
-            let rendering: ExpectedWorkflowType.Rendering
-            let output: ExpectedWorkflowType.Output?
-            let assertions: (ExpectedWorkflowType) -> Void
-
-            init(key: String, rendering: ExpectedWorkflowType.Rendering, output: ExpectedWorkflowType.Output?, assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }, file: StaticString, line: UInt) {
-                self.rendering = rendering
-                self.output = output
-                self.assertions = assertions
-                super.init(workflowType: ExpectedWorkflowType.self, key: key, file: file, line: line)
-            }
+        fileprivate init(workflowType: Any.Type, key: String, file: StaticString, line: UInt) {
+            self.workflowType = workflowType
+            self.key = key
+            self.file = file
+            self.line = line
         }
     }
 
-    extension RenderTester {
-        internal class ExpectedSideEffect<WorkflowType: Workflow> {
-            let key: AnyHashable
-            let file: StaticString
-            let line: UInt
+    internal class ExpectedWorkflow<ExpectedWorkflowType: Workflow>: AnyExpectedWorkflow {
+        let rendering: ExpectedWorkflowType.Rendering
+        let output: ExpectedWorkflowType.Output?
+        let assertions: (ExpectedWorkflowType) -> Void
 
-            init(key: AnyHashable, file: StaticString, line: UInt) {
-                self.key = key
-                self.file = file
-                self.line = line
-            }
-
-            func apply<ContextType>(context: ContextType) where ContextType: RenderContextType, ContextType.WorkflowType == WorkflowType {}
-        }
-
-        internal final class ExpectedSideEffectWithAction<WorkflowType, ActionType: WorkflowAction>: ExpectedSideEffect<WorkflowType> where ActionType.WorkflowType == WorkflowType {
-            let action: ActionType
-
-            internal init(key: AnyHashable, action: ActionType, file: StaticString, line: UInt) {
-                self.action = action
-                super.init(key: key, file: file, line: line)
-            }
-
-            override func apply<ContextType>(context: ContextType) where ContextType: RenderContextType, ContextType.WorkflowType == WorkflowType {
-                let sink = context.makeSink(of: ActionType.self)
-                sink.send(action)
-            }
+        init(key: String, rendering: ExpectedWorkflowType.Rendering, output: ExpectedWorkflowType.Output?, assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }, file: StaticString, line: UInt) {
+            self.rendering = rendering
+            self.output = output
+            self.assertions = assertions
+            super.init(workflowType: ExpectedWorkflowType.self, key: key, file: file, line: line)
         }
     }
+}
+
+extension RenderTester {
+    internal class ExpectedSideEffect<WorkflowType: Workflow> {
+        let key: AnyHashable
+        let file: StaticString
+        let line: UInt
+
+        init(key: AnyHashable, file: StaticString, line: UInt) {
+            self.key = key
+            self.file = file
+            self.line = line
+        }
+
+        func apply<ContextType>(context: ContextType) where ContextType: RenderContextType, ContextType.WorkflowType == WorkflowType {}
+    }
+
+    internal final class ExpectedSideEffectWithAction<WorkflowType, ActionType: WorkflowAction>: ExpectedSideEffect<WorkflowType> where ActionType.WorkflowType == WorkflowType {
+        let action: ActionType
+
+        internal init(key: AnyHashable, action: ActionType, file: StaticString, line: UInt) {
+            self.action = action
+            super.init(key: key, file: file, line: line)
+        }
+
+        override func apply<ContextType>(context: ContextType) where ContextType: RenderContextType, ContextType.WorkflowType == WorkflowType {
+            let sink = context.makeSink(of: ActionType.self)
+            sink.send(action)
+        }
+    }
+}
 
 #endif

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -19,281 +19,281 @@
 // `@testable import Workflow` will fail compilation in Release mode.
 #if DEBUG
 
-    import XCTest
-    @testable import Workflow
+import XCTest
+@testable import Workflow
 
-    extension Workflow {
-        /// Returns a `RenderTester` with a specified initial state.
-        public func renderTester(initialState: Self.State) -> RenderTester<Self> {
-            return RenderTester(workflow: self, state: initialState)
-        }
-
-        /// Returns a `RenderTester` with an initial state provided by `self.makeInitialState()`
-        public func renderTester() -> RenderTester<Self> {
-            return renderTester(initialState: makeInitialState())
-        }
+extension Workflow {
+    /// Returns a `RenderTester` with a specified initial state.
+    public func renderTester(initialState: Self.State) -> RenderTester<Self> {
+        return RenderTester(workflow: self, state: initialState)
     }
 
-    /// Testing helper for validating the behavior of calls to `render`.
-    ///
-    /// Usage: `expect` workflows and side effects then validate with a call to `render` and
-    /// the resulting `RenderTesterResult`.
-    /// Side-effects may be performed against the rendering to validate the behavior of actions.
-    ///
-    /// To directly test actions and their effects, use the `WorkflowActionTester`.
-    ///
-    /// ```
-    /// workflow
-    ///     .renderTester(initialState: TestWorkflow.State())
-    ///     .expect(
-    ///         worker: TestWorker(),
-    ///         producingOutput: TestWorker.Output.success
-    ///     )
-    ///     .expectWorkflow(
-    ///         type: ChildWorkflow.self,
-    ///         key: "key",
-    ///         rendering: "rendering",
-    ///         // ⚠️ N.B. Only one output per call to `render` may be produced,
-    ///         // even if multiple child Workflows are expected in a call
-    ///         // to `render`. This is an invariant enforced by `RenderTester`
-    ///         // and the real runtime.
-    ///         producingOutput: nil
-    ///     )
-    ///     .render { rendering in
-    ///         XCTAssertEqual("expected text on rendering", rendering.text)
-    ///     }
-    ///     .assert(state: TestWorkflow.State())
-    ///     .assert(output: TestWorkflow.Output.finished)
-    /// ```
-    ///
-    /// Validating the rendering only from the initial state provided by the workflow:
-    /// ```
-    /// workflow
-    ///     .renderTester()
-    ///     .render { rendering in
-    ///         XCTAssertEqual("expected text on rendering", rendering.text)
-    ///     }
-    /// ```
-    ///
-    /// Validate the state was updated from a callback on the rendering:
-    /// ```
-    /// workflow
-    ///     .renderTester()
-    ///     .render { rendering in
-    ///         XCTAssertEqual("expected text on rendering", rendering.text)
-    ///         rendering.updateText("updated")
-    ///     }
-    ///     .assert(
-    ///         state: TestWorkflow.State(text: "updated")
-    ///     )
-    /// ```
-    ///
-    /// Validate an output was received from the workflow. The `action()` on the rendering will cause an action that will return an output.
-    /// ```
-    /// workflow
-    ///     .renderTester()
-    ///     .render { rendering in
-    ///         rendering.action()
-    ///     }
-    ///     .assert(
-    ///        output: .success
-    ///     )
-    /// ```
-    ///
-    /// Validate a worker is running, and simulate the effect of its output:
-    /// ```
-    /// workflow
-    ///     .renderTester(initialState: TestWorkflow.State(loadingState: .loading))
-    ///     .expect(
-    ///         worker: TestWorker(),
-    ///         output: TestWorker.Output.success
-    ///     )
-    ///     .render { _ in }
-    /// ```
-    ///
-    /// Validate a child workflow is run, and simulate the effect of its output:
-    /// ```
-    /// workflow
-    ///     .renderTester(initialState: TestWorkflow.State(loadingState: .loading))
-    ///     .expectWorkflow(
-    ///         type: ChildWorkflow.self,
-    ///         rendering: "rendering",
-    ///         producingOutput: ChildWorkflow.Output.success
-    ///     )
-    ///     .render { _ in }
-    /// ```
-    public struct RenderTester<WorkflowType: Workflow> {
-        let workflow: WorkflowType
-        let state: WorkflowType.State
+    /// Returns a `RenderTester` with an initial state provided by `self.makeInitialState()`
+    public func renderTester() -> RenderTester<Self> {
+        return renderTester(initialState: makeInitialState())
+    }
+}
 
-        private let expectedWorkflows: [AnyExpectedWorkflow]
-        private let expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>]
+/// Testing helper for validating the behavior of calls to `render`.
+///
+/// Usage: `expect` workflows and side effects then validate with a call to `render` and
+/// the resulting `RenderTesterResult`.
+/// Side-effects may be performed against the rendering to validate the behavior of actions.
+///
+/// To directly test actions and their effects, use the `WorkflowActionTester`.
+///
+/// ```
+/// workflow
+///     .renderTester(initialState: TestWorkflow.State())
+///     .expect(
+///         worker: TestWorker(),
+///         producingOutput: TestWorker.Output.success
+///     )
+///     .expectWorkflow(
+///         type: ChildWorkflow.self,
+///         key: "key",
+///         rendering: "rendering",
+///         // ⚠️ N.B. Only one output per call to `render` may be produced,
+///         // even if multiple child Workflows are expected in a call
+///         // to `render`. This is an invariant enforced by `RenderTester`
+///         // and the real runtime.
+///         producingOutput: nil
+///     )
+///     .render { rendering in
+///         XCTAssertEqual("expected text on rendering", rendering.text)
+///     }
+///     .assert(state: TestWorkflow.State())
+///     .assert(output: TestWorkflow.Output.finished)
+/// ```
+///
+/// Validating the rendering only from the initial state provided by the workflow:
+/// ```
+/// workflow
+///     .renderTester()
+///     .render { rendering in
+///         XCTAssertEqual("expected text on rendering", rendering.text)
+///     }
+/// ```
+///
+/// Validate the state was updated from a callback on the rendering:
+/// ```
+/// workflow
+///     .renderTester()
+///     .render { rendering in
+///         XCTAssertEqual("expected text on rendering", rendering.text)
+///         rendering.updateText("updated")
+///     }
+///     .assert(
+///         state: TestWorkflow.State(text: "updated")
+///     )
+/// ```
+///
+/// Validate an output was received from the workflow. The `action()` on the rendering will cause an action that will return an output.
+/// ```
+/// workflow
+///     .renderTester()
+///     .render { rendering in
+///         rendering.action()
+///     }
+///     .assert(
+///        output: .success
+///     )
+/// ```
+///
+/// Validate a worker is running, and simulate the effect of its output:
+/// ```
+/// workflow
+///     .renderTester(initialState: TestWorkflow.State(loadingState: .loading))
+///     .expect(
+///         worker: TestWorker(),
+///         output: TestWorker.Output.success
+///     )
+///     .render { _ in }
+/// ```
+///
+/// Validate a child workflow is run, and simulate the effect of its output:
+/// ```
+/// workflow
+///     .renderTester(initialState: TestWorkflow.State(loadingState: .loading))
+///     .expectWorkflow(
+///         type: ChildWorkflow.self,
+///         rendering: "rendering",
+///         producingOutput: ChildWorkflow.Output.success
+///     )
+///     .render { _ in }
+/// ```
+public struct RenderTester<WorkflowType: Workflow> {
+    let workflow: WorkflowType
+    let state: WorkflowType.State
 
-        init(
-            workflow: WorkflowType,
-            state: WorkflowType.State,
-            expectedWorkflows: [AnyExpectedWorkflow] = [],
-            expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>] = [:]
-        ) {
-            self.workflow = workflow
-            self.state = state
-            self.expectedWorkflows = expectedWorkflows
-            self.expectedSideEffects = expectedSideEffects
-        }
+    private let expectedWorkflows: [AnyExpectedWorkflow]
+    private let expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>]
 
-        /// Expect the given workflow type in the next rendering.
-        ///
-        /// - Parameters:
-        ///   - type: The type of the expected workflow.
-        ///   - key: The key of the expected workflow (if specified).
-        ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
-        ///   - output: An output that should be returned after the workflow of this type is rendered, if any.
-        ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
-        public func expectWorkflow<ExpectedWorkflowType: Workflow>(
-            type: ExpectedWorkflowType.Type,
-            key: String = "",
-            producingRendering rendering: ExpectedWorkflowType.Rendering,
-            producingOutput output: ExpectedWorkflowType.Output? = nil,
-            file: StaticString = #file, line: UInt = #line,
-            assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
-        ) -> RenderTester<WorkflowType> {
-            return RenderTester(
-                workflow: workflow,
-                state: state,
-                expectedWorkflows: expectedWorkflows.appending(
-                    ExpectedWorkflow<ExpectedWorkflowType>(
-                        key: key,
-                        rendering: rendering,
-                        output: output,
-                        assertions: assertions,
-                        file: file,
-                        line: line
-                    )
-                ),
-                expectedSideEffects: expectedSideEffects
-            )
-        }
+    init(
+        workflow: WorkflowType,
+        state: WorkflowType.State,
+        expectedWorkflows: [AnyExpectedWorkflow] = [],
+        expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>] = [:]
+    ) {
+        self.workflow = workflow
+        self.state = state
+        self.expectedWorkflows = expectedWorkflows
+        self.expectedSideEffects = expectedSideEffects
+    }
 
-        /// Expect the given workflow type in the next rendering, with its output being ignored by a call to `ignoringOutput()`.
-        ///
-        /// - Parameters:
-        ///   - type: The type of the expected workflow.
-        ///   - key: The key of the expected workflow (if specified).
-        ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
-        ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
-        public func expectWorkflowIgnoringOutput<ExpectedWorkflowType: Workflow>(
-            type: ExpectedWorkflowType.Type,
-            key: String = "",
-            producingRendering rendering: ExpectedWorkflowType.Rendering,
-            file: StaticString = #file,
-            line: UInt = #line,
-            assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
-        ) -> RenderTester<WorkflowType> {
-            return expectWorkflow(
-                type: OutputBlockingWorkflow<ExpectedWorkflowType>.self,
+    /// Expect the given workflow type in the next rendering.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the expected workflow.
+    ///   - key: The key of the expected workflow (if specified).
+    ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
+    ///   - output: An output that should be returned after the workflow of this type is rendered, if any.
+    ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
+    public func expectWorkflow<ExpectedWorkflowType: Workflow>(
+        type: ExpectedWorkflowType.Type,
+        key: String = "",
+        producingRendering rendering: ExpectedWorkflowType.Rendering,
+        producingOutput output: ExpectedWorkflowType.Output? = nil,
+        file: StaticString = #file, line: UInt = #line,
+        assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
+    ) -> RenderTester<WorkflowType> {
+        return RenderTester(
+            workflow: workflow,
+            state: state,
+            expectedWorkflows: expectedWorkflows.appending(
+                ExpectedWorkflow<ExpectedWorkflowType>(
+                    key: key,
+                    rendering: rendering,
+                    output: output,
+                    assertions: assertions,
+                    file: file,
+                    line: line
+                )
+            ),
+            expectedSideEffects: expectedSideEffects
+        )
+    }
+
+    /// Expect the given workflow type in the next rendering, with its output being ignored by a call to `ignoringOutput()`.
+    ///
+    /// - Parameters:
+    ///   - type: The type of the expected workflow.
+    ///   - key: The key of the expected workflow (if specified).
+    ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
+    ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
+    public func expectWorkflowIgnoringOutput<ExpectedWorkflowType: Workflow>(
+        type: ExpectedWorkflowType.Type,
+        key: String = "",
+        producingRendering rendering: ExpectedWorkflowType.Rendering,
+        file: StaticString = #file,
+        line: UInt = #line,
+        assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
+    ) -> RenderTester<WorkflowType> {
+        return expectWorkflow(
+            type: OutputBlockingWorkflow<ExpectedWorkflowType>.self,
+            key: key,
+            producingRendering: rendering,
+            file: file,
+            line: line,
+            assertions: { assertions($0.child) }
+        )
+    }
+
+    /// Expect a side-effect for the given key.
+    ///
+    /// - Parameter key: The key to expect.
+    public func expectSideEffect(
+        key: AnyHashable,
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> {
+        return RenderTester(
+            workflow: workflow,
+            state: state,
+            expectedWorkflows: expectedWorkflows,
+            expectedSideEffects: expectedSideEffects.setting(
                 key: key,
-                producingRendering: rendering,
-                file: file,
-                line: line,
-                assertions: { assertions($0.child) }
-            )
-        }
-
-        /// Expect a side-effect for the given key.
-        ///
-        /// - Parameter key: The key to expect.
-        public func expectSideEffect(
-            key: AnyHashable,
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> {
-            return RenderTester(
-                workflow: workflow,
-                state: state,
-                expectedWorkflows: expectedWorkflows,
-                expectedSideEffects: expectedSideEffects.setting(
+                value: ExpectedSideEffect(
                     key: key,
-                    value: ExpectedSideEffect(
-                        key: key,
-                        file: file,
-                        line: line
-                    )
+                    file: file,
+                    line: line
                 )
             )
-        }
+        )
+    }
 
-        /// Expect a side-effect for the given key, and produce the given action when it is requested.
-        ///
-        /// - Parameters:
-        ///   - key: The key to expect.
-        ///   - action: The action to produce when this side-effect is requested.
-        public func expectSideEffect<ActionType>(
-            key: AnyHashable,
-            producingAction action: ActionType,
-            file: StaticString = #file, line: UInt = #line
-        ) -> RenderTester<WorkflowType> where ActionType: WorkflowAction, ActionType.WorkflowType == WorkflowType {
-            return RenderTester(
-                workflow: workflow,
-                state: state,
-                expectedWorkflows: expectedWorkflows,
-                expectedSideEffects: expectedSideEffects.setting(
+    /// Expect a side-effect for the given key, and produce the given action when it is requested.
+    ///
+    /// - Parameters:
+    ///   - key: The key to expect.
+    ///   - action: The action to produce when this side-effect is requested.
+    public func expectSideEffect<ActionType>(
+        key: AnyHashable,
+        producingAction action: ActionType,
+        file: StaticString = #file, line: UInt = #line
+    ) -> RenderTester<WorkflowType> where ActionType: WorkflowAction, ActionType.WorkflowType == WorkflowType {
+        return RenderTester(
+            workflow: workflow,
+            state: state,
+            expectedWorkflows: expectedWorkflows,
+            expectedSideEffects: expectedSideEffects.setting(
+                key: key,
+                value: ExpectedSideEffectWithAction(
                     key: key,
-                    value: ExpectedSideEffectWithAction(
-                        key: key,
-                        action: action,
-                        file: file,
-                        line: line
-                    )
+                    action: action,
+                    file: file,
+                    line: line
                 )
             )
-        }
-
-        /// Render the workflow under test. At this point, you should have set up all expectations.
-        ///
-        /// The given `assertions` closure will be called with the produced rendering, allowing you to assert its properties or
-        /// perform actions on it (such as closures that are wired up to a `Sink` inside the workflow.
-        ///
-        /// - Parameters:
-        ///   - assertions: A closure called with the produced rendering for verification
-        /// - Returns: A `RenderTesterResult` that can be used to verify expected resulting state or outputs.
-        @discardableResult
-        public func render(
-            file: StaticString = #file, line: UInt = #line,
-            assertions: (WorkflowType.Rendering) throws -> Void
-        ) rethrows -> RenderTesterResult<WorkflowType> {
-            let contextImplementation = TestContext(
-                state: state,
-                expectedWorkflows: expectedWorkflows,
-                expectedSideEffects: expectedSideEffects,
-                file: file,
-                line: line
-            )
-            let context = RenderContext.make(implementation: contextImplementation)
-            let rendering = workflow.render(state: contextImplementation.state, context: context)
-
-            contextImplementation.assertNoLeftOverExpectations()
-
-            try assertions(rendering)
-
-            return RenderTesterResult<WorkflowType>(
-                state: contextImplementation.state,
-                appliedAction: contextImplementation.appliedAction,
-                output: contextImplementation.producedOutput
-            )
-        }
+        )
     }
 
-    extension Collection {
-        fileprivate func appending(_ element: Element) -> [Element] {
-            return self + [element]
-        }
-    }
+    /// Render the workflow under test. At this point, you should have set up all expectations.
+    ///
+    /// The given `assertions` closure will be called with the produced rendering, allowing you to assert its properties or
+    /// perform actions on it (such as closures that are wired up to a `Sink` inside the workflow.
+    ///
+    /// - Parameters:
+    ///   - assertions: A closure called with the produced rendering for verification
+    /// - Returns: A `RenderTesterResult` that can be used to verify expected resulting state or outputs.
+    @discardableResult
+    public func render(
+        file: StaticString = #file, line: UInt = #line,
+        assertions: (WorkflowType.Rendering) throws -> Void
+    ) rethrows -> RenderTesterResult<WorkflowType> {
+        let contextImplementation = TestContext(
+            state: state,
+            expectedWorkflows: expectedWorkflows,
+            expectedSideEffects: expectedSideEffects,
+            file: file,
+            line: line
+        )
+        let context = RenderContext.make(implementation: contextImplementation)
+        let rendering = workflow.render(state: contextImplementation.state, context: context)
 
-    extension Dictionary {
-        fileprivate func setting(key: Key, value: Value) -> [Key: Value] {
-            var newDictionary = self
-            newDictionary[key] = value
-            return newDictionary
-        }
+        contextImplementation.assertNoLeftOverExpectations()
+
+        try assertions(rendering)
+
+        return RenderTesterResult<WorkflowType>(
+            state: contextImplementation.state,
+            appliedAction: contextImplementation.appliedAction,
+            output: contextImplementation.producedOutput
+        )
     }
+}
+
+extension Collection {
+    fileprivate func appending(_ element: Element) -> [Element] {
+        return self + [element]
+    }
+}
+
+extension Dictionary {
+    fileprivate func setting(key: Key, value: Value) -> [Key: Value] {
+        var newDictionary = self
+        newDictionary[key] = value
+        return newDictionary
+    }
+}
 
 #endif

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -67,25 +67,25 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
 
     #if swift(>=5.3)
 
-        // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
-        override func record(_ issue: XCTIssue) {
-            if removeFailure(withDescription: issue.compactDescription) {
-                // Don’t forward the issue, it was expected
-            } else {
-                super.record(issue)
-            }
+    // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
+    override func record(_ issue: XCTIssue) {
+        if removeFailure(withDescription: issue.compactDescription) {
+            // Don’t forward the issue, it was expected
+        } else {
+            super.record(issue)
         }
+    }
 
     #else
 
-        // Otherwise, use old API
-        override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-            if removeFailure(withDescription: description) {
-                // Don’t forward the failure, it was expected
-            } else {
-                super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-            }
+    // Otherwise, use old API
+    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
+        if removeFailure(withDescription: description) {
+            // Don’t forward the failure, it was expected
+        } else {
+            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
         }
+    }
 
     #endif
 

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -16,156 +16,156 @@
 
 #if canImport(UIKit)
 
-    import ReactiveSwift
-    import UIKit
-    import Workflow
+import ReactiveSwift
+import UIKit
+import Workflow
 
-    /// Drives view controllers from a root Workflow.
-    public final class WorkflowHostingController<ScreenType, Output>: UIViewController where ScreenType: Screen {
-        /// Emits output events from the bound workflow.
-        public var output: Signal<Output, Never> {
-            return workflowHost.output
+/// Drives view controllers from a root Workflow.
+public final class WorkflowHostingController<ScreenType, Output>: UIViewController where ScreenType: Screen {
+    /// Emits output events from the bound workflow.
+    public var output: Signal<Output, Never> {
+        return workflowHost.output
+    }
+
+    private(set) var rootViewController: UIViewController
+
+    private let workflowHost: WorkflowHost<RootWorkflow<ScreenType, Output>>
+
+    private let (lifetime, token) = Lifetime.make()
+
+    public var rootViewEnvironment: ViewEnvironment {
+        didSet {
+            update(screen: workflowHost.rendering.value, environment: rootViewEnvironment)
         }
+    }
 
-        private(set) var rootViewController: UIViewController
+    public init<W: AnyWorkflowConvertible>(workflow: W, rootViewEnvironment: ViewEnvironment = .empty) where W.Rendering == ScreenType, W.Output == Output {
+        self.workflowHost = WorkflowHost(workflow: RootWorkflow(workflow))
 
-        private let workflowHost: WorkflowHost<RootWorkflow<ScreenType, Output>>
+        self.rootViewController = workflowHost
+            .rendering
+            .value
+            .buildViewController(in: rootViewEnvironment)
 
-        private let (lifetime, token) = Lifetime.make()
+        self.rootViewEnvironment = rootViewEnvironment
 
-        public var rootViewEnvironment: ViewEnvironment {
-            didSet {
-                update(screen: workflowHost.rendering.value, environment: rootViewEnvironment)
+        super.init(nibName: nil, bundle: nil)
+
+        addChild(rootViewController)
+        rootViewController.didMove(toParent: self)
+
+        workflowHost
+            .rendering
+            .signal
+            .take(during: lifetime)
+            .observeValues { [weak self] screen in
+                guard let self = self else { return }
+
+                self.update(screen: screen, environment: self.rootViewEnvironment)
             }
-        }
-
-        public init<W: AnyWorkflowConvertible>(workflow: W, rootViewEnvironment: ViewEnvironment = .empty) where W.Rendering == ScreenType, W.Output == Output {
-            self.workflowHost = WorkflowHost(workflow: RootWorkflow(workflow))
-
-            self.rootViewController = workflowHost
-                .rendering
-                .value
-                .buildViewController(in: rootViewEnvironment)
-
-            self.rootViewEnvironment = rootViewEnvironment
-
-            super.init(nibName: nil, bundle: nil)
-
-            addChild(rootViewController)
-            rootViewController.didMove(toParent: self)
-
-            workflowHost
-                .rendering
-                .signal
-                .take(during: lifetime)
-                .observeValues { [weak self] screen in
-                    guard let self = self else { return }
-
-                    self.update(screen: screen, environment: self.rootViewEnvironment)
-                }
-        }
-
-        /// Updates the root Workflow in this container.
-        public func update<W: AnyWorkflowConvertible>(workflow: W) where W.Rendering == ScreenType, W.Output == Output {
-            workflowHost.update(workflow: RootWorkflow(workflow))
-        }
-
-        public required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        private func update(screen: ScreenType, environment: ViewEnvironment) {
-            update(child: \.rootViewController, with: screen, in: environment)
-
-            updatePreferredContentSizeIfNeeded()
-        }
-
-        override public func viewDidLoad() {
-            super.viewDidLoad()
-
-            view.backgroundColor = .white
-
-            rootViewController.view.frame = view.bounds
-            view.addSubview(rootViewController.view)
-
-            updatePreferredContentSizeIfNeeded()
-        }
-
-        override public func viewDidLayoutSubviews() {
-            super.viewDidLayoutSubviews()
-            rootViewController.view.frame = view.bounds
-        }
-
-        override public var childForStatusBarStyle: UIViewController? {
-            return rootViewController
-        }
-
-        override public var childForStatusBarHidden: UIViewController? {
-            return rootViewController
-        }
-
-        override public var childForHomeIndicatorAutoHidden: UIViewController? {
-            return rootViewController
-        }
-
-        override public var childForScreenEdgesDeferringSystemGestures: UIViewController? {
-            return rootViewController
-        }
-
-        override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-            return rootViewController.supportedInterfaceOrientations
-        }
-
-        override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
-            return rootViewController.preferredStatusBarUpdateAnimation
-        }
-
-        @available(iOS 14.0, *)
-        override public var childViewControllerForPointerLock: UIViewController? {
-            return rootViewController
-        }
-
-        override public func preferredContentSizeDidChange(
-            forChildContentContainer container: UIContentContainer
-        ) {
-            super.preferredContentSizeDidChange(forChildContentContainer: container)
-
-            guard container === rootViewController else { return }
-
-            updatePreferredContentSizeIfNeeded()
-        }
-
-        private func updatePreferredContentSizeIfNeeded() {
-            let newPreferredContentSize = rootViewController.preferredContentSize
-
-            guard newPreferredContentSize != preferredContentSize else { return }
-
-            preferredContentSize = newPreferredContentSize
-        }
     }
 
-    /// Wrapper around an AnyWorkflow that allows us to have a concrete
-    /// WorkflowHost without WorkflowHostingController itself being generic
-    /// around a Workflow.
-    fileprivate struct RootWorkflow<Rendering, Output>: Workflow {
-        typealias State = Void
-        typealias Output = Output
-        typealias Rendering = Rendering
-
-        var wrapped: AnyWorkflow<Rendering, Output>
-
-        init<W: AnyWorkflowConvertible>(_ wrapped: W) where W.Rendering == Rendering, W.Output == Output {
-            self.wrapped = wrapped.asAnyWorkflow()
-        }
-
-        func render(state: State, context: RenderContext<RootWorkflow>) -> Rendering {
-            return wrapped
-                .mapOutput { AnyWorkflowAction(sendingOutput: $0) }
-                .rendered(in: context)
-        }
+    /// Updates the root Workflow in this container.
+    public func update<W: AnyWorkflowConvertible>(workflow: W) where W.Rendering == ScreenType, W.Output == Output {
+        workflowHost.update(workflow: RootWorkflow(workflow))
     }
 
-    @available(*, deprecated, renamed: "WorkflowHostingController")
-    public typealias ContainerViewController = WorkflowHostingController
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func update(screen: ScreenType, environment: ViewEnvironment) {
+        update(child: \.rootViewController, with: screen, in: environment)
+
+        updatePreferredContentSizeIfNeeded()
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        rootViewController.view.frame = view.bounds
+        view.addSubview(rootViewController.view)
+
+        updatePreferredContentSizeIfNeeded()
+    }
+
+    override public func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        rootViewController.view.frame = view.bounds
+    }
+
+    override public var childForStatusBarStyle: UIViewController? {
+        return rootViewController
+    }
+
+    override public var childForStatusBarHidden: UIViewController? {
+        return rootViewController
+    }
+
+    override public var childForHomeIndicatorAutoHidden: UIViewController? {
+        return rootViewController
+    }
+
+    override public var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+        return rootViewController
+    }
+
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return rootViewController.supportedInterfaceOrientations
+    }
+
+    override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        return rootViewController.preferredStatusBarUpdateAnimation
+    }
+
+    @available(iOS 14.0, *)
+    override public var childViewControllerForPointerLock: UIViewController? {
+        return rootViewController
+    }
+
+    override public func preferredContentSizeDidChange(
+        forChildContentContainer container: UIContentContainer
+    ) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+        guard container === rootViewController else { return }
+
+        updatePreferredContentSizeIfNeeded()
+    }
+
+    private func updatePreferredContentSizeIfNeeded() {
+        let newPreferredContentSize = rootViewController.preferredContentSize
+
+        guard newPreferredContentSize != preferredContentSize else { return }
+
+        preferredContentSize = newPreferredContentSize
+    }
+}
+
+/// Wrapper around an AnyWorkflow that allows us to have a concrete
+/// WorkflowHost without WorkflowHostingController itself being generic
+/// around a Workflow.
+fileprivate struct RootWorkflow<Rendering, Output>: Workflow {
+    typealias State = Void
+    typealias Output = Output
+    typealias Rendering = Rendering
+
+    var wrapped: AnyWorkflow<Rendering, Output>
+
+    init<W: AnyWorkflowConvertible>(_ wrapped: W) where W.Rendering == Rendering, W.Output == Output {
+        self.wrapped = wrapped.asAnyWorkflow()
+    }
+
+    func render(state: State, context: RenderContext<RootWorkflow>) -> Rendering {
+        return wrapped
+            .mapOutput { AnyWorkflowAction(sendingOutput: $0) }
+            .rendered(in: context)
+    }
+}
+
+@available(*, deprecated, renamed: "WorkflowHostingController")
+public typealias ContainerViewController = WorkflowHostingController
 
 #endif

--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -16,35 +16,35 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    public struct AnyScreen: Screen {
-        /// The original screen, retained for debugging
-        internal let wrappedScreen: Screen
+public struct AnyScreen: Screen {
+    /// The original screen, retained for debugging
+    internal let wrappedScreen: Screen
 
-        /// Stored getter for the wrapped screen’s view controller description
-        private let _viewControllerDescription: (ViewEnvironment) -> ViewControllerDescription
+    /// Stored getter for the wrapped screen’s view controller description
+    private let _viewControllerDescription: (ViewEnvironment) -> ViewControllerDescription
 
-        public init<T: Screen>(_ screen: T) {
-            if let anyScreen = screen as? AnyScreen {
-                self = anyScreen
-                return
-            }
-            self.wrappedScreen = screen
-            self._viewControllerDescription = screen.viewControllerDescription(environment:)
+    public init<T: Screen>(_ screen: T) {
+        if let anyScreen = screen as? AnyScreen {
+            self = anyScreen
+            return
         }
-
-        public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-            // Passed straight through
-            return _viewControllerDescription(environment)
-        }
+        self.wrappedScreen = screen
+        self._viewControllerDescription = screen.viewControllerDescription(environment:)
     }
 
-    extension Screen {
-        /// Wraps the screen in an AnyScreen
-        public func asAnyScreen() -> AnyScreen {
-            AnyScreen(self)
-        }
+    public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        // Passed straight through
+        return _viewControllerDescription(environment)
     }
+}
+
+extension Screen {
+    /// Wraps the screen in an AnyScreen
+    public func asAnyScreen() -> AnyScreen {
+        AnyScreen(self)
+    }
+}
 
 #endif

--- a/WorkflowUI/Sources/Screen/Screen.swift
+++ b/WorkflowUI/Sources/Screen/Screen.swift
@@ -16,40 +16,40 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    /// Screens are the building blocks of an interactive application.
+/// Screens are the building blocks of an interactive application.
+///
+/// Conforming types contain any information needed to populate a screen: data,
+/// styling, event handlers, etc.
+public protocol Screen {
+    /// A view controller description that acts as a recipe to either build
+    /// or update a previously-built view controller to match this screen.
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription
+}
+
+extension Screen {
+    /// If the given view controller is of the correct type to be updated by this screen.
     ///
-    /// Conforming types contain any information needed to populate a screen: data,
-    /// styling, event handlers, etc.
-    public protocol Screen {
-        /// A view controller description that acts as a recipe to either build
-        /// or update a previously-built view controller to match this screen.
-        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription
+    /// If your view controller type can change between updates, call this method before invoking `update(viewController:with:)`.
+    public func canUpdate(viewController: UIViewController, with environment: ViewEnvironment) -> Bool {
+        viewControllerDescription(environment: environment).canUpdate(viewController: viewController)
     }
 
-    extension Screen {
-        /// If the given view controller is of the correct type to be updated by this screen.
-        ///
-        /// If your view controller type can change between updates, call this method before invoking `update(viewController:with:)`.
-        public func canUpdate(viewController: UIViewController, with environment: ViewEnvironment) -> Bool {
-            viewControllerDescription(environment: environment).canUpdate(viewController: viewController)
-        }
-
-        /// Update the given view controller with the content from the screen.
-        ///
-        /// ### Note
-        /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
-        /// that passes `canUpdate(viewController:with:)`. Failure to do so will result in a fatal precondition.
-        public func update(viewController: UIViewController, with environment: ViewEnvironment) {
-            viewControllerDescription(environment: environment).update(viewController: viewController)
-        }
-
-        /// Construct and update a new view controller as described by this Screen.
-        /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
-        public func buildViewController(in environment: ViewEnvironment) -> UIViewController {
-            viewControllerDescription(environment: environment).buildViewController()
-        }
+    /// Update the given view controller with the content from the screen.
+    ///
+    /// ### Note
+    /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
+    /// that passes `canUpdate(viewController:with:)`. Failure to do so will result in a fatal precondition.
+    public func update(viewController: UIViewController, with environment: ViewEnvironment) {
+        viewControllerDescription(environment: environment).update(viewController: viewController)
     }
+
+    /// Construct and update a new view controller as described by this Screen.
+    /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
+    public func buildViewController(in environment: ViewEnvironment) -> UIViewController {
+        viewControllerDescription(environment: environment).buildViewController()
+    }
+}
 
 #endif

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -16,73 +16,73 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    /// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
-    /// given screen type.
-    ///
-    /// Using this base class, a screen can be implemented as:
-    /// ```
-    /// struct MyScreen: Screen {
-    ///     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-    ///         return MyScreenViewController.description(for: self)
-    ///     }
-    /// }
-    ///
-    /// private class MyScreenViewController: ScreenViewController<MyScreen> {
-    ///     override func screenDidChange(from previousScreen: MyScreen, previousEnvironment: ViewEnvironment) {
-    ///         // … update views as necessary
-    ///     }
-    /// }
-    /// ```
-    open class ScreenViewController<ScreenType: Screen>: UIViewController {
-        public private(set) final var screen: ScreenType
+/// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
+/// given screen type.
+///
+/// Using this base class, a screen can be implemented as:
+/// ```
+/// struct MyScreen: Screen {
+///     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+///         return MyScreenViewController.description(for: self)
+///     }
+/// }
+///
+/// private class MyScreenViewController: ScreenViewController<MyScreen> {
+///     override func screenDidChange(from previousScreen: MyScreen, previousEnvironment: ViewEnvironment) {
+///         // … update views as necessary
+///     }
+/// }
+/// ```
+open class ScreenViewController<ScreenType: Screen>: UIViewController {
+    public private(set) final var screen: ScreenType
 
-        public final var screenType: Screen.Type {
-            return ScreenType.self
-        }
-
-        public private(set) final var environment: ViewEnvironment
-
-        public required init(screen: ScreenType, environment: ViewEnvironment) {
-            self.screen = screen
-            self.environment = environment
-            super.init(nibName: nil, bundle: nil)
-        }
-
-        @available(*, unavailable)
-        public required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        public final func update(screen: ScreenType, environment: ViewEnvironment) {
-            let previousScreen = self.screen
-            self.screen = screen
-            let previousEnvironment = self.environment
-            self.environment = environment
-            screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
-        }
-
-        /// Subclasses should override this method in order to update any relevant UI bits when the screen model changes.
-        open func screenDidChange(from previousScreen: ScreenType, previousEnvironment: ViewEnvironment) {}
+    public final var screenType: Screen.Type {
+        return ScreenType.self
     }
 
-    extension ScreenViewController {
-        /// Convenience to create a view controller description for the given screen
-        /// value. See the example on the comment for ScreenViewController for
-        /// usage.
-        public final class func description(
-            for screen: ScreenType,
-            environment: ViewEnvironment,
-            performInitialUpdate: Bool = true
-        ) -> ViewControllerDescription {
-            ViewControllerDescription(
-                performInitialUpdate: performInitialUpdate,
-                type: self,
-                build: { self.init(screen: screen, environment: environment) },
-                update: { $0.update(screen: screen, environment: environment) }
-            )
-        }
+    public private(set) final var environment: ViewEnvironment
+
+    public required init(screen: ScreenType, environment: ViewEnvironment) {
+        self.screen = screen
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
     }
+
+    @available(*, unavailable)
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public final func update(screen: ScreenType, environment: ViewEnvironment) {
+        let previousScreen = self.screen
+        self.screen = screen
+        let previousEnvironment = self.environment
+        self.environment = environment
+        screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+    }
+
+    /// Subclasses should override this method in order to update any relevant UI bits when the screen model changes.
+    open func screenDidChange(from previousScreen: ScreenType, previousEnvironment: ViewEnvironment) {}
+}
+
+extension ScreenViewController {
+    /// Convenience to create a view controller description for the given screen
+    /// value. See the example on the comment for ScreenViewController for
+    /// usage.
+    public final class func description(
+        for screen: ScreenType,
+        environment: ViewEnvironment,
+        performInitialUpdate: Bool = true
+    ) -> ViewControllerDescription {
+        ViewControllerDescription(
+            performInitialUpdate: performInitialUpdate,
+            type: self,
+            build: { self.init(screen: screen, environment: environment) },
+            update: { $0.update(screen: screen, environment: environment) }
+        )
+    }
+}
 
 #endif

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -16,115 +16,115 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    public final class DescribedViewController: UIViewController {
-        var currentViewController: UIViewController
+public final class DescribedViewController: UIViewController {
+    var currentViewController: UIViewController
 
-        public init(description: ViewControllerDescription) {
-            self.currentViewController = description.buildViewController()
-            super.init(nibName: nil, bundle: nil)
+    public init(description: ViewControllerDescription) {
+        self.currentViewController = description.buildViewController()
+        super.init(nibName: nil, bundle: nil)
+
+        addChild(currentViewController)
+        currentViewController.didMove(toParent: self)
+    }
+
+    public convenience init<S: Screen>(screen: S, environment: ViewEnvironment) {
+        self.init(description: screen.viewControllerDescription(environment: environment))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    public func update(description: ViewControllerDescription) {
+        if description.canUpdate(viewController: currentViewController) {
+            description.update(viewController: currentViewController)
+        } else {
+            currentViewController.willMove(toParent: nil)
+            currentViewController.viewIfLoaded?.removeFromSuperview()
+            currentViewController.removeFromParent()
+
+            currentViewController = description.buildViewController()
 
             addChild(currentViewController)
-            currentViewController.didMove(toParent: self)
-        }
 
-        public convenience init<S: Screen>(screen: S, environment: ViewEnvironment) {
-            self.init(description: screen.viewControllerDescription(environment: environment))
-        }
-
-        @available(*, unavailable)
-        required init?(coder: NSCoder) {
-            fatalError("init(coder:) is unavailable")
-        }
-
-        public func update(description: ViewControllerDescription) {
-            if description.canUpdate(viewController: currentViewController) {
-                description.update(viewController: currentViewController)
-            } else {
-                currentViewController.willMove(toParent: nil)
-                currentViewController.viewIfLoaded?.removeFromSuperview()
-                currentViewController.removeFromParent()
-
-                currentViewController = description.buildViewController()
-
-                addChild(currentViewController)
-
-                if isViewLoaded {
-                    currentViewController.view.frame = view.bounds
-                    view.addSubview(currentViewController.view)
-                    updatePreferredContentSizeIfNeeded()
-                }
-
-                currentViewController.didMove(toParent: self)
-
+            if isViewLoaded {
+                currentViewController.view.frame = view.bounds
+                view.addSubview(currentViewController.view)
                 updatePreferredContentSizeIfNeeded()
             }
-        }
 
-        public func update<S: Screen>(screen: S, environment: ViewEnvironment) {
-            update(description: screen.viewControllerDescription(environment: environment))
-        }
-
-        override public func viewDidLoad() {
-            super.viewDidLoad()
-
-            currentViewController.view.frame = view.bounds
-            view.addSubview(currentViewController.view)
+            currentViewController.didMove(toParent: self)
 
             updatePreferredContentSizeIfNeeded()
-        }
-
-        override public func viewDidLayoutSubviews() {
-            super.viewDidLayoutSubviews()
-            currentViewController.view.frame = view.bounds
-        }
-
-        override public var childForStatusBarStyle: UIViewController? {
-            return currentViewController
-        }
-
-        override public var childForStatusBarHidden: UIViewController? {
-            return currentViewController
-        }
-
-        override public var childForHomeIndicatorAutoHidden: UIViewController? {
-            return currentViewController
-        }
-
-        override public var childForScreenEdgesDeferringSystemGestures: UIViewController? {
-            return currentViewController
-        }
-
-        override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-            return currentViewController.supportedInterfaceOrientations
-        }
-
-        override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
-            return currentViewController.preferredStatusBarUpdateAnimation
-        }
-
-        @available(iOS 14.0, *)
-        override public var childViewControllerForPointerLock: UIViewController? {
-            return currentViewController
-        }
-
-        override public func preferredContentSizeDidChange(
-            forChildContentContainer container: UIContentContainer
-        ) {
-            super.preferredContentSizeDidChange(forChildContentContainer: container)
-
-            guard container === currentViewController else { return }
-
-            updatePreferredContentSizeIfNeeded()
-        }
-
-        private func updatePreferredContentSizeIfNeeded() {
-            let newPreferredContentSize = currentViewController.preferredContentSize
-
-            guard newPreferredContentSize != preferredContentSize else { return }
-
-            preferredContentSize = newPreferredContentSize
         }
     }
+
+    public func update<S: Screen>(screen: S, environment: ViewEnvironment) {
+        update(description: screen.viewControllerDescription(environment: environment))
+    }
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+
+        currentViewController.view.frame = view.bounds
+        view.addSubview(currentViewController.view)
+
+        updatePreferredContentSizeIfNeeded()
+    }
+
+    override public func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        currentViewController.view.frame = view.bounds
+    }
+
+    override public var childForStatusBarStyle: UIViewController? {
+        return currentViewController
+    }
+
+    override public var childForStatusBarHidden: UIViewController? {
+        return currentViewController
+    }
+
+    override public var childForHomeIndicatorAutoHidden: UIViewController? {
+        return currentViewController
+    }
+
+    override public var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+        return currentViewController
+    }
+
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return currentViewController.supportedInterfaceOrientations
+    }
+
+    override public var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
+        return currentViewController.preferredStatusBarUpdateAnimation
+    }
+
+    @available(iOS 14.0, *)
+    override public var childViewControllerForPointerLock: UIViewController? {
+        return currentViewController
+    }
+
+    override public func preferredContentSizeDidChange(
+        forChildContentContainer container: UIContentContainer
+    ) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+        guard container === currentViewController else { return }
+
+        updatePreferredContentSizeIfNeeded()
+    }
+
+    private func updatePreferredContentSizeIfNeeded() {
+        let newPreferredContentSize = currentViewController.preferredContentSize
+
+        guard newPreferredContentSize != preferredContentSize else { return }
+
+        preferredContentSize = newPreferredContentSize
+    }
+}
 #endif

--- a/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
@@ -16,108 +16,108 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    extension UpdateChildScreenViewController where Self: UIViewController {
-        /// Updates the view controller at the given `child` key path with the
-        /// `ViewControllerDescription` from `screen`. If the type of the underlying view
-        /// controller changes between update passes, this method will remove
-        /// the old view controller, create a new one, update it, and insert it into the view controller hierarchy.
-        ///
-        /// The view controller at `child` must be a child of `self`.
-        ///
-        /// - Parameters:
-        /// - parameter child: The `KeyPath` which describes what view controller to update. This view controller must be a direct child of `self`.
-        /// - parameter screen: The `Screen` instance to apply to the view controller.
-        /// - parameter environment: The `environment` to used when updating the view controller.
-        /// - parameter onChange: A callback called if the view controller instance changed.
-        ///
-        public func update<VC: UIViewController, ScreenType: Screen>(
-            child: ReferenceWritableKeyPath<Self, VC>,
-            with screen: ScreenType,
-            in environment: ViewEnvironment,
-            onChange: (VC) -> Void = { _ in }
-        ) {
-            let description = screen.viewControllerDescription(environment: environment)
+extension UpdateChildScreenViewController where Self: UIViewController {
+    /// Updates the view controller at the given `child` key path with the
+    /// `ViewControllerDescription` from `screen`. If the type of the underlying view
+    /// controller changes between update passes, this method will remove
+    /// the old view controller, create a new one, update it, and insert it into the view controller hierarchy.
+    ///
+    /// The view controller at `child` must be a child of `self`.
+    ///
+    /// - Parameters:
+    /// - parameter child: The `KeyPath` which describes what view controller to update. This view controller must be a direct child of `self`.
+    /// - parameter screen: The `Screen` instance to apply to the view controller.
+    /// - parameter environment: The `environment` to used when updating the view controller.
+    /// - parameter onChange: A callback called if the view controller instance changed.
+    ///
+    public func update<VC: UIViewController, ScreenType: Screen>(
+        child: ReferenceWritableKeyPath<Self, VC>,
+        with screen: ScreenType,
+        in environment: ViewEnvironment,
+        onChange: (VC) -> Void = { _ in }
+    ) {
+        let description = screen.viewControllerDescription(environment: environment)
 
-            let existing = self[keyPath: child]
+        let existing = self[keyPath: child]
 
-            if description.canUpdate(viewController: existing) {
-                // Easy path: Just update the existing view controller if we can do that.
-                description.update(viewController: existing)
-            } else {
-                // If we can't update the view controller, that means its type changed.
-                // We'll need to make a new view controller and swap over to it.
+        if description.canUpdate(viewController: existing) {
+            // Easy path: Just update the existing view controller if we can do that.
+            description.update(viewController: existing)
+        } else {
+            // If we can't update the view controller, that means its type changed.
+            // We'll need to make a new view controller and swap over to it.
 
-                let old = existing
+            let old = existing
 
-                // Make the new view controller.
+            // Make the new view controller.
 
-                let new = description.buildViewController() as! VC
+            let new = description.buildViewController() as! VC
 
-                // We already have a reference to the old vc above, update the keypath to the new one.
+            // We already have a reference to the old vc above, update the keypath to the new one.
 
-                self[keyPath: child] = new
+            self[keyPath: child] = new
 
-                // We should only add the view controller if the old one was already within the parent.
+            // We should only add the view controller if the old one was already within the parent.
 
-                if let parent = old.parent {
-                    precondition(
-                        parent == self,
-                        """
-                        The parent of the child view controller must be \(self). Instead, it was \(parent). \
-                        Please call `update(child:)` on the correct parent view controller.
-                        """
-                    )
+            if let parent = old.parent {
+                precondition(
+                    parent == self,
+                    """
+                    The parent of the child view controller must be \(self). Instead, it was \(parent). \
+                    Please call `update(child:)` on the correct parent view controller.
+                    """
+                )
 
-                    // Begin the transition: Signal the new vc will begin moving in, and the old one, out.
+                // Begin the transition: Signal the new vc will begin moving in, and the old one, out.
 
-                    parent.addChild(new)
-                    old.willMove(toParent: nil)
+                parent.addChild(new)
+                old.willMove(toParent: nil)
 
-                    if
-                        parent.isViewLoaded,
-                        old.isViewLoaded,
-                        let container = old.view.superview {
-                        // We will only add the view to the hierarchy if
-                        // the parent's view is loaded, and the existing view
-                        // is loaded, and the old view was in a superview.
+                if
+                    parent.isViewLoaded,
+                    old.isViewLoaded,
+                    let container = old.view.superview {
+                    // We will only add the view to the hierarchy if
+                    // the parent's view is loaded, and the existing view
+                    // is loaded, and the old view was in a superview.
 
-                        // We will only perform appearance transitions if we're visible.
+                    // We will only perform appearance transitions if we're visible.
 
-                        let isVisible = parent.view.window != nil
+                    let isVisible = parent.view.window != nil
 
-                        // The view should end up with the same frame.
+                    // The view should end up with the same frame.
 
-                        new.view.frame = old.view.frame
+                    new.view.frame = old.view.frame
 
-                        if isVisible {
-                            new.beginAppearanceTransition(true, animated: false)
-                            old.beginAppearanceTransition(false, animated: false)
-                        }
-
-                        container.insertSubview(new.view, aboveSubview: old.view)
-                        old.view.removeFromSuperview()
-
-                        if isVisible {
-                            new.endAppearanceTransition()
-                            old.endAppearanceTransition()
-                        }
+                    if isVisible {
+                        new.beginAppearanceTransition(true, animated: false)
+                        old.beginAppearanceTransition(false, animated: false)
                     }
 
-                    // Finish the transition by signaling the vc they've fully moved in / out.
+                    container.insertSubview(new.view, aboveSubview: old.view)
+                    old.view.removeFromSuperview()
 
-                    new.didMove(toParent: parent)
-                    old.removeFromParent()
+                    if isVisible {
+                        new.endAppearanceTransition()
+                        old.endAppearanceTransition()
+                    }
                 }
 
-                onChange(new)
+                // Finish the transition by signaling the vc they've fully moved in / out.
+
+                new.didMove(toParent: parent)
+                old.removeFromParent()
             }
+
+            onChange(new)
         }
     }
+}
 
-    public protocol UpdateChildScreenViewController {}
+public protocol UpdateChildScreenViewController {}
 
-    extension UIViewController: UpdateChildScreenViewController {}
+extension UIViewController: UpdateChildScreenViewController {}
 
 #endif

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -16,156 +16,156 @@
 
 #if canImport(UIKit)
 
-    import UIKit
+import UIKit
 
-    /// A ViewControllerDescription acts as a "recipe" for building and updating a specific `UIViewController`.
-    /// It describes how to _create_ and later _update_ a given view controller instance, without creating one
-    /// itself. This means it is a lightweight currency you can create and pass around to describe a view controller,
-    /// without needing to create one.
+/// A ViewControllerDescription acts as a "recipe" for building and updating a specific `UIViewController`.
+/// It describes how to _create_ and later _update_ a given view controller instance, without creating one
+/// itself. This means it is a lightweight currency you can create and pass around to describe a view controller,
+/// without needing to create one.
+///
+/// The most common use case for a `ViewControllerDescription` is to return it from your `Screen`'s
+/// `viewControllerDescription(environment:)` method. The `WorkflowUI` machinery (or your
+/// custom container view controller) will then use this view controller description to create or update the
+/// on-screen presented view controller.
+///
+/// As a creator of a custom container view controller, you will usually pass this view controller description to
+/// a `DescribedViewController`, which will internally create and manage the described view
+/// controller for its current view controller description. However, you can also directly invoke the public
+/// methods such as `buildViewController()`, `update(viewController:)`, if you are
+/// manually managing your own view controller hierarchy.
+public struct ViewControllerDescription {
+    /// If an initial call to `update(viewController:)` will be performed
+    /// when the view controller is created. Defaults to `true`.
     ///
-    /// The most common use case for a `ViewControllerDescription` is to return it from your `Screen`'s
-    /// `viewControllerDescription(environment:)` method. The `WorkflowUI` machinery (or your
-    /// custom container view controller) will then use this view controller description to create or update the
-    /// on-screen presented view controller.
+    /// ### Note
+    /// When creating container view controllers that contain other view controllers
+    /// (eg, a navigation stack), you usually want to set this value to `false` to avoid
+    /// duplicate updates to your children if they are created in `init`.
+    public var performInitialUpdate: Bool
+
+    /// Describes the `UIViewController` type that backs the `ViewControllerDescription`
+    /// in a way that is `Equatable` and `Hashable`. When implementing view controller
+    /// updating and diffing, you can use this type to identify if the backing view controller
+    /// type changed.
+    public let kind: KindIdentifier
+
+    private let build: () -> UIViewController
+    private let update: (UIViewController) -> Void
+
+    /// Constructs a view controller description by providing closures used to
+    /// build and update a specific view controller type.
     ///
-    /// As a creator of a custom container view controller, you will usually pass this view controller description to
-    /// a `DescribedViewController`, which will internally create and manage the described view
-    /// controller for its current view controller description. However, you can also directly invoke the public
-    /// methods such as `buildViewController()`, `update(viewController:)`, if you are
-    /// manually managing your own view controller hierarchy.
-    public struct ViewControllerDescription {
-        /// If an initial call to `update(viewController:)` will be performed
-        /// when the view controller is created. Defaults to `true`.
-        ///
-        /// ### Note
-        /// When creating container view controllers that contain other view controllers
-        /// (eg, a navigation stack), you usually want to set this value to `false` to avoid
-        /// duplicate updates to your children if they are created in `init`.
-        public var performInitialUpdate: Bool
+    /// - Parameters:
+    ///   - performInitialUpdate: If an initial call to `update(viewController:)`
+    ///     will be performed when the view controller is created. Defaults to `true`.
+    ///
+    ///   - type: The type of view controller produced by this description.
+    ///     Typically, should should be able to omit this parameter, but
+    ///     in cases where type inference has trouble, it’s offered as
+    ///     an escape hatch.
+    ///
+    ///   - build: Closure that produces a new instance of the view controller
+    ///
+    ///   - update: Closure that updates the given view controller
+    public init<VC: UIViewController>(
+        performInitialUpdate: Bool = true,
+        type: VC.Type = VC.self,
+        build: @escaping () -> VC,
+        update: @escaping (VC) -> Void
+    ) {
+        self.performInitialUpdate = performInitialUpdate
 
-        /// Describes the `UIViewController` type that backs the `ViewControllerDescription`
-        /// in a way that is `Equatable` and `Hashable`. When implementing view controller
-        /// updating and diffing, you can use this type to identify if the backing view controller
-        /// type changed.
-        public let kind: KindIdentifier
+        self.kind = .init(VC.self)
 
-        private let build: () -> UIViewController
-        private let update: (UIViewController) -> Void
+        self.build = build
 
-        /// Constructs a view controller description by providing closures used to
-        /// build and update a specific view controller type.
-        ///
-        /// - Parameters:
-        ///   - performInitialUpdate: If an initial call to `update(viewController:)`
-        ///     will be performed when the view controller is created. Defaults to `true`.
-        ///
-        ///   - type: The type of view controller produced by this description.
-        ///     Typically, should should be able to omit this parameter, but
-        ///     in cases where type inference has trouble, it’s offered as
-        ///     an escape hatch.
-        ///
-        ///   - build: Closure that produces a new instance of the view controller
-        ///
-        ///   - update: Closure that updates the given view controller
-        public init<VC: UIViewController>(
-            performInitialUpdate: Bool = true,
-            type: VC.Type = VC.self,
-            build: @escaping () -> VC,
-            update: @escaping (VC) -> Void
-        ) {
-            self.performInitialUpdate = performInitialUpdate
-
-            self.kind = .init(VC.self)
-
-            self.build = build
-
-            self.update = { untypedViewController in
-                guard let viewController = untypedViewController as? VC else {
-                    fatalError("Unable to update \(untypedViewController), expecting a \(VC.self)")
-                }
-
-                update(viewController)
+        self.update = { untypedViewController in
+            guard let viewController = untypedViewController as? VC else {
+                fatalError("Unable to update \(untypedViewController), expecting a \(VC.self)")
             }
+
+            update(viewController)
+        }
+    }
+
+    /// Construct and update a new view controller as described by this view controller description.
+    /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
+    public func buildViewController() -> UIViewController {
+        let viewController = build()
+
+        if performInitialUpdate {
+            // Perform an initial update of the built view controller
+            update(viewController: viewController)
         }
 
-        /// Construct and update a new view controller as described by this view controller description.
-        /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
-        public func buildViewController() -> UIViewController {
-            let viewController = build()
+        return viewController
+    }
 
-            if performInitialUpdate {
-                // Perform an initial update of the built view controller
-                update(viewController: viewController)
-            }
+    /// If the given view controller is of the correct type to be updated by this view controller description.
+    ///
+    /// If your view controller type can change between updates, call this method before invoking `update(viewController:)`.
+    public func canUpdate(viewController: UIViewController) -> Bool {
+        kind.canUpdate(viewController: viewController)
+    }
 
-            return viewController
+    /// Update the given view controller with the content from the view controller description.
+    ///
+    /// - Parameters:
+    ///   - viewController: The view controller to update.
+    ///
+    /// ### Note
+    /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
+    /// that passes `canUpdate(viewController:)`. Failure to do so will result in a fatal precondition.
+    public func update(viewController: UIViewController) {
+        precondition(
+            canUpdate(viewController: viewController),
+            """
+            `ViewControllerDescription` was provided a view controller it cannot update: (\(viewController).
+
+            The view controller type (\(type(of: viewController)) is a compatible type to the expected type \(kind.viewControllerType)).
+            """
+        )
+
+        update(viewController)
+    }
+}
+
+extension ViewControllerDescription {
+    /// Describes the `UIViewController` type that backs the `ViewControllerDescription`
+    /// in a way that is `Equatable` and `Hashable`. When implementing view controller
+    /// updating and diffing, you can use this type to identify if the backing view controller
+    /// type changed.
+    public struct KindIdentifier: Hashable {
+        fileprivate let viewControllerType: UIViewController.Type
+
+        private let checkViewControllerType: (UIViewController) -> Bool
+
+        /// Creates a new kind for the given view controller type.
+        public init<VC: UIViewController>(_ kind: VC.Type) {
+            self.viewControllerType = VC.self
+
+            self.checkViewControllerType = { $0 is VC }
         }
 
         /// If the given view controller is of the correct type to be updated by this view controller description.
         ///
         /// If your view controller type can change between updates, call this method before invoking `update(viewController:)`.
         public func canUpdate(viewController: UIViewController) -> Bool {
-            kind.canUpdate(viewController: viewController)
+            return checkViewControllerType(viewController)
         }
 
-        /// Update the given view controller with the content from the view controller description.
-        ///
-        /// - Parameters:
-        ///   - viewController: The view controller to update.
-        ///
-        /// ### Note
-        /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
-        /// that passes `canUpdate(viewController:)`. Failure to do so will result in a fatal precondition.
-        public func update(viewController: UIViewController) {
-            precondition(
-                canUpdate(viewController: viewController),
-                """
-                `ViewControllerDescription` was provided a view controller it cannot update: (\(viewController).
+        // MARK: Hashable
 
-                The view controller type (\(type(of: viewController)) is a compatible type to the expected type \(kind.viewControllerType)).
-                """
-            )
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(ObjectIdentifier(viewControllerType))
+        }
 
-            update(viewController)
+        // MARK: Equatable
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.viewControllerType == rhs.viewControllerType
         }
     }
-
-    extension ViewControllerDescription {
-        /// Describes the `UIViewController` type that backs the `ViewControllerDescription`
-        /// in a way that is `Equatable` and `Hashable`. When implementing view controller
-        /// updating and diffing, you can use this type to identify if the backing view controller
-        /// type changed.
-        public struct KindIdentifier: Hashable {
-            fileprivate let viewControllerType: UIViewController.Type
-
-            private let checkViewControllerType: (UIViewController) -> Bool
-
-            /// Creates a new kind for the given view controller type.
-            public init<VC: UIViewController>(_ kind: VC.Type) {
-                self.viewControllerType = VC.self
-
-                self.checkViewControllerType = { $0 is VC }
-            }
-
-            /// If the given view controller is of the correct type to be updated by this view controller description.
-            ///
-            /// If your view controller type can change between updates, call this method before invoking `update(viewController:)`.
-            public func canUpdate(viewController: UIViewController) -> Bool {
-                return checkViewControllerType(viewController)
-            }
-
-            // MARK: Hashable
-
-            public func hash(into hasher: inout Hasher) {
-                hasher.combine(ObjectIdentifier(viewControllerType))
-            }
-
-            // MARK: Equatable
-
-            public static func == (lhs: Self, rhs: Self) -> Bool {
-                lhs.viewControllerType == rhs.viewControllerType
-            }
-        }
-    }
+}
 
 #endif

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -16,319 +16,319 @@
 
 #if canImport(UIKit)
 
-    import XCTest
+import XCTest
 
-    import ReactiveSwift
-    import Workflow
-    @testable import WorkflowUI
+import ReactiveSwift
+import Workflow
+@testable import WorkflowUI
 
-    class DescribedViewControllerTests: XCTestCase {
-        // MARK: - Tests
+class DescribedViewControllerTests: XCTestCase {
+    // MARK: - Tests
 
-        func test_init() {
-            // Given
-            let screen = TestScreen.counter(0)
+    func test_init() {
+        // Given
+        let screen = TestScreen.counter(0)
 
-            // When
-            let describedViewController = DescribedViewController(screen: screen, environment: .empty)
+        // When
+        let describedViewController = DescribedViewController(screen: screen, environment: .empty)
 
-            // Then
-            guard
-                let currentViewController = describedViewController.currentViewController as? CounterViewController
-            else {
-                XCTFail("Expected a \(String(reflecting: CounterViewController.self)), but got:  \(describedViewController.currentViewController)")
-                return
-            }
-
-            XCTAssertEqual(currentViewController.count, 0)
-            XCTAssertFalse(describedViewController.isViewLoaded)
-            XCTAssertFalse(currentViewController.isViewLoaded)
-            XCTAssertEqual(currentViewController.parent, describedViewController)
+        // Then
+        guard
+            let currentViewController = describedViewController.currentViewController as? CounterViewController
+        else {
+            XCTFail("Expected a \(String(reflecting: CounterViewController.self)), but got:  \(describedViewController.currentViewController)")
+            return
         }
 
-        func test_viewDidLoad() {
-            // Given
-            let screen = TestScreen.counter(0)
-            let describedViewController = DescribedViewController(screen: screen, environment: .empty)
-
-            // When
-            _ = describedViewController.view
-
-            // Then
-            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
-            XCTAssertNotNil(describedViewController.currentViewController.viewIfLoaded?.superview)
-        }
-
-        func test_update_toCompatibleDescription_beforeViewLoads() {
-            // Given
-            let screenA = TestScreen.counter(0)
-            let screenB = TestScreen.counter(1)
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let initialChildViewController = describedViewController.currentViewController
-
-            // When
-            describedViewController.update(screen: screenB, environment: .empty)
-
-            // Then
-            XCTAssertEqual(initialChildViewController, describedViewController.currentViewController)
-            XCTAssertEqual((describedViewController.currentViewController as? CounterViewController)?.count, 1)
-            XCTAssertFalse(describedViewController.isViewLoaded)
-            XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
-            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
-        }
-
-        func test_update_toCompatibleDescription_afterViewLoads() {
-            // Given
-            let screenA = TestScreen.counter(0)
-            let screenB = TestScreen.counter(1)
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let initialChildViewController = describedViewController.currentViewController
-
-            // When
-            _ = describedViewController.view
-            describedViewController.update(screen: screenB, environment: .empty)
-
-            // Then
-            XCTAssertEqual(initialChildViewController, describedViewController.currentViewController)
-            XCTAssertEqual((describedViewController.currentViewController as? CounterViewController)?.count, 1)
-        }
-
-        func test_update_toIncompatibleDescription_beforeViewLoads() {
-            // Given
-            let screenA = TestScreen.counter(0)
-            let screenB = TestScreen.message("Test")
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let initialChildViewController = describedViewController.currentViewController
-
-            // When
-            describedViewController.update(screen: screenB, environment: .empty)
-
-            // Then
-            XCTAssertNotEqual(initialChildViewController, describedViewController.currentViewController)
-            XCTAssertNil(initialChildViewController.parent)
-            XCTAssertEqual((describedViewController.currentViewController as? MessageViewController)?.message, "Test")
-            XCTAssertFalse(describedViewController.isViewLoaded)
-            XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
-            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
-        }
-
-        func test_update_toIncompatibleDescription_afterViewLoads() {
-            // Given
-            let screenA = TestScreen.counter(0)
-            let screenB = TestScreen.message("Test")
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let initialChildViewController = describedViewController.currentViewController
-
-            // When
-            _ = describedViewController.view
-            describedViewController.update(screen: screenB, environment: .empty)
-
-            // Then
-            XCTAssertNotEqual(initialChildViewController, describedViewController.currentViewController)
-            XCTAssertEqual((describedViewController.currentViewController as? MessageViewController)?.message, "Test")
-            XCTAssertNil(initialChildViewController.parent)
-            XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
-            XCTAssertNil(initialChildViewController.viewIfLoaded?.superview)
-            XCTAssertNotNil(describedViewController.currentViewController.viewIfLoaded?.superview)
-        }
-
-        func test_childViewControllerFor() {
-            // Given
-            let screen = TestScreen.counter(0)
-
-            let describedViewController = DescribedViewController(screen: screen, environment: .empty)
-            let currentViewController = describedViewController.currentViewController
-
-            // When, Then
-            XCTAssertEqual(describedViewController.childForStatusBarStyle, currentViewController)
-            XCTAssertEqual(describedViewController.childForStatusBarHidden, currentViewController)
-            XCTAssertEqual(describedViewController.childForHomeIndicatorAutoHidden, currentViewController)
-            XCTAssertEqual(describedViewController.childForScreenEdgesDeferringSystemGestures, currentViewController)
-            XCTAssertEqual(describedViewController.supportedInterfaceOrientations, currentViewController.supportedInterfaceOrientations)
-        }
-
-        func test_childViewControllerFor_afterIncompatibleUpdate() {
-            // Given
-            let screenA = TestScreen.counter(0)
-            let screenB = TestScreen.message("Test")
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let initialChildViewController = describedViewController.currentViewController
-
-            describedViewController.update(screen: screenB, environment: .empty)
-            let currentViewController = describedViewController.currentViewController
-
-            // When, Then
-            XCTAssertNotEqual(initialChildViewController, currentViewController)
-            XCTAssertEqual(describedViewController.childForStatusBarStyle, currentViewController)
-            XCTAssertEqual(describedViewController.childForStatusBarHidden, currentViewController)
-            XCTAssertEqual(describedViewController.childForHomeIndicatorAutoHidden, currentViewController)
-            XCTAssertEqual(describedViewController.childForScreenEdgesDeferringSystemGestures, currentViewController)
-            XCTAssertEqual(describedViewController.supportedInterfaceOrientations, currentViewController.supportedInterfaceOrientations)
-        }
-
-        func test_preferredContentSizeDidChange() {
-            // Given
-            let screenA = TestScreen.counter(1)
-            let screenB = TestScreen.counter(2)
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
-
-            // When
-            let expectation = self.expectation(description: "did observe size changes")
-            expectation.expectedFulfillmentCount = 2
-
-            var observedSizes: [CGSize] = []
-            let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
-                observedSizes.append($0)
-                expectation.fulfill()
-            }
-
-            defer { disposable?.dispose() }
-
-            _ = WorkflowHostingController.view
-            describedViewController.update(screen: screenB, environment: .empty)
-
-            // Then
-            let expectedSizes = [CGSize(width: 10, height: 0), CGSize(width: 20, height: 0)]
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(observedSizes, expectedSizes)
-        }
-
-        func test_preferredContentSizeDidChange_afterIncompatibleUpdate() {
-            // Given
-            let screenA = TestScreen.counter(1)
-            let screenB = TestScreen.message("Test")
-            let screenC = TestScreen.message("Testing")
-
-            let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
-            let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
-
-            // When
-            let expectation = self.expectation(description: "did observe size changes")
-            expectation.expectedFulfillmentCount = 3
-
-            var observedSizes: [CGSize] = []
-            let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
-                observedSizes.append($0)
-                expectation.fulfill()
-            }
-
-            defer { disposable?.dispose() }
-
-            _ = WorkflowHostingController.view
-            describedViewController.update(screen: screenB, environment: .empty)
-            describedViewController.update(screen: screenC, environment: .empty)
-
-            // Then
-            let expectedSizes = [
-                CGSize(width: 10, height: 0),
-                CGSize(width: 40, height: 0),
-                CGSize(width: 70, height: 0),
-            ]
-
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(observedSizes, expectedSizes)
-        }
+        XCTAssertEqual(currentViewController.count, 0)
+        XCTAssertFalse(describedViewController.isViewLoaded)
+        XCTAssertFalse(currentViewController.isViewLoaded)
+        XCTAssertEqual(currentViewController.parent, describedViewController)
     }
 
-    // MARK: - Helper Types
+    func test_viewDidLoad() {
+        // Given
+        let screen = TestScreen.counter(0)
+        let describedViewController = DescribedViewController(screen: screen, environment: .empty)
 
-    fileprivate enum TestScreen: Screen, Equatable {
-        case counter(Int)
-        case message(String)
+        // When
+        _ = describedViewController.view
 
-        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-            switch self {
-            case .counter(let count):
-                return ViewControllerDescription(
-                    build: { CounterViewController(count: count) },
-                    update: { $0.count = count }
-                )
-
-            case .message(let message):
-                return ViewControllerDescription(
-                    build: { MessageViewController(message: message) },
-                    update: { $0.message = message }
-                )
-            }
-        }
+        // Then
+        XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
+        XCTAssertNotNil(describedViewController.currentViewController.viewIfLoaded?.superview)
     }
 
-    fileprivate class WorkflowHostingController: UIViewController {
-        let describedViewController: DescribedViewController
+    func test_update_toCompatibleDescription_beforeViewLoads() {
+        // Given
+        let screenA = TestScreen.counter(0)
+        let screenB = TestScreen.counter(1)
 
-        var preferredContentSizeSignal: Signal<CGSize, Never> { return signal.skipRepeats() }
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let initialChildViewController = describedViewController.currentViewController
 
-        private let (signal, sink) = Signal<CGSize, Never>.pipe()
+        // When
+        describedViewController.update(screen: screenB, environment: .empty)
 
-        init(describedViewController: DescribedViewController) {
-            self.describedViewController = describedViewController
-            super.init(nibName: nil, bundle: nil)
-        }
-
-        @available(*, unavailable) required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        override func viewDidLoad() {
-            super.viewDidLoad()
-
-            addChild(describedViewController)
-            describedViewController.view.frame = view.bounds
-            describedViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            view.addSubview(describedViewController.view)
-            describedViewController.didMove(toParent: self)
-        }
-
-        override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
-            super.preferredContentSizeDidChange(forChildContentContainer: container)
-
-            guard container === describedViewController else { return }
-
-            sink.send(value: container.preferredContentSize)
-        }
+        // Then
+        XCTAssertEqual(initialChildViewController, describedViewController.currentViewController)
+        XCTAssertEqual((describedViewController.currentViewController as? CounterViewController)?.count, 1)
+        XCTAssertFalse(describedViewController.isViewLoaded)
+        XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
+        XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
     }
 
-    fileprivate class CounterViewController: UIViewController {
-        var count: Int {
-            didSet {
-                preferredContentSize.width = CGFloat(count * 10)
-            }
+    func test_update_toCompatibleDescription_afterViewLoads() {
+        // Given
+        let screenA = TestScreen.counter(0)
+        let screenB = TestScreen.counter(1)
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let initialChildViewController = describedViewController.currentViewController
+
+        // When
+        _ = describedViewController.view
+        describedViewController.update(screen: screenB, environment: .empty)
+
+        // Then
+        XCTAssertEqual(initialChildViewController, describedViewController.currentViewController)
+        XCTAssertEqual((describedViewController.currentViewController as? CounterViewController)?.count, 1)
+    }
+
+    func test_update_toIncompatibleDescription_beforeViewLoads() {
+        // Given
+        let screenA = TestScreen.counter(0)
+        let screenB = TestScreen.message("Test")
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let initialChildViewController = describedViewController.currentViewController
+
+        // When
+        describedViewController.update(screen: screenB, environment: .empty)
+
+        // Then
+        XCTAssertNotEqual(initialChildViewController, describedViewController.currentViewController)
+        XCTAssertNil(initialChildViewController.parent)
+        XCTAssertEqual((describedViewController.currentViewController as? MessageViewController)?.message, "Test")
+        XCTAssertFalse(describedViewController.isViewLoaded)
+        XCTAssertFalse(describedViewController.currentViewController.isViewLoaded)
+        XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
+    }
+
+    func test_update_toIncompatibleDescription_afterViewLoads() {
+        // Given
+        let screenA = TestScreen.counter(0)
+        let screenB = TestScreen.message("Test")
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let initialChildViewController = describedViewController.currentViewController
+
+        // When
+        _ = describedViewController.view
+        describedViewController.update(screen: screenB, environment: .empty)
+
+        // Then
+        XCTAssertNotEqual(initialChildViewController, describedViewController.currentViewController)
+        XCTAssertEqual((describedViewController.currentViewController as? MessageViewController)?.message, "Test")
+        XCTAssertNil(initialChildViewController.parent)
+        XCTAssertEqual(describedViewController.currentViewController.parent, describedViewController)
+        XCTAssertNil(initialChildViewController.viewIfLoaded?.superview)
+        XCTAssertNotNil(describedViewController.currentViewController.viewIfLoaded?.superview)
+    }
+
+    func test_childViewControllerFor() {
+        // Given
+        let screen = TestScreen.counter(0)
+
+        let describedViewController = DescribedViewController(screen: screen, environment: .empty)
+        let currentViewController = describedViewController.currentViewController
+
+        // When, Then
+        XCTAssertEqual(describedViewController.childForStatusBarStyle, currentViewController)
+        XCTAssertEqual(describedViewController.childForStatusBarHidden, currentViewController)
+        XCTAssertEqual(describedViewController.childForHomeIndicatorAutoHidden, currentViewController)
+        XCTAssertEqual(describedViewController.childForScreenEdgesDeferringSystemGestures, currentViewController)
+        XCTAssertEqual(describedViewController.supportedInterfaceOrientations, currentViewController.supportedInterfaceOrientations)
+    }
+
+    func test_childViewControllerFor_afterIncompatibleUpdate() {
+        // Given
+        let screenA = TestScreen.counter(0)
+        let screenB = TestScreen.message("Test")
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let initialChildViewController = describedViewController.currentViewController
+
+        describedViewController.update(screen: screenB, environment: .empty)
+        let currentViewController = describedViewController.currentViewController
+
+        // When, Then
+        XCTAssertNotEqual(initialChildViewController, currentViewController)
+        XCTAssertEqual(describedViewController.childForStatusBarStyle, currentViewController)
+        XCTAssertEqual(describedViewController.childForStatusBarHidden, currentViewController)
+        XCTAssertEqual(describedViewController.childForHomeIndicatorAutoHidden, currentViewController)
+        XCTAssertEqual(describedViewController.childForScreenEdgesDeferringSystemGestures, currentViewController)
+        XCTAssertEqual(describedViewController.supportedInterfaceOrientations, currentViewController.supportedInterfaceOrientations)
+    }
+
+    func test_preferredContentSizeDidChange() {
+        // Given
+        let screenA = TestScreen.counter(1)
+        let screenB = TestScreen.counter(2)
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
+
+        // When
+        let expectation = self.expectation(description: "did observe size changes")
+        expectation.expectedFulfillmentCount = 2
+
+        var observedSizes: [CGSize] = []
+        let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
+            observedSizes.append($0)
+            expectation.fulfill()
         }
 
-        init(count: Int) {
-            self.count = count
-            super.init(nibName: nil, bundle: nil)
+        defer { disposable?.dispose() }
+
+        _ = WorkflowHostingController.view
+        describedViewController.update(screen: screenB, environment: .empty)
+
+        // Then
+        let expectedSizes = [CGSize(width: 10, height: 0), CGSize(width: 20, height: 0)]
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(observedSizes, expectedSizes)
+    }
+
+    func test_preferredContentSizeDidChange_afterIncompatibleUpdate() {
+        // Given
+        let screenA = TestScreen.counter(1)
+        let screenB = TestScreen.message("Test")
+        let screenC = TestScreen.message("Testing")
+
+        let describedViewController = DescribedViewController(screen: screenA, environment: .empty)
+        let WorkflowHostingController = WorkflowHostingController(describedViewController: describedViewController)
+
+        // When
+        let expectation = self.expectation(description: "did observe size changes")
+        expectation.expectedFulfillmentCount = 3
+
+        var observedSizes: [CGSize] = []
+        let disposable = WorkflowHostingController.preferredContentSizeSignal.observeValues {
+            observedSizes.append($0)
+            expectation.fulfill()
+        }
+
+        defer { disposable?.dispose() }
+
+        _ = WorkflowHostingController.view
+        describedViewController.update(screen: screenB, environment: .empty)
+        describedViewController.update(screen: screenC, environment: .empty)
+
+        // Then
+        let expectedSizes = [
+            CGSize(width: 10, height: 0),
+            CGSize(width: 40, height: 0),
+            CGSize(width: 70, height: 0),
+        ]
+
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(observedSizes, expectedSizes)
+    }
+}
+
+// MARK: - Helper Types
+
+fileprivate enum TestScreen: Screen, Equatable {
+    case counter(Int)
+    case message(String)
+
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        switch self {
+        case .counter(let count):
+            return ViewControllerDescription(
+                build: { CounterViewController(count: count) },
+                update: { $0.count = count }
+            )
+
+        case .message(let message):
+            return ViewControllerDescription(
+                build: { MessageViewController(message: message) },
+                update: { $0.message = message }
+            )
+        }
+    }
+}
+
+fileprivate class WorkflowHostingController: UIViewController {
+    let describedViewController: DescribedViewController
+
+    var preferredContentSizeSignal: Signal<CGSize, Never> { return signal.skipRepeats() }
+
+    private let (signal, sink) = Signal<CGSize, Never>.pipe()
+
+    init(describedViewController: DescribedViewController) {
+        self.describedViewController = describedViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(describedViewController)
+        describedViewController.view.frame = view.bounds
+        describedViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(describedViewController.view)
+        describedViewController.didMove(toParent: self)
+    }
+
+    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+
+        guard container === describedViewController else { return }
+
+        sink.send(value: container.preferredContentSize)
+    }
+}
+
+fileprivate class CounterViewController: UIViewController {
+    var count: Int {
+        didSet {
             preferredContentSize.width = CGFloat(count * 10)
         }
-
-        @available(*, unavailable) required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
     }
 
-    fileprivate class MessageViewController: UIViewController {
-        var message: String {
-            didSet {
-                preferredContentSize.width = CGFloat(message.count * 10)
-            }
-        }
+    init(count: Int) {
+        self.count = count
+        super.init(nibName: nil, bundle: nil)
+        preferredContentSize.width = CGFloat(count * 10)
+    }
 
-        init(message: String) {
-            self.message = message
-            super.init(nibName: nil, bundle: nil)
+    @available(*, unavailable) required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+fileprivate class MessageViewController: UIViewController {
+    var message: String {
+        didSet {
             preferredContentSize.width = CGFloat(message.count * 10)
         }
-
-        @available(*, unavailable) required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
     }
+
+    init(message: String) {
+        self.message = message
+        super.init(nibName: nil, bundle: nil)
+        preferredContentSize.width = CGFloat(message.count * 10)
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
 
 #endif

--- a/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
+++ b/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
@@ -16,256 +16,256 @@
 
 #if canImport(UIKit)
 
-    import UIKit
-    import XCTest
-    @testable import WorkflowUI
+import UIKit
+import XCTest
+@testable import WorkflowUI
 
-    class UIViewControllerExtensionTests: XCTestCase {
-        func test_update_viewNotLoaded() {
-            let fixture = TestFixture(loadView: false, screen: Screen1(), environment: .empty)
+class UIViewControllerExtensionTests: XCTestCase {
+    func test_update_viewNotLoaded() {
+        let fixture = TestFixture(loadView: false, screen: Screen1(), environment: .empty)
+
+        // Update to the same screen type should do nothing.
+
+        XCTAssertFalse(fixture.root.isViewLoaded)
+        XCTAssertFalse(fixture.root.content.isViewLoaded)
+
+        fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
+        XCTAssertFalse(fixture.root.isViewLoaded)
+        XCTAssertFalse(fixture.root.content.isViewLoaded)
+        XCTAssertEqual(fixture.events, [])
+
+        // Update to a new screen type should swap out the screen and send the correct events.
+
+        fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+        XCTAssertFalse(fixture.root.isViewLoaded)
+        XCTAssertFalse(fixture.root.content.isViewLoaded)
+        XCTAssertEqual(fixture.events, [
+            .child_willMoveTo(identifier: "2", parent: fixture.root),
+            .child_willMoveTo(identifier: "1", parent: nil),
+            .child_didMoveTo(identifier: "2", parent: fixture.root),
+            .child_didMoveTo(identifier: "1", parent: nil),
+        ])
+    }
+
+    func test_update_viewLoaded() {
+        let fixture = TestFixture(screen: Screen1(), environment: .empty)
+        fixture.root.loadViewIfNeeded()
+
+        // Update to the same screen type should do nothing.
+
+        fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
+        XCTAssertEqual(fixture.events, [])
+
+        // Update to a new screen type should swap out the screen and send the correct events.
+
+        fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+        XCTAssertEqual(fixture.events, [
+            .child_willMoveTo(identifier: "2", parent: fixture.root),
+            .child_willMoveTo(identifier: "1", parent: nil),
+            .child_view_loadView(identifier: "2"),
+            .child_didMoveTo(identifier: "2", parent: fixture.root),
+            .child_didMoveTo(identifier: "1", parent: nil),
+        ])
+    }
+
+    func test_update_hostedView() {
+        let fixture = TestFixture(screen: Screen1(), environment: .empty)
+
+        show(vc: fixture.root) { root in
+
+            fixture.clearAllEvents()
 
             // Update to the same screen type should do nothing.
 
-            XCTAssertFalse(fixture.root.isViewLoaded)
-            XCTAssertFalse(fixture.root.content.isViewLoaded)
-
-            fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
-            XCTAssertFalse(fixture.root.isViewLoaded)
-            XCTAssertFalse(fixture.root.content.isViewLoaded)
+            root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
             XCTAssertEqual(fixture.events, [])
 
             // Update to a new screen type should swap out the screen and send the correct events.
 
-            fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
-            XCTAssertFalse(fixture.root.isViewLoaded)
-            XCTAssertFalse(fixture.root.content.isViewLoaded)
-            XCTAssertEqual(fixture.events, [
-                .child_willMoveTo(identifier: "2", parent: fixture.root),
-                .child_willMoveTo(identifier: "1", parent: nil),
-                .child_didMoveTo(identifier: "2", parent: fixture.root),
-                .child_didMoveTo(identifier: "1", parent: nil),
-            ])
-        }
-
-        func test_update_viewLoaded() {
-            let fixture = TestFixture(screen: Screen1(), environment: .empty)
-            fixture.root.loadViewIfNeeded()
-
-            // Update to the same screen type should do nothing.
-
-            fixture.root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
-            XCTAssertEqual(fixture.events, [])
-
-            // Update to a new screen type should swap out the screen and send the correct events.
-
-            fixture.root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
+            root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
             XCTAssertEqual(fixture.events, [
                 .child_willMoveTo(identifier: "2", parent: fixture.root),
                 .child_willMoveTo(identifier: "1", parent: nil),
                 .child_view_loadView(identifier: "2"),
+                .child_viewWillAppear(identifier: "2", animated: false),
+                .child_viewWillDisappear(identifier: "1", animated: false),
+                .child_viewDidAppear(identifier: "2", animated: false),
+                .child_viewDidDisappear(identifier: "1", animated: false),
                 .child_didMoveTo(identifier: "2", parent: fixture.root),
                 .child_didMoveTo(identifier: "1", parent: nil),
             ])
         }
+    }
+}
 
-        func test_update_hostedView() {
-            let fixture = TestFixture(screen: Screen1(), environment: .empty)
+fileprivate enum TestingEvent: Equatable {
+    // View Controller Events
 
-            show(vc: fixture.root) { root in
+    case child_viewWillAppear(identifier: String, animated: Bool)
+    case child_viewWillDisappear(identifier: String, animated: Bool)
+    case child_viewDidAppear(identifier: String, animated: Bool)
+    case child_viewDidDisappear(identifier: String, animated: Bool)
 
-                fixture.clearAllEvents()
+    case child_willMoveTo(identifier: String, parent: UIViewController?)
+    case child_didMoveTo(identifier: String, parent: UIViewController?)
 
-                // Update to the same screen type should do nothing.
+    // View Events
 
-                root.update(with: Screen1(recordEvent: fixture.recordEvent), environment: .empty)
-                XCTAssertEqual(fixture.events, [])
+    case child_view_loadView(identifier: String)
+}
 
-                // Update to a new screen type should swap out the screen and send the correct events.
+private final class RootVC: UIViewController {
+    var content: VCBase
 
-                root.update(with: Screen2(recordEvent: fixture.recordEvent), environment: .empty)
-                XCTAssertEqual(fixture.events, [
-                    .child_willMoveTo(identifier: "2", parent: fixture.root),
-                    .child_willMoveTo(identifier: "1", parent: nil),
-                    .child_view_loadView(identifier: "2"),
-                    .child_viewWillAppear(identifier: "2", animated: false),
-                    .child_viewWillDisappear(identifier: "1", animated: false),
-                    .child_viewDidAppear(identifier: "2", animated: false),
-                    .child_viewDidDisappear(identifier: "1", animated: false),
-                    .child_didMoveTo(identifier: "2", parent: fixture.root),
-                    .child_didMoveTo(identifier: "1", parent: nil),
-                ])
-            }
-        }
+    init(screen: Screen, environment: ViewEnvironment) {
+        self.content = screen
+            .viewControllerDescription(environment: environment)
+            .buildViewController() as! VCBase
+
+        super.init(nibName: nil, bundle: nil)
+
+        addChild(content)
+        content.didMove(toParent: self)
     }
 
-    fileprivate enum TestingEvent: Equatable {
-        // View Controller Events
+    required init?(coder: NSCoder) { fatalError() }
 
-        case child_viewWillAppear(identifier: String, animated: Bool)
-        case child_viewWillDisappear(identifier: String, animated: Bool)
-        case child_viewDidAppear(identifier: String, animated: Bool)
-        case child_viewDidDisappear(identifier: String, animated: Bool)
+    override func loadView() {
+        super.loadView()
 
-        case child_willMoveTo(identifier: String, parent: UIViewController?)
-        case child_didMoveTo(identifier: String, parent: UIViewController?)
+        content.view.frame = view.bounds
 
-        // View Events
-
-        case child_view_loadView(identifier: String)
+        view.addSubview(content.view)
     }
 
-    private final class RootVC: UIViewController {
-        var content: VCBase
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
 
-        init(screen: Screen, environment: ViewEnvironment) {
-            self.content = screen
-                .viewControllerDescription(environment: environment)
-                .buildViewController() as! VCBase
-
-            super.init(nibName: nil, bundle: nil)
-
-            addChild(content)
-            content.didMove(toParent: self)
-        }
-
-        required init?(coder: NSCoder) { fatalError() }
-
-        override func loadView() {
-            super.loadView()
-
-            content.view.frame = view.bounds
-
-            view.addSubview(content.view)
-        }
-
-        override func viewDidLayoutSubviews() {
-            super.viewDidLayoutSubviews()
-
-            content.view.frame = view.bounds
-        }
-
-        func update(with screen: Screen, environment: ViewEnvironment) {
-            update(child: \.content, with: screen.asAnyScreen(), in: environment)
-        }
+        content.view.frame = view.bounds
     }
 
-    private struct Screen1: Screen {
-        var recordEvent: (TestingEvent) -> Void = { _ in }
+    func update(with screen: Screen, environment: ViewEnvironment) {
+        update(child: \.content, with: screen.asAnyScreen(), in: environment)
+    }
+}
 
-        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-            ViewControllerDescription(
-                type: VC1.self,
-                build: { VC1(identifier: "1", recordEvent: recordEvent) },
-                update: { $0.recordEvent = recordEvent }
-            )
-        }
+private struct Screen1: Screen {
+    var recordEvent: (TestingEvent) -> Void = { _ in }
+
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        ViewControllerDescription(
+            type: VC1.self,
+            build: { VC1(identifier: "1", recordEvent: recordEvent) },
+            update: { $0.recordEvent = recordEvent }
+        )
+    }
+}
+
+private struct Screen2: Screen {
+    var recordEvent: (TestingEvent) -> Void = { _ in }
+
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        ViewControllerDescription(
+            type: VC2.self,
+            build: { VC2(identifier: "2", recordEvent: recordEvent) },
+            update: { $0.recordEvent = recordEvent }
+        )
+    }
+}
+
+private final class TestFixture {
+    public let root: RootVC
+
+    private(set) var events: [TestingEvent] = []
+
+    public func clearAllEvents() {
+        events.removeAll()
     }
 
-    private struct Screen2: Screen {
-        var recordEvent: (TestingEvent) -> Void = { _ in }
+    public init(
+        loadView: Bool = true,
+        screen: Screen,
+        environment: ViewEnvironment
+    ) {
+        self.root = .init(
+            screen: screen,
+            environment: environment
+        )
 
-        func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-            ViewControllerDescription(
-                type: VC2.self,
-                build: { VC2(identifier: "2", recordEvent: recordEvent) },
-                update: { $0.recordEvent = recordEvent }
-            )
+        root.content.recordEvent = recordEvent
+
+        if loadView {
+            root.loadViewIfNeeded()
         }
+
+        clearAllEvents()
     }
 
-    private final class TestFixture {
-        public let root: RootVC
+    var recordEvent: (TestingEvent) -> Void {
+        { [weak self] in self?.events.append($0) }
+    }
+}
 
-        private(set) var events: [TestingEvent] = []
+private final class VC1: VCBase {}
+private final class VC2: VCBase {}
 
-        public func clearAllEvents() {
-            events.removeAll()
-        }
+private class VCBase: UIViewController {
+    let identifier: String
 
-        public init(
-            loadView: Bool = true,
-            screen: Screen,
-            environment: ViewEnvironment
-        ) {
-            self.root = .init(
-                screen: screen,
-                environment: environment
-            )
+    var recordEvent: (TestingEvent) -> Void = { _ in }
 
-            root.content.recordEvent = recordEvent
+    public init(
+        identifier: String,
+        recordEvent: @escaping (TestingEvent) -> Void
+    ) {
+        self.identifier = identifier
+        self.recordEvent = recordEvent
 
-            if loadView {
-                root.loadViewIfNeeded()
-            }
-
-            clearAllEvents()
-        }
-
-        var recordEvent: (TestingEvent) -> Void {
-            { [weak self] in self?.events.append($0) }
-        }
+        super.init(nibName: nil, bundle: nil)
     }
 
-    private final class VC1: VCBase {}
-    private final class VC2: VCBase {}
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
 
-    private class VCBase: UIViewController {
-        let identifier: String
+    override public func loadView() {
+        super.loadView()
 
-        var recordEvent: (TestingEvent) -> Void = { _ in }
-
-        public init(
-            identifier: String,
-            recordEvent: @escaping (TestingEvent) -> Void
-        ) {
-            self.identifier = identifier
-            self.recordEvent = recordEvent
-
-            super.init(nibName: nil, bundle: nil)
-        }
-
-        @available(*, unavailable)
-        required init?(coder: NSCoder) { fatalError() }
-
-        override public func loadView() {
-            super.loadView()
-
-            recordEvent(.child_view_loadView(identifier: identifier))
-        }
-
-        override public func viewWillAppear(_ animated: Bool) {
-            super.viewWillAppear(animated)
-            recordEvent(.child_viewWillAppear(identifier: identifier, animated: animated))
-
-            /// Ensure that as we're appearing, our frame is the correct final size.
-
-            XCTAssertEqual(view.bounds.size, parent?.view.bounds.size)
-        }
-
-        override public func viewDidAppear(_ animated: Bool) {
-            super.viewDidAppear(animated)
-            recordEvent(.child_viewDidAppear(identifier: identifier, animated: animated))
-        }
-
-        override public func viewWillDisappear(_ animated: Bool) {
-            super.viewWillDisappear(animated)
-            recordEvent(.child_viewWillDisappear(identifier: identifier, animated: animated))
-        }
-
-        override public func viewDidDisappear(_ animated: Bool) {
-            super.viewDidDisappear(animated)
-            recordEvent(.child_viewDidDisappear(identifier: identifier, animated: animated))
-        }
-
-        override public func willMove(toParent parent: UIViewController?) {
-            super.willMove(toParent: parent)
-            recordEvent(.child_willMoveTo(identifier: identifier, parent: parent))
-        }
-
-        override public func didMove(toParent parent: UIViewController?) {
-            super.didMove(toParent: parent)
-            recordEvent(.child_didMoveTo(identifier: identifier, parent: parent))
-        }
+        recordEvent(.child_view_loadView(identifier: identifier))
     }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        recordEvent(.child_viewWillAppear(identifier: identifier, animated: animated))
+
+        /// Ensure that as we're appearing, our frame is the correct final size.
+
+        XCTAssertEqual(view.bounds.size, parent?.view.bounds.size)
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        recordEvent(.child_viewDidAppear(identifier: identifier, animated: animated))
+    }
+
+    override public func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        recordEvent(.child_viewWillDisappear(identifier: identifier, animated: animated))
+    }
+
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        recordEvent(.child_viewDidDisappear(identifier: identifier, animated: animated))
+    }
+
+    override public func willMove(toParent parent: UIViewController?) {
+        super.willMove(toParent: parent)
+        recordEvent(.child_willMoveTo(identifier: identifier, parent: parent))
+    }
+
+    override public func didMove(toParent parent: UIViewController?) {
+        super.didMove(toParent: parent)
+        recordEvent(.child_didMoveTo(identifier: identifier, parent: parent))
+    }
+}
 
 #endif

--- a/WorkflowUI/Tests/XCTestCase+Extensions.swift
+++ b/WorkflowUI/Tests/XCTestCase+Extensions.swift
@@ -7,60 +7,60 @@
 
 #if canImport(UIKit)
 
-    import Foundation
-    import UIKit
-    import XCTest
+import Foundation
+import UIKit
+import XCTest
 
-    extension XCTestCase {
-        ///
-        /// Call this method to show a view controller in the test host application
-        /// during a unit test. The view controller will be the size of host application's device.
-        ///
-        /// After the test runs, the view controller will be removed from the view hierarchy.
-        ///
-        /// A test failure will occur if the host application does not exist, or does not have a root view controller.
-        ///
-        public func show<ViewController: UIViewController>(
-            vc viewController: ViewController,
-            loadAndPlaceView: Bool = true,
-            test: (ViewController) throws -> Void
-        ) rethrows {
-            guard let rootVC = UIApplication.shared.delegate?.window??.rootViewController else {
-                #if SWIFT_PACKAGE
-                    print("WARNING: Test cannot run in SPM, it requires an app host. Please run WorkflowUI.podspec's tests.")
-                #else
-                    XCTFail("Cannot present a view controller in a test host that does not have a root window.")
-                #endif
-                return
-            }
+extension XCTestCase {
+    ///
+    /// Call this method to show a view controller in the test host application
+    /// during a unit test. The view controller will be the size of host application's device.
+    ///
+    /// After the test runs, the view controller will be removed from the view hierarchy.
+    ///
+    /// A test failure will occur if the host application does not exist, or does not have a root view controller.
+    ///
+    public func show<ViewController: UIViewController>(
+        vc viewController: ViewController,
+        loadAndPlaceView: Bool = true,
+        test: (ViewController) throws -> Void
+    ) rethrows {
+        guard let rootVC = UIApplication.shared.delegate?.window??.rootViewController else {
+            #if SWIFT_PACKAGE
+            print("WARNING: Test cannot run in SPM, it requires an app host. Please run WorkflowUI.podspec's tests.")
+            #else
+            XCTFail("Cannot present a view controller in a test host that does not have a root window.")
+            #endif
+            return
+        }
 
-            rootVC.addChild(viewController)
-            viewController.didMove(toParent: rootVC)
+        rootVC.addChild(viewController)
+        viewController.didMove(toParent: rootVC)
 
+        if loadAndPlaceView {
+            viewController.view.frame = rootVC.view.bounds
+            viewController.view.layoutIfNeeded()
+
+            rootVC.beginAppearanceTransition(true, animated: false)
+            rootVC.view.addSubview(viewController.view)
+            rootVC.endAppearanceTransition()
+        }
+
+        defer {
             if loadAndPlaceView {
-                viewController.view.frame = rootVC.view.bounds
-                viewController.view.layoutIfNeeded()
-
-                rootVC.beginAppearanceTransition(true, animated: false)
-                rootVC.view.addSubview(viewController.view)
-                rootVC.endAppearanceTransition()
+                viewController.beginAppearanceTransition(false, animated: false)
+                viewController.view.removeFromSuperview()
+                viewController.endAppearanceTransition()
             }
 
-            defer {
-                if loadAndPlaceView {
-                    viewController.beginAppearanceTransition(false, animated: false)
-                    viewController.view.removeFromSuperview()
-                    viewController.endAppearanceTransition()
-                }
+            viewController.willMove(toParent: nil)
+            viewController.removeFromParent()
+        }
 
-                viewController.willMove(toParent: nil)
-                viewController.removeFromParent()
-            }
-
-            try autoreleasepool {
-                try test(viewController)
-            }
+        try autoreleasepool {
+            try test(viewController)
         }
     }
+}
 
 #endif


### PR DESCRIPTION
### Issue

- existing ifdef indentation rule doesn't match the style used in the rest of the Square codebase (and IMO makes the code more difficult to read)

### Description

- update swiftformat ifdef indent rule to `no-indent`
- run rule on the repo

note: view the PR with the 'hide whitespace' option enabled (use settings or add the `?w=0` URL query param)

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
