### PR TITLE
[release]: bump version to 2.2.0 & remove separate concurrency version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,11 +17,7 @@ For Squares, membership is managed through the `Workflow Swift Owners` registry 
 
 > ⚠️ [Optional] To avoid possible headaches when publishing podspecs, validation can be performed before updating the Workflow version number(s). To do this, run the following in the root directory of this repo:
 > ```bash
-> bundle exec pod lib lint Workflow.podspec WorkflowTesting.podspec WorkflowReactiveSwift.podspec WorkflowUI.podspec WorkflowRxSwift.podspec WorkflowReactiveSwiftTesting.podspec WorkflowRxSwiftTesting.podspec WorkflowSwiftUI.podspec WorkflowCombine.podspec WorkflowCombineTesting.podspec ViewEnvironment.podspec
-> ```
-> And then run a similar command to check the `WorkflowConcurrency*` libraries. These specs will fail default validation as their version differs from the git tag used, so run the command with the `--allow-warnings` option, and check that only that warning is produced.
-> ```bash
-> bundle exec pod lib lint WorkflowConcurrency.podspec WorkflowConcurrencyTesting.podspec --allow-warnings
+> bundle exec pod lib lint Workflow.podspec ViewEnvironment.podspec WorkflowTesting.podspec WorkflowReactiveSwift.podspec WorkflowUI.podspec WorkflowRxSwift.podspec WorkflowReactiveSwiftTesting.podspec WorkflowRxSwiftTesting.podspec WorkflowSwiftUI.podspec WorkflowCombine.podspec WorkflowCombineTesting.podspec WorkflowConcurrency.podspec WorkflowConcurrencyTesting.podspec
 > ```
 
 1. Update `VERSION` file based on [`semver`](https://semver.org/).
@@ -48,9 +44,6 @@ For Squares, membership is managed through the `Workflow Swift Owners` registry 
     bundle exec pod trunk push WorkflowSwiftUI.podspec --synchronous
     bundle exec pod trunk push WorkflowCombine.podspec --synchronous
     bundle exec pod trunk push WorkflowCombineTesting.podspec --synchronous
-
-    # Note: If the following fail due to a validation warning about their version number not matching the git tag,
-    # it is safe to ignore, and publish anyway by adding the `--allow-warnings` option to the command.
     bundle exec pod trunk push WorkflowConcurrency.podspec --synchronous
     bundle exec pod trunk push WorkflowConcurrencyTesting.podspec --synchronous
     ```

--- a/WorkflowConcurrency.podspec
+++ b/WorkflowConcurrency.podspec
@@ -2,13 +2,13 @@ require_relative('version')
 
 Pod::Spec.new do |s|
     s.name         = 'WorkflowConcurrency'
-    s.version      = WORKFLOW_CONCURRENCY_VERSION
+    s.version      = WORKFLOW_VERSION
 
     s.summary      = 'Infrastructure for Concurrency-powered Workers'
     s.homepage     = 'https://www.github.com/square/workflow-swift'
     s.license      = 'Apache License, Version 2.0'
     s.author       = 'Square'
-    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{WORKFLOW_VERSION}" }
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
     # 1.7 is needed for `swift_versions` support
     s.cocoapods_version = '>= 1.7.0'
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
     s.source_files = 'WorkflowConcurrency/Sources/*.swift'
 
-    s.dependency 'Workflow', "#{WORKFLOW_VERSION}"
+    s.dependency 'Workflow', "#{s.version}"
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 

--- a/WorkflowConcurrencyTesting.podspec
+++ b/WorkflowConcurrencyTesting.podspec
@@ -2,12 +2,12 @@ require_relative('version')
 
 Pod::Spec.new do |s|
     s.name         = 'WorkflowConcurrencyTesting'
-    s.version      = WORKFLOW_CONCURRENCY_VERSION
+    s.version      = WORKFLOW_VERSION
     s.summary      = 'Infrastructure for Concurrency-powered Workers'
     s.homepage     = 'https://www.github.com/square/workflow-swift'
     s.license      = 'Apache License, Version 2.0'
     s.author       = 'Square'
-    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{WORKFLOW_VERSION}" }
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "v#{s.version}" }
 
     # 1.7 is needed for `swift_versions` support
     s.cocoapods_version = '>= 1.7.0'
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
 
     s.source_files = 'WorkflowConcurrency/Testing/**/*.swift'
 
-    s.dependency 'Workflow', "#{WORKFLOW_VERSION}"
+    s.dependency 'Workflow', "#{s.version}"
     s.dependency 'WorkflowConcurrency', "#{s.version}"
-    s.dependency 'WorkflowTesting', "#{WORKFLOW_VERSION}"
+    s.dependency 'WorkflowTesting', "#{s.version}"
 
     s.framework = 'XCTest'
 

--- a/version.rb
+++ b/version.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 # The primary version number for Workflow-related pods
-WORKFLOW_VERSION ||= '1.3.1'
-
-# The version number for the WorkflowConcurrency library which
-# currently differs from others due to a source-breaking change
-# TODO: unify version numbers on next Workflow major release
-WORKFLOW_CONCURRENCY_VERSION ||= '2.1.1'
+WORKFLOW_VERSION ||= '2.2.0'
 
 # iOS deployment target
 WORKFLOW_IOS_DEPLOYMENT_TARGET ||= '14.0'


### PR DESCRIPTION
### Description

(major) version bump and minor cleanup

- remove WORKFLOW_CONCURRENCY_VERSION & related code/docs
- bump WORKFLOW_VERSION to 2.2.0 (to align with what the concurrency version would have been)

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
