### PR TITLE
[task]: attempt to improve debugging info for AnyWorkflowAction

### DIFF
--- a/Workflow/Sources/WorkflowAction.swift
+++ b/Workflow/Sources/WorkflowAction.swift
@@ -39,6 +39,9 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
     /// The underlying type-erased `WorkflowAction`
     public let base: Any
 
+    /// True iff the underlying `apply` implementation is defined by a closure vs wrapping a `WorkflowAction` conformance
+    public let isClosureBased: Bool
+
     /// Creates a type-erased workflow action that wraps the given instance.
     ///
     /// - Parameter base: A workflow action to wrap.
@@ -49,6 +52,7 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
         }
         self._apply = { return base.apply(toState: &$0) }
         self.base = base
+        self.isClosureBased = false
     }
 
     /// Creates a type-erased workflow action with the given `apply` implementation.
@@ -72,6 +76,7 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
     fileprivate init(closureAction: ClosureAction<WorkflowType>) {
         self._apply = closureAction.apply(toState:)
         self.base = closureAction
+        self.isClosureBased = true
     }
 
     public func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {

--- a/Workflow/Sources/WorkflowAction.swift
+++ b/Workflow/Sources/WorkflowAction.swift
@@ -56,11 +56,12 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
     /// - Parameter apply: the apply function for the resulting action.
     public init(
         _ apply: @escaping (inout WorkflowType.State) -> WorkflowType.Output?,
-        file: String = #file, line: Int = #line
+        fileID: StaticString = #fileID,
+        line: UInt = #line
     ) {
         let closureAction = ClosureAction<WorkflowType>(
             _apply: apply,
-            file: file,
+            fileID: fileID,
             line: line
         )
         self.init(closureAction: closureAction)
@@ -104,16 +105,16 @@ extension AnyWorkflowAction {
 /// defined via a closure.
 struct ClosureAction<WorkflowType: Workflow>: WorkflowAction {
     private let _apply: (inout WorkflowType.State) -> WorkflowType.Output?
-    let file: String
-    let line: Int
+    let fileID: StaticString
+    let line: UInt
 
     init(
         _apply: @escaping (inout WorkflowType.State) -> WorkflowType.Output?,
-        file: String,
-        line: Int
+        fileID: StaticString,
+        line: UInt
     ) {
         self._apply = _apply
-        self.file = file
+        self.fileID = fileID
         self.line = line
     }
 
@@ -124,6 +125,6 @@ struct ClosureAction<WorkflowType: Workflow>: WorkflowAction {
 
 extension ClosureAction: CustomStringConvertible {
     var description: String {
-        "\(Self.self)(file: \(file), line: \(line))"
+        "\(Self.self)(fileID: \(fileID), line: \(line))"
     }
 }

--- a/Workflow/Tests/AnyWorkflowActionTests.swift
+++ b/Workflow/Tests/AnyWorkflowActionTests.swift
@@ -35,14 +35,14 @@ final class AnyWorkflowActionTests: XCTestCase {
         }
 
         do {
-            let file = #file
-            let line = #line + 1 // must match line # the initializer is on
-            let erased = AnyWorkflowAction<ExampleWorkflow> { _ in
+            let fileID: StaticString = #fileID
+            // must match line # the initializer is on
+            let line: UInt = #line; let erased = AnyWorkflowAction<ExampleWorkflow> { _ in
                 nil
             }
 
             let closureAction = try XCTUnwrap(erased.base as? ClosureAction<ExampleWorkflow>)
-            XCTAssertEqual(closureAction.file, file)
+            XCTAssertEqual("\(closureAction.fileID)", "\(fileID)")
             XCTAssertEqual(closureAction.line, line)
         }
     }

--- a/Workflow/Tests/AnyWorkflowActionTests.swift
+++ b/Workflow/Tests/AnyWorkflowActionTests.swift
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+@testable import Workflow
+
+final class AnyWorkflowActionTests: XCTestCase {
+    func testRetainsBaseActionTypeInfo() {
+        let action = ExampleAction()
+        let erased = AnyWorkflowAction(action)
+
+        XCTAssertEqual(action, erased.base as? ExampleAction)
+    }
+
+    func testRetainsClosureActionTypeInfo() throws {
+        do {
+            let erased = AnyWorkflowAction<ExampleWorkflow> { _ in
+                nil
+            }
+
+            XCTAssertNotNil(erased.base as? ClosureAction<ExampleWorkflow>)
+        }
+
+        do {
+            let file = #file
+            let line = #line + 1 // must match line # the initializer is on
+            let erased = AnyWorkflowAction<ExampleWorkflow> { _ in
+                nil
+            }
+
+            let closureAction = try XCTUnwrap(erased.base as? ClosureAction<ExampleWorkflow>)
+            XCTAssertEqual(closureAction.file, file)
+            XCTAssertEqual(closureAction.line, line)
+        }
+    }
+
+    func testMultipleErasure() {
+        // standard init
+        do {
+            let action = ExampleAction()
+            let erasedOnce = AnyWorkflowAction(action)
+            let erasedTwice = AnyWorkflowAction(erasedOnce)
+
+            XCTAssertEqual(
+                erasedOnce.base as? ExampleAction,
+                erasedTwice.base as? ExampleAction
+            )
+        }
+
+        // closure init
+        do {
+            let action = AnyWorkflowAction<ExampleWorkflow> { _ in nil }
+            let erasedAgain = AnyWorkflowAction(action)
+
+            XCTAssertEqual(
+                "\(action.base.self)",
+                "\(erasedAgain.base.self)"
+            )
+        }
+    }
+
+    func testApplyForwarding() {
+        var log: [String] = []
+        let action = ObservableExampleAction {
+            log.append("action invoked")
+        }
+
+        let erased = AnyWorkflowAction(action)
+
+        XCTAssertEqual(log, [])
+
+        var state: Void = ()
+        _ = erased.apply(toState: &state)
+
+        XCTAssertEqual(log, ["action invoked"])
+    }
+}
+
+private struct ExampleWorkflow: Workflow {
+    typealias State = Void
+    typealias Output = Never
+    typealias Rendering = Void
+
+    func render(state: Void, context: RenderContext<ExampleWorkflow>) {}
+}
+
+private struct ExampleAction: WorkflowAction, Equatable {
+    typealias WorkflowType = ExampleWorkflow
+
+    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
+        return nil
+    }
+}
+
+private struct ObservableExampleAction: WorkflowAction {
+    typealias WorkflowType = ExampleWorkflow
+
+    var block: () -> Void = {}
+
+    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
+        block()
+        return nil
+    }
+}

--- a/Workflow/Tests/AnyWorkflowActionTests.swift
+++ b/Workflow/Tests/AnyWorkflowActionTests.swift
@@ -87,6 +87,14 @@ final class AnyWorkflowActionTests: XCTestCase {
 
         XCTAssertEqual(log, ["action invoked"])
     }
+
+    func testIsClosureBased() {
+        let nonClosureBased = AnyWorkflowAction(ExampleAction())
+        XCTAssertFalse(nonClosureBased.isClosureBased)
+
+        let closureBased = AnyWorkflowAction<ExampleWorkflow> { _ in .none }
+        XCTAssertTrue(closureBased.isClosureBased)
+    }
 }
 
 private struct ExampleWorkflow: Workflow {

--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -20,18 +20,18 @@ import UIKit
 
 public struct AnyScreen: Screen {
     /// The original screen, retained for debugging
-    public let base: Screen
+    public let wrappedScreen: Screen
 
     public init<T: Screen>(_ screen: T) {
         if let anyScreen = screen as? AnyScreen {
             self = anyScreen
             return
         }
-        self.base = screen
+        self.wrappedScreen = screen
     }
 
     public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-        return base.viewControllerDescription(environment: environment)
+        return wrappedScreen.viewControllerDescription(environment: environment)
     }
 }
 

--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -20,18 +20,18 @@ import UIKit
 
 public struct AnyScreen: Screen {
     /// The original screen, retained for debugging
-    public let wrappedScreen: Screen
+    public let base: Screen
 
     public init<T: Screen>(_ screen: T) {
         if let anyScreen = screen as? AnyScreen {
             self = anyScreen
             return
         }
-        self.wrappedScreen = screen
+        self.base = screen
     }
 
     public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-        return wrappedScreen.viewControllerDescription(environment: environment)
+        return base.viewControllerDescription(environment: environment)
     }
 }
 


### PR DESCRIPTION
### Description

this change adds introspection capabilities for what i believe is the final type-eraser that lacks them – AnyWorkflowAction. changes include:

- adds a public `base` property on `AnyWorkflowAction` to expose the underlying action as an `Any` value
- adds an internal utility type, `ClosureAction`, for closure-based `AnyWorkflowAction`s. the intent is to provide the possibility of improved telemetry information when logging such actions.
- adds a new public property `isClosureBased` on `AnyWorkflowAction` to differentiate instances that forward to an underlying wrapped action vs those whose implementations are defined by a closure.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
