### PR TITLE
[fix]: use weak reference to internal sinks when vending to clients

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -198,12 +198,11 @@ extension WorkflowNode.SubtreeManager {
         func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action: WorkflowAction, WorkflowType == Action.WorkflowType {
             let reusableSink = sinkStore.findOrCreate(actionType: Action.self)
 
-            let signpostRef = SignpostRef()
+            let sink = Sink<Action> { [weak reusableSink] action in
+                WorkflowLogger.logSinkEvent(ref: SignpostRef(), action: action)
 
-            let sink = Sink<Action> { action in
-                WorkflowLogger.logSinkEvent(ref: signpostRef, action: action)
-
-                reusableSink.handle(action: action)
+                // use a weak reference as we'd like control over the lifetime
+                reusableSink?.handle(action: action)
             }
 
             return sink

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -23,7 +23,7 @@ extension WorkflowNode {
         internal var onUpdate: ((Output) -> Void)?
 
         /// Sinks from the outside world (i.e. UI)
-        private var eventPipes: [EventPipe] = []
+        internal private(set) var eventPipes: [EventPipe] = []
 
         /// Reusable sinks from the previous render pass
         private var previousSinks: [ObjectIdentifier: AnyReusableSink] = [:]
@@ -290,7 +290,7 @@ extension WorkflowNode.SubtreeManager {
 // MARK: - EventPipe
 
 extension WorkflowNode.SubtreeManager {
-    fileprivate final class EventPipe {
+    internal final class EventPipe {
         var validationState: ValidationState
         enum ValidationState {
             case preparing

--- a/Workflow/Tests/SubtreeManagerTests.swift
+++ b/Workflow/Tests/SubtreeManagerTests.swift
@@ -243,6 +243,26 @@ final class SubtreeManagerTests: XCTestCase {
         XCTAssertEqual(manager.sideEffectLifetimes.count, 1)
         XCTAssertEqual(manager.sideEffectLifetimes.keys.first, "key-2")
     }
+
+    func test_eventPipes_notRetainedByExternalSinks() {
+        weak var weakEventPipe: WorkflowNode<TestWorkflow>.SubtreeManager.EventPipe?
+        var externalSink: Sink<TestWorkflow.Event>?
+        autoreleasepool {
+            let manager = WorkflowNode<TestWorkflow>.SubtreeManager()
+
+            manager.render { context in
+                externalSink = context.makeSink(of: TestWorkflow.Event.self)
+            }
+
+            weakEventPipe = manager.eventPipes.last
+
+            XCTAssertEqual(manager.eventPipes.count, 1)
+            XCTAssertNotNil(weakEventPipe)
+        }
+
+        XCTAssertNotNil(externalSink)
+        XCTAssertNil(weakEventPipe)
+    }
 }
 
 private struct TestViewModel {


### PR DESCRIPTION
### Description

previously we would allow a strong reference to the internal `ReusableSink` to be captured by the `Sink` types that are vended to clients. this meant that events sent into such 'external' sinks would still propagate through the event handling machinery a bit before realizing that the backing workflow node to which they were destined was no longer around. by using weak references we can prevent extending the life of the internal sinks (and underlying EventPipe) unnecessarily in such cases.

- make `ReusableSink` captures `weak` when vending to the 'outside world'
- update various access control values to facilitate testing this behavior

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
