### PR TITLE
[chore]: pre major version bump cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Workflow",
     platforms: [
         .iOS("14.0"),
-        .macOS("10.13"),
+        .macOS("10.15"),
     ],
     products: [
         // MARK: Workflow

--- a/Samples/ModalContainer/Sources/ModalContainerViewController.swift
+++ b/Samples/ModalContainer/Sources/ModalContainerViewController.swift
@@ -162,10 +162,8 @@ internal final class ModalContainerViewController<ModalScreen: Screen>: ScreenVi
 
         setNeedsStatusBarAppearanceUpdate()
 
-        if #available(iOS 11.0, *) {
-            setNeedsUpdateOfHomeIndicatorAutoHidden()
-            setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
-        }
+        setNeedsUpdateOfHomeIndicatorAutoHidden()
+        setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
 
         // Set the topmost screen to be the accessibility modal
         presentedScreens.last?.viewController.view.accessibilityViewIsModal = true

--- a/Samples/SplitScreenContainer/Sources/SplitScreenContainerViewController.swift
+++ b/Samples/SplitScreenContainer/Sources/SplitScreenContainerViewController.swift
@@ -120,10 +120,6 @@ internal final class SplitScreenContainerViewController<LeadingScreenType: Scree
 
 private extension UIViewController {
     var isLayoutDirectionRightToLeft: Bool {
-        if #available(iOS 10.0, *) {
-            return traitCollection.layoutDirection == .rightToLeft
-        } else {
-            return UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft
-        }
+        return traitCollection.layoutDirection == .rightToLeft
     }
 }

--- a/ViewEnvironment.podspec
+++ b/ViewEnvironment.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'ViewEnvironment/Sources/**/*.swift'
 

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'Workflow/Sources/*.swift'
 

--- a/Workflow/Sources/Workflow.swift
+++ b/Workflow/Sources/Workflow.swift
@@ -49,7 +49,6 @@
 /// }
 /// ```
 ///
-#if swift(>=5.7)
 public protocol Workflow<Rendering, Output>: AnyWorkflowConvertible {
     /// Defines the state that is managed by this workflow.
     associatedtype State
@@ -81,39 +80,6 @@ public protocol Workflow<Rendering, Output>: AnyWorkflowConvertible {
     ///                      This will return the child's `Rendering` type after creating or updating the nested workflow.
     func render(state: State, context: RenderContext<Self>) -> Rendering
 }
-#else
-public protocol Workflow: AnyWorkflowConvertible {
-    /// Defines the state that is managed by this workflow.
-    associatedtype State
-
-    /// `Output` defines the type that can be emitted as output events.
-    associatedtype Output = Never
-
-    /// `Rendering` is the type that is produced by the `render` method: it
-    /// is commonly a view / screen model.
-    associatedtype Rendering
-
-    /// This method is invoked once when a workflow node comes into existence.
-    ///
-    /// - Returns: The initial state for the workflow.
-    func makeInitialState() -> State
-
-    /// Called when a new workflow is passed down from the parent to an existing workflow node.
-    ///
-    /// - Parameter previousWorkflow: The workflow before the update.
-    /// - Parameter state: The current state.
-    func workflowDidChange(from previousWorkflow: Self, state: inout State)
-
-    /// Called by the internal Workflow infrastructure to "render" the current state into `Rendering`.
-    /// A workflow's `Rendering` type is commonly a view or screen model.
-    ///
-    /// - Parameter state: The current state.
-    /// - Parameter context: The workflow context is the composition point for the workflow tree. To use a nested
-    ///                      workflow, instantiate it based on the current state, then call `rendered(in:key:outputMap:)`.
-    ///                      This will return the child's `Rendering` type after creating or updating the nested workflow.
-    func render(state: State, context: RenderContext<Self>) -> Rendering
-}
-#endif
 
 extension Workflow {
     public func workflowDidChange(from previousWorkflow: Self, state: inout State) {}

--- a/Workflow/Sources/WorkflowLogger.swift
+++ b/Workflow/Sources/WorkflowLogger.swift
@@ -93,44 +93,38 @@ final class WorkflowLogger {
     // MARK: Workflows
 
     static func logWorkflowStarted<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            guard WorkflowLogging.config.logLifetimes else { return }
+        guard WorkflowLogging.config.logLifetimes else { return }
 
-            let signpostID = OSSignpostID(log: .active, object: ref)
-            os_signpost(
-                .begin,
-                log: .active,
-                name: "Alive",
-                signpostID: signpostID,
-                "Workflow: %{public}@",
-                String(describing: WorkflowType.self)
-            )
-        }
+        let signpostID = OSSignpostID(log: .active, object: ref)
+        os_signpost(
+            .begin,
+            log: .active,
+            name: "Alive",
+            signpostID: signpostID,
+            "Workflow: %{public}@",
+            String(describing: WorkflowType.self)
+        )
     }
 
     static func logWorkflowFinished<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            guard WorkflowLogging.config.logLifetimes else { return }
+        guard WorkflowLogging.config.logLifetimes else { return }
 
-            let signpostID = OSSignpostID(log: .active, object: ref)
-            os_signpost(.end, log: .active, name: "Alive", signpostID: signpostID)
-        }
+        let signpostID = OSSignpostID(log: .active, object: ref)
+        os_signpost(.end, log: .active, name: "Alive", signpostID: signpostID)
     }
 
     static func logSinkEvent<Action: WorkflowAction>(ref: AnyObject, action: Action) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            guard WorkflowLogging.config.logActions else { return }
