### PR TITLE
[feat]: add primary associated types to more protocols

### DIFF
--- a/Workflow/Sources/AnyWorkflowConvertible.swift
+++ b/Workflow/Sources/AnyWorkflowConvertible.swift
@@ -16,7 +16,7 @@
 
 /// Conforming types can be converted into `AnyWorkflow` values, allowing them to participate
 /// in a workflow hierarchy.
-public protocol AnyWorkflowConvertible {
+public protocol AnyWorkflowConvertible<Rendering, Output> {
     /// The rendering type of this type's `AnyWorkflow` representation
     associatedtype Rendering
 

--- a/Workflow/Sources/WorkflowAction.swift
+++ b/Workflow/Sources/WorkflowAction.swift
@@ -16,7 +16,7 @@
 
 /// Conforming types represent an action that advances a workflow. When applied, an action emits the next
 /// state and / or output for the workflow.
-public protocol WorkflowAction {
+public protocol WorkflowAction<WorkflowType> {
     /// The type of workflow that this action can be applied to.
     associatedtype WorkflowType: Workflow
 

--- a/WorkflowCombine/Sources/Worker.swift
+++ b/WorkflowCombine/Sources/Worker.swift
@@ -28,7 +28,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
     associatedtype WorkerPublisher: Publisher where

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -25,7 +25,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 

--- a/WorkflowReactiveSwift/Sources/Worker.swift
+++ b/WorkflowReactiveSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 

--- a/WorkflowRxSwift/Sources/Worker.swift
+++ b/WorkflowRxSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
     /// The type of output events returned by this worker.
     associatedtype Output
 


### PR DESCRIPTION
### Description

since we've bumped to swift 5.7, let's add primary associated types in some more places

- adds `<Rendering, Output>` PAT to `AnyWorkflowConvertible`
- adds `<WorkflowType>` PAT to `WorkflowAction`
- adds `<Output>` to the various definitions of `Worker`

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
