### PR TITLE
Conditionally conform AdaptedEnvironmentScreen to Screen, based on its content

### DIFF
--- a/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
+++ b/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
@@ -30,7 +30,7 @@ import ViewEnvironment
 ///     .adaptedEnvironment(keyPath: \.myValue, to: newValue)
 /// ```
 ///
-public struct AdaptedEnvironmentScreen<Content: Screen>: Screen {
+public struct AdaptedEnvironmentScreen<Content> {
     /// The screen wrapped by this screen.
     public var wrapped: Content
 
@@ -79,9 +79,9 @@ public struct AdaptedEnvironmentScreen<Content: Screen>: Screen {
     ) {
         self.init(wrapping: screen, adapting: { $0[keyPath: keyPath] = value })
     }
+}
 
-    // MARK: Screen
-
+extension AdaptedEnvironmentScreen: Screen where Content: Screen {
     public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         var environment = environment
 


### PR DESCRIPTION
Based on the work done in https://github.com/square/workflow-swift/pull/106, so that way you can do an adaptation before, eg you map something to a `Screen`.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