+        guard WorkflowLogging.config.logActions else { return }
 
-            let signpostID = OSSignpostID(log: .active, object: ref)
-            os_signpost(
-                .event,
-                log: .active,
-                name: "Sink Event",
-                signpostID: signpostID,
-                "Event for workflow: %{public}@",
-                String(describing: Action.WorkflowType.self)
-            )
-        }
+        let signpostID = OSSignpostID(log: .active, object: ref)
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Sink Event",
+            signpostID: signpostID,
+            "Event for workflow: %{public}@",
+            String(describing: Action.WorkflowType.self)
+        )
     }
 
     // MARK: Rendering
@@ -139,35 +133,31 @@ final class WorkflowLogger {
         ref: WorkflowNode<WorkflowType>,
         isRootNode: Bool
     ) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            guard shouldLogRenderTimings(
-                isRootNode: isRootNode
-            ) else { return }
+        guard shouldLogRenderTimings(
+            isRootNode: isRootNode
+        ) else { return }
 
-            let signpostID = OSSignpostID(log: .active, object: ref)
-            os_signpost(
-                .begin,
-                log: .active,
-                name: "Render",
-                signpostID: signpostID,
-                "Render Workflow: %{public}@",
-                String(describing: WorkflowType.self)
-            )
-        }
+        let signpostID = OSSignpostID(log: .active, object: ref)
+        os_signpost(
+            .begin,
+            log: .active,
+            name: "Render",
+            signpostID: signpostID,
+            "Render Workflow: %{public}@",
+            String(describing: WorkflowType.self)
+        )
     }
 
     static func logWorkflowFinishedRendering<WorkflowType>(
         ref: WorkflowNode<WorkflowType>,
         isRootNode: Bool
     ) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            guard shouldLogRenderTimings(
-                isRootNode: isRootNode
-            ) else { return }
+        guard shouldLogRenderTimings(
+            isRootNode: isRootNode
+        ) else { return }
 
-            let signpostID = OSSignpostID(log: .active, object: ref)
-            os_signpost(.end, log: .active, name: "Render", signpostID: signpostID)
-        }
+        let signpostID = OSSignpostID(log: .active, object: ref)
+        os_signpost(.end, log: .active, name: "Render", signpostID: signpostID)
     }
 
     // MARK: - Utilities

--- a/WorkflowCombine.podspec
+++ b/WorkflowCombine.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.15'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowCombine/Sources/*.swift'
 

