### PR TITLE
Expose WorkflowHost.rendering from WorkflowHostingController

### DIFF
--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -27,6 +27,11 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
         return workflowHost.output
     }
 
+    /// Represents the `Rendering` produced by the hosted workflow.
+    public var rendering: Property<ScreenType> {
+        return workflowHost.rendering
+    }
+
     private(set) var rootViewController: UIViewController
 
     private let workflowHost: WorkflowHost<AnyWorkflow<ScreenType, Output>>

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -154,6 +154,25 @@ class WorkflowHostingControllerTests: XCTestCase {
 
         disposable?.dispose()
     }
+
+    func test_workflow_render_causes_container_render() {
+        let (signal, observer) = Signal<Int, Never>.pipe()
+        let workflow = SubscribingWorkflow(subscription: signal)
+        let container = WorkflowHostingController(workflow: workflow)
+
+        let expectation = XCTestExpectation(description: "Render")
+
+        let disposable = container.rendering.signal.observeValues { rendering in
+            XCTAssertEqual(rendering.string, "7")
+            expectation.fulfill()
+        }
+
+        observer.send(value: 7)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        disposable?.dispose()
+    }
 }
 
 fileprivate struct SubscribingWorkflow: Workflow {


### PR DESCRIPTION
Currently the only way to watch a rendering over time when using a `WorkflowHostingController` is by using a `WorkflowObserver`. This change makes it much easier to observe the rendering by using the existing `WorkflowHost` functionality.


## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
