### PR TITLE
Expose AnyScreen.wrappedScreen for inspection

### DIFF
--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -20,10 +20,7 @@ import UIKit
 
 public struct AnyScreen: Screen {
     /// The original screen, retained for debugging
-    internal let wrappedScreen: Screen
-
-    /// Stored getter for the wrapped screen’s view controller description
-    private let _viewControllerDescription: (ViewEnvironment) -> ViewControllerDescription
+    public let wrappedScreen: Screen
 
     public init<T: Screen>(_ screen: T) {
         if let anyScreen = screen as? AnyScreen {
@@ -31,12 +28,10 @@ public struct AnyScreen: Screen {
             return
         }
         self.wrappedScreen = screen
-        self._viewControllerDescription = screen.viewControllerDescription(environment:)
     }
 
     public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-        // Passed straight through
-        return _viewControllerDescription(environment)
+        return wrappedScreen.viewControllerDescription(environment: environment)
     }
 }
 


### PR DESCRIPTION
When using observation APIs from https://github.com/square/workflow-swift/pull/168 encountering an instance of `AnyScreen` leaves you with no options for retrieving the underlying type and doing something with it.

```swift
func workflowWillRender<WorkflowType: Workflow>(
    _ workflow: WorkflowType,
    state: WorkflowType.State,
    session: WorkflowSession
) -> ((WorkflowType.Rendering) -> Void)? {
    return { (rendering: WorkflowType.Rendering) -> Void in
        guard let screen = rendering as? Screen else {
            return
        }

        if screen is AnyScreen {
            // ?? Can't do anything here since we cannot access `.wrappedScreen`
        }
    }
}        
```

This can also come up in `ScreenViewController.update(screen:environment:)` when using Screen types that wrap other screen values, such as [BackStackScreen](https://github.com/square/workflow-swift/blob/dbdcb967b4c83cdc283b4bfd672c60f4398bd80b/Samples/BackStackContainer/Sources/BackStackScreen.swift#L19) if typed as `BackStackScreen<AnyScreen>`.

 This exposes the wrapped value so it can be accessed and casted as desired.

```swift

struct MyScreen: Screen {
    let objectCount: Int
}

func workflowWillRender<WorkflowType: Workflow>(
    _ workflow: WorkflowType,
    state: WorkflowType.State,
    session: WorkflowSession
) -> ((WorkflowType.Rendering) -> Void)? {
    return { (rendering: WorkflowType.Rendering) -> Void in
        guard let screen = rendering as? Screen else {
            return
        }

        // First wrap in AnyScreen if not one already. It won't get nested
        switch screen.asAnyScreen().wrappedScreen {
        case let typed as MyScreen:
            print("Workflow \(workflow) produced screen \(MyScreen.self) with object count \(typed.objectCount)")
            if typed.objectCount > 100 {
                Logger.instance.logError("Produced rendering with oversized object count: \(typed.objectCount)")
            }
        case let typed as SomeOtherScreen:
            print("Workflow \(workflow) produced unexpected screen \(typed)")
        }
    }
}
```


## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