--- a/WorkflowCombine/Sources/Logger.swift
+++ b/WorkflowCombine/Sources/Logger.swift
@@ -20,7 +20,6 @@ private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowCombine", category: "Worker")
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 /// Logs Worker events to OSLog
 final class WorkerLogger<WorkerType: Worker> {
     init() {}

--- a/WorkflowCombine/Sources/Publisher+Extensions.swift
+++ b/WorkflowCombine/Sources/Publisher+Extensions.swift
@@ -5,13 +5,12 @@
 //  Created by Soo Rin Park on 11/3/21.
 //
 
-#if canImport(Combine) && swift(>=5.1)
+#if canImport(Combine)
 
 import Combine
 import Foundation
 import Workflow
 
-@available(iOS 13.0, macOS 10.15, *)
 /// This is a workaround to the fact you extensions of protocols cannot have an inheritance clause.
 /// a previous solution had extending the `AnyPublisher` to conform to `AnyWorkflowConvertible`,
 /// but was limited in the fact that rendering was only available to `AnyPublisher`s.

--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-#if canImport(Combine) && swift(>=5.1)
+#if canImport(Combine)
 
 import Combine
 import Foundation
 import Workflow
 
-@available(iOS 13.0, macOS 10.15, *)
 struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowPublisher.Failure == Never {
     public typealias Output = WorkflowPublisher.Output
     public typealias State = Void

--- a/WorkflowCombine/Sources/Worker.swift
+++ b/WorkflowCombine/Sources/Worker.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if canImport(Combine) && swift(>=5.1)
+#if canImport(Combine)
 
 import Combine
 import Foundation
@@ -28,7 +28,6 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-@available(iOS 13.0, macOS 10.15, *)
 public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
@@ -43,14 +42,12 @@ public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     func isEquivalent(to otherWorker: Self) -> Bool
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension Worker {
     public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
         WorkerWorkflow(worker: self).asAnyWorkflow()
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     let worker: WorkerType
 
@@ -92,7 +89,6 @@ struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension Worker where Self: Equatable {
     public func isEquivalent(to otherWorker: Self) -> Bool {
         self == otherWorker

--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -22,8 +22,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowCombine
 
-@available(macOS 10.15, *)
-@available(iOS 13.0, *)
 extension RenderTester {
     /// Expect a `Publisher`s.
     ///

--- a/WorkflowCombine/Testing/WorkerTesting.swift
+++ b/WorkflowCombine/Testing/WorkerTesting.swift
@@ -20,8 +20,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowCombine
 
-@available(macOS 10.15, *)
-@available(iOS 13.0, *)
 extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
     ///

--- a/WorkflowCombine/TestingTests/PublisherTests.swift
+++ b/WorkflowCombine/TestingTests/PublisherTests.swift
@@ -12,7 +12,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowCombineTesting
 
-@available(iOS 13.0, macOS 10.15, *)
 class PublisherTests: XCTestCase {
     func testPublisherWorkflow() {
         TestWorkflow()

--- a/WorkflowCombine/TestingTests/TestingTests.swift
+++ b/WorkflowCombine/TestingTests/TestingTests.swift
@@ -21,7 +21,6 @@ import WorkflowCombineTesting
 import WorkflowTesting
 import XCTest
 
-@available(iOS 13.0, macOS 10.15, *)
 class WorkflowCombineTestingTests: XCTestCase {
     func test_workers() {
         let renderTester = TestWorkflow()
@@ -125,8 +124,6 @@ class WorkflowCombineTestingTests: XCTestCase {
         }
     }
 
-    #if swift(>=5.3)
-
     // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
     override func record(_ issue: XCTIssue) {
         if removeFailure(withDescription: issue.compactDescription) {
@@ -135,22 +132,8 @@ class WorkflowCombineTestingTests: XCTestCase {
             super.record(issue)
         }
     }
-
-    #else
-
-    // Otherwise, use old API
-    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-        if removeFailure(withDescription: description) {
-            // Don’t forward the failure, it was expected
-        } else {
-            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-        }
-    }
-
-    #endif
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TestWorkflow: Workflow {
     struct State: Equatable {
         enum Mode: Equatable {
@@ -185,7 +168,6 @@ private struct TestWorkflow: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TestWorker: Worker {
     typealias Output = String
     typealias WorkerPublisher = Just<Output>

--- a/WorkflowCombine/Tests/PublisherTests.swift
+++ b/WorkflowCombine/Tests/PublisherTests.swift
@@ -21,7 +21,6 @@ import WorkflowCombineTesting
 import XCTest
 @testable import WorkflowCombine
 
-@available(iOS 13.0, macOS 10.15, *)
 class PublisherTests: XCTestCase {
     func test_publisherWorkflow_usesSideEffectWithKey() {
         PublisherWorkflow(publisher: Just(1))

--- a/WorkflowCombine/Tests/WorkerTests.swift
+++ b/WorkflowCombine/Tests/WorkerTests.swift
@@ -19,7 +19,6 @@ import Workflow
 import XCTest
 @testable import WorkflowCombine
 
-@available(iOS 13.0, macOS 10.15, *)
 class WorkerTests: XCTestCase {
     func testExpectedWorker() {
         PublisherTestWorkflow(key: "123")
@@ -169,7 +168,6 @@ class WorkerTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct PublisherTestWorkflow: Workflow {
     typealias State = Int
     typealias Rendering = Int
@@ -193,7 +191,6 @@ private struct PublisherTestWorkflow: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct PublisherTestWorker: Worker {
     typealias Output = Int
     func run() -> Just<Int> { Just(1) }

--- a/WorkflowCombineTesting.podspec
+++ b/WorkflowCombineTesting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.15'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowCombine/Testing/**/*.swift'
 

--- a/WorkflowConcurrency.podspec
+++ b/WorkflowConcurrency.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.15'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowConcurrency/Sources/*.swift'
 

--- a/WorkflowConcurrency/Sources/AsyncOperationWorker.swift
+++ b/WorkflowConcurrency/Sources/AsyncOperationWorker.swift
@@ -43,7 +43,6 @@ import Workflow
 /// }
 /// ```
 
-@available(iOS 13.0, macOS 10.15, *)
 public struct AsyncOperationWorker<OutputType>: Worker {
     private let operation: () async -> OutputType
 

--- a/WorkflowConcurrency/Sources/Logger.swift
+++ b/WorkflowConcurrency/Sources/Logger.swift
@@ -20,7 +20,6 @@ private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowConcurrency", category: "Worker")
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 // Logs Worker events to OSLog
 final class WorkerLogger<WorkerType: Worker> {
     init() {}

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -25,7 +25,6 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-@available(iOS 13.0, macOS 10.15, *)
 public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
@@ -38,14 +37,12 @@ public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
     func isEquivalent(to otherWorker: Self) -> Bool
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension Worker {
     public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
         WorkerWorkflow(worker: self).asAnyWorkflow()
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     let worker: WorkerType
 
@@ -85,7 +82,6 @@ struct WorkerWorkflow<WorkerType: Worker>: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension Worker where Self: Equatable {
     public func isEquivalent(to otherWorker: Self) -> Bool {
         self == otherWorker

--- a/WorkflowConcurrency/Testing/WorkerTesting.swift
+++ b/WorkflowConcurrency/Testing/WorkerTesting.swift
@@ -20,8 +20,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowConcurrency
 
-@available(macOS 10.15, *)
-@available(iOS 13.0, *)
 extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
     ///

--- a/WorkflowConcurrency/TestingTests/TestingTests.swift
+++ b/WorkflowConcurrency/TestingTests/TestingTests.swift
@@ -20,7 +20,6 @@ import WorkflowConcurrencyTesting
 import WorkflowTesting
 import XCTest
 
-@available(iOS 13.0, macOS 10.15, *)
 class WorkflowConcurrencyTestingTests: XCTestCase {
     func test_workers() {
         let renderTester = TestWorkflow()
@@ -124,8 +123,6 @@ class WorkflowConcurrencyTestingTests: XCTestCase {
         }
     }
 
-    #if swift(>=5.3)
-
     // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
     override func record(_ issue: XCTIssue) {
         if removeFailure(withDescription: issue.compactDescription) {
@@ -134,22 +131,8 @@ class WorkflowConcurrencyTestingTests: XCTestCase {
             super.record(issue)
         }
     }
-
-    #else
-
-    // Otherwise, use old API
-    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-        if removeFailure(withDescription: description) {
-            // Don’t forward the failure, it was expected
-        } else {
-            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-        }
-    }
-
-    #endif
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TestWorkflow: Workflow {
     struct State: Equatable {
         enum Mode: Equatable {
@@ -184,7 +167,6 @@ private struct TestWorkflow: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TestWorker: Worker {
     typealias Output = String
 

--- a/WorkflowConcurrency/Tests/AsyncOperationWorkerTests.swift
+++ b/WorkflowConcurrency/Tests/AsyncOperationWorkerTests.swift
@@ -19,7 +19,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowConcurrency
 
-@available(iOS 13.0, macOS 10.15, *)
 final class AsyncOperationWorkerTests: XCTestCase {
     func testWorkerOutput() {
         let host = WorkflowHost(
@@ -127,7 +126,6 @@ final class AsyncOperationWorkerTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TestAsyncOperationWorkerWorkflow: Workflow {
     typealias State = Int
     typealias Rendering = Int

--- a/WorkflowConcurrency/Tests/WorkerTests.swift
+++ b/WorkflowConcurrency/Tests/WorkerTests.swift
@@ -19,7 +19,6 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowConcurrency
 
-@available(iOS 13.0, macOS 10.15, *)
 class WorkerTests: XCTestCase {
     func testWorkerOutput() {
         let host = WorkflowHost(
@@ -123,7 +122,6 @@ class WorkerTests: XCTestCase {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TaskTestWorkerWorkflow: Workflow {
     typealias State = Int
     typealias Rendering = Int
@@ -145,7 +143,6 @@ private struct TaskTestWorkerWorkflow: Workflow {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 private struct TaskTestWorker: Worker {
     typealias Output = Int
 

--- a/WorkflowConcurrencyTesting.podspec
+++ b/WorkflowConcurrencyTesting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.15'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowConcurrency/Testing/**/*.swift'
 

--- a/WorkflowReactiveSwift.podspec
+++ b/WorkflowReactiveSwift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.swift_versions = [WORKFLOW_SWIFT_VERSION]
   s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-  s.osx.deployment_target = '10.13'
+  s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
   s.source_files = 'WorkflowReactiveSwift/Sources/**/*.swift'
 

--- a/WorkflowReactiveSwift/Sources/Logger.swift
+++ b/WorkflowReactiveSwift/Sources/Logger.swift
@@ -38,7 +38,6 @@ private extension OSLog {
 final class WorkerLogger<WorkerType: Worker> {
     init() {}
 
-    @available(iOS 12.0, macOS 10.14, *)
     var signpostID: OSSignpostID { OSSignpostID(log: .active, object: self) }
 
     // MARK: - Workers

--- a/WorkflowReactiveSwift/Sources/Logger.swift
+++ b/WorkflowReactiveSwift/Sources/Logger.swift
@@ -43,34 +43,28 @@ final class WorkerLogger<WorkerType: Worker> {
     // MARK: - Workers
 
     func logStarted() {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(
-                .begin,
-                log: .active,
-                name: "Running",
-                signpostID: self.signpostID,
-                "Worker: %{private}@",
-                String(describing: WorkerType.self)
-            )
-        }
+        os_signpost(
+            .begin,
+            log: .active,
+            name: "Running",
+            signpostID: signpostID,
+            "Worker: %{private}@",
+            String(describing: WorkerType.self)
+        )
     }
 
     func logFinished(status: StaticString) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
-        }
+        os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
     }
 
     func logOutput() {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(
-                .event,
-                log: .active,
-                name: "Worker Event",
-                signpostID: signpostID,
-                "Event: %{private}@",
-                String(describing: WorkerType.self)
-            )
-        }
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Worker Event",
+            signpostID: signpostID,
+            "Event: %{private}@",
+            String(describing: WorkerType.self)
+        )
     }
 }

--- a/WorkflowReactiveSwift/TestingTests/TestingTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/TestingTests.swift
@@ -124,8 +124,6 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
         }
     }
 
-    #if swift(>=5.3)
-
     // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
     override func record(_ issue: XCTIssue) {
         if removeFailure(withDescription: issue.compactDescription) {
@@ -134,19 +132,6 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
             super.record(issue)
         }
     }
-
-    #else
-
-    // Otherwise, use old API
-    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-        if removeFailure(withDescription: description) {
-            // Don’t forward the failure, it was expected
-        } else {
-            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-        }
-    }
-
-    #endif
 }
 
 private struct TestWorkflow: Workflow {

--- a/WorkflowReactiveSwiftTesting.podspec
+++ b/WorkflowReactiveSwiftTesting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.swift_versions = [WORKFLOW_SWIFT_VERSION]
   s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-  s.osx.deployment_target = '10.13'
+  s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
   s.source_files = 'WorkflowReactiveSwift/Testing/**/*.swift'
 

--- a/WorkflowRxSwift.podspec
+++ b/WorkflowRxSwift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowRxSwift/Sources/**/*.swift'
 

--- a/WorkflowRxSwift/Sources/Logger.swift
+++ b/WorkflowRxSwift/Sources/Logger.swift
@@ -38,7 +38,6 @@ private extension OSLog {
 final class WorkerLogger<WorkerType: Worker> {
     init() {}
 
-    @available(iOS 12.0, macOS 10.14, *)
     var signpostID: OSSignpostID { OSSignpostID(log: .active, object: self) }
 
     // MARK: - Workers

--- a/WorkflowRxSwift/Sources/Logger.swift
+++ b/WorkflowRxSwift/Sources/Logger.swift
@@ -43,34 +43,28 @@ final class WorkerLogger<WorkerType: Worker> {
     // MARK: - Workers
 
     func logStarted() {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(
-                .begin,
-                log: .active,
-                name: "Running",
-                signpostID: self.signpostID,
-                "Worker: %{private}@",
-                String(describing: WorkerType.self)
-            )
-        }
+        os_signpost(
+            .begin,
+            log: .active,
+            name: "Running",
+            signpostID: signpostID,
+            "Worker: %{private}@",
+            String(describing: WorkerType.self)
+        )
     }
 
     func logFinished(status: StaticString) {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
-        }
+        os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
     }
 
     func logOutput() {
-        if #available(iOS 12.0, macOS 10.14, *) {
-            os_signpost(
-                .event,
-                log: .active,
-                name: "Worker Event",
-                signpostID: signpostID,
-                "Event: %{private}@",
-                String(describing: WorkerType.self)
-            )
-        }
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Worker Event",
+            signpostID: signpostID,
+            "Event: %{private}@",
+            String(describing: WorkerType.self)
+        )
     }
 }

--- a/WorkflowRxSwift/TestingTests/TestingTests.swift
+++ b/WorkflowRxSwift/TestingTests/TestingTests.swift
@@ -115,8 +115,6 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
         }
     }
 
-    #if swift(>=5.3)
-
     // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
     override func record(_ issue: XCTIssue) {
         if removeFailure(withDescription: issue.compactDescription) {
@@ -125,19 +123,6 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
             super.record(issue)
         }
     }
-
-    #else
-
-    // Otherwise, use old API
-    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-        if removeFailure(withDescription: description) {
-            // Don’t forward the failure, it was expected
-        } else {
-            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-        }
-    }
-
-    #endif
 }
 
 private struct TestWorkflow: Workflow {

--- a/WorkflowRxSwiftTesting.podspec
+++ b/WorkflowRxSwiftTesting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowRxSwift/Testing/**/*.swift'
 

--- a/WorkflowSwiftUI.podspec
+++ b/WorkflowSwiftUI.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.15'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowSwiftUI/Sources/*.swift'
 

--- a/WorkflowSwiftUI/Sources/WorkflowView.swift
+++ b/WorkflowSwiftUI/Sources/WorkflowView.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if canImport(SwiftUI) && canImport(Combine) && swift(>=5.1)
+#if canImport(SwiftUI) && canImport(Combine)
 
 import Combine
 import ReactiveSwift
@@ -44,7 +44,6 @@ import Workflow
 ///     }
 /// }
 /// ```
-@available(iOS 13.0, macOS 10.15, *)
 public struct WorkflowView<T: Workflow, Content: View>: View {
     /// The workflow implementation to use
     public var workflow: T
@@ -70,7 +69,6 @@ public struct WorkflowView<T: Workflow, Content: View>: View {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension WorkflowView where T.Output == Never {
     /// Convenience initializer for workflows with no output.
     public init(workflow: T, content: @escaping (T.Rendering) -> Content) {
@@ -78,7 +76,6 @@ extension WorkflowView where T.Output == Never {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension WorkflowView where T.Rendering == Content {
     /// Convenience initializer for workflows whose rendering type conforms to `View`.
     public init(workflow: T, onOutput: @escaping (T.Output) -> Void) {
@@ -86,7 +83,6 @@ extension WorkflowView where T.Rendering == Content {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 extension WorkflowView where T.Output == Never, T.Rendering == Content {
     /// Convenience initializer for workflows with no output whose rendering type conforms to `View`.
     public init(workflow: T) {
@@ -98,7 +94,6 @@ extension WorkflowView where T.Output == Never, T.Rendering == Content {
 // update mechanism via `updateUIViewController(_:context:)`. If we were to manage a `WorkflowHost` instance directly
 // within a SwiftUI view we would need to update the host with the updated workflow from our implementation of `body`.
 // Performing work within the body accessor is strongly discouraged, so we jump back into UIKit for a second here.
-@available(iOS 13.0, macOS 10.15, *)
 fileprivate struct IntermediateView<T: Workflow, Content: View> {
     var workflow: T
     var onOutput: (T.Output) -> Void
@@ -109,7 +104,6 @@ fileprivate struct IntermediateView<T: Workflow, Content: View> {
 
 import UIKit
 
-@available(iOS 13.0, *)
 extension IntermediateView: UIViewControllerRepresentable {
     func makeUIViewController(context: UIViewControllerRepresentableContext<IntermediateView<T, Content>>) -> WorkflowHostingViewController<T, Content> {
         WorkflowHostingViewController(workflow: workflow, content: content)
@@ -122,7 +116,6 @@ extension IntermediateView: UIViewControllerRepresentable {
     }
 }
 
-@available(iOS 13.0, *)
 fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View>: UIViewController {
     private let workflowHost: WorkflowHost<T>
     private let hostingController: UIHostingController<RootView<Content>>
@@ -277,7 +270,6 @@ fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View
 // Assigning `rootView` on a `UIHostingController` causes unwanted animated transitions.
 // To avoid this, we never change the root view, but we pass down an `ObservableObject`
 // so that we can still update the hierarchy as the workflow emits new renderings.
-@available(iOS 13.0, macOS 10.15, *)
 fileprivate final class RootViewProvider<T: View>: ObservableObject {
     @Published var view: T
 
@@ -286,7 +278,6 @@ fileprivate final class RootViewProvider<T: View>: ObservableObject {
     }
 }
 
-@available(iOS 13.0, macOS 10.15, *)
 fileprivate struct RootView<T: View>: View {
     @ObservedObject var provider: RootViewProvider<T>
 

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowTesting/Sources/**/*.swift'
 

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -65,8 +65,6 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         }
     }
 
-    #if swift(>=5.3)
-
     // Undeprecated API on Xcode 12+ (which ships with Swift 5.3)
     override func record(_ issue: XCTIssue) {
         if removeFailure(withDescription: issue.compactDescription) {
@@ -75,19 +73,6 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             super.record(issue)
         }
     }
-
-    #else
-
-    // Otherwise, use old API
-    override func recordFailure(withDescription description: String, inFile filePath: String, atLine lineNumber: Int, expected: Bool) {
-        if removeFailure(withDescription: description) {
-            // Don’t forward the failure, it was expected
-        } else {
-            super.recordFailure(withDescription: description, inFile: filePath, atLine: lineNumber, expected: expected)
-        }
-    }
-
-    #endif
 
     // MARK: Child workflows
 

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
     s.swift_versions = [WORKFLOW_SWIFT_VERSION]
     s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
-    s.osx.deployment_target = '10.13'
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
 
     s.source_files = 'WorkflowUI/Sources/**/*.swift'
 

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -165,7 +165,4 @@ fileprivate struct RootWorkflow<Rendering, Output>: Workflow {
     }
 }
 
-@available(*, deprecated, renamed: "WorkflowHostingController")
-public typealias ContainerViewController = WorkflowHostingController
-
 #endif

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -120,7 +120,6 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
         return rootViewController.preferredStatusBarUpdateAnimation
     }
 
-    @available(iOS 14.0, *)
     override public var childViewControllerForPointerLock: UIViewController? {
         return rootViewController
     }

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -104,7 +104,6 @@ public final class DescribedViewController: UIViewController {
         return currentViewController.preferredStatusBarUpdateAnimation
     }
 
-    @available(iOS 14.0, *)
     override public var childViewControllerForPointerLock: UIViewController? {
         return currentViewController
     }

--- a/version.rb
+++ b/version.rb
@@ -11,5 +11,8 @@ WORKFLOW_CONCURRENCY_VERSION ||= '2.1.1'
 # iOS deployment target
 WORKFLOW_IOS_DEPLOYMENT_TARGET ||= '14.0'
 
+# macOS deployment target
+WORKFLOW_MACOS_DEPLOYMENT_TARGET ||= '10.15'
+
 # Required Swift version
 WORKFLOW_SWIFT_VERSION ||= '5.7'


### PR DESCRIPTION
### Description

after bumping our min iOS version to 14 & swift version to 5.7, did a pass to remove some unneeded annotations, and other minor cleanup.

- remove unneeded `#if swift(...)` and `@available(iOS, ....)` conditional compilation statements
- remove deprecated typealias of `ContainerViewController`
- extract target macOS deploy target to versions.rb & standardize to 10.15

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
