### PR TITLE
[chore]: refactor some internal actions to use existential any

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -114,7 +114,7 @@ extension WorkflowNode {
 
 extension WorkflowNode.SubtreeManager {
     enum Output {
-        case update(AnyWorkflowAction<WorkflowType>, source: WorkflowUpdateDebugInfo.Source)
+        case update(any WorkflowAction<WorkflowType>, source: WorkflowUpdateDebugInfo.Source)
         case childDidUpdate(WorkflowUpdateDebugInfo)
     }
 }
@@ -175,7 +175,7 @@ extension WorkflowNode.SubtreeManager {
                 /// Update the existing child
                 existing.update(
                     workflow: workflow,
-                    outputMap: { AnyWorkflowAction(outputMap($0)) },
+                    outputMap: { outputMap($0) },
                     eventPipe: eventPipe
                 )
                 child = existing
@@ -184,7 +184,7 @@ extension WorkflowNode.SubtreeManager {
                 /// This spins up a new workflow node, etc to host the newly created child.
                 child = ChildWorkflow<Child>(
                     workflow: workflow,
-                    outputMap: { AnyWorkflowAction(outputMap($0)) },
+                    outputMap: { outputMap($0) },
                     eventPipe: eventPipe
                 )
             }
@@ -272,7 +272,7 @@ extension WorkflowNode.SubtreeManager {
 
     fileprivate final class ReusableSink<Action: WorkflowAction>: AnyReusableSink where Action.WorkflowType == WorkflowType {
         func handle(action: Action) {
-            let output = Output.update(AnyWorkflowAction(action), source: .external)
+            let output = Output.update(action, source: .external)
 
             if case .pending = eventPipe.validationState {
                 // Workflow is currently processing an `event`.
@@ -387,9 +387,13 @@ extension WorkflowNode.SubtreeManager {
 
     fileprivate final class ChildWorkflow<W: Workflow>: AnyChildWorkflow {
         private let node: WorkflowNode<W>
-        private var outputMap: (W.Output) -> AnyWorkflowAction<WorkflowType>
+        private var outputMap: (W.Output) -> any WorkflowAction<WorkflowType>
 
-        init(workflow: W, outputMap: @escaping (W.Output) -> AnyWorkflowAction<WorkflowType>, eventPipe: EventPipe) {
+        init(
+            workflow: W,
+            outputMap: @escaping (W.Output) -> any WorkflowAction<WorkflowType>,
+            eventPipe: EventPipe
+        ) {
             self.outputMap = outputMap
             self.node = WorkflowNode<W>(workflow: workflow)
 
@@ -408,7 +412,11 @@ extension WorkflowNode.SubtreeManager {
             return node.render(isRootNode: false)
         }
 
-        func update(workflow: W, outputMap: @escaping (W.Output) -> AnyWorkflowAction<WorkflowType>, eventPipe: EventPipe) {
+        func update(
+            workflow: W,
+            outputMap: @escaping (W.Output) -> any WorkflowAction<WorkflowType>,
+            eventPipe: EventPipe
+        ) {
             self.outputMap = outputMap
             self.eventPipe = eventPipe
             node.update(workflow: workflow)

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -48,9 +48,19 @@ final class WorkflowNode<WorkflowType: Workflow> {
         let output: Output
 
         switch subtreeOutput {
-        case .update(let event, let source):
-            /// Apply the update to the current state
-            let outputEvent = event.apply(toState: &state)
+        case .update(let action, let source):
+
+            /// 'Opens' the existential `any WorkflowAction<WorkflowType>` value
+            /// allowing the underlying conformance to be applied to the Workflow's State
+            func openAndApply<A: WorkflowAction>(
+                _ action: A,
+                to state: inout WorkflowType.State
+            ) -> WorkflowType.Output? where A.WorkflowType == WorkflowType {
+                /// Apply the update to the current state
+                action.apply(toState: &state)
+            }
+
+            let outputEvent = openAndApply(action, to: &state)
 
             /// Finally, we tell the outside world that our state has changed (including an output event if it exists).
             output = Output(

--- a/Workflow/Tests/SubtreeManagerTests.swift
+++ b/Workflow/Tests/SubtreeManagerTests.swift
@@ -72,7 +72,7 @@ final class SubtreeManagerTests: XCTestCase {
         manager.onUpdate = {
             switch $0 {
             case .update(let event, _):
-                events.append(event)
+                events.append(AnyWorkflowAction(event))
             default:
                 break
             }


### PR DESCRIPTION
### Description

since we now have access to primary associated types, there are a couple places internally where it likely makes sense to leverage the language's 'existential' boxing facilities over our own. to start, we'll update a couple places that pass an `AnyWorkflowAction<T>` that can now be replaced with `any WorkflowAction<T>`.

additional comments inline.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
