### PR TITLE
WIP UI Observation with typed events

### DIFF
--- a/WorkflowUI/Sources/Observation/DescribedViewControllerEvents.swift
+++ b/WorkflowUI/Sources/Observation/DescribedViewControllerEvents.swift
@@ -1,0 +1,29 @@
+
+import ViewEnvironment
+
+public protocol DescribedViewControllerEvent {
+    var viewController: DescribedViewController { get }
+}
+
+public struct DescribedViewControllerWillLayoutSubviews: DescribedViewControllerEvent {
+    public let viewController: DescribedViewController
+}
+
+public struct DescribedViewControllerDidLayoutSubviews: DescribedViewControllerEvent {
+    public let viewController: DescribedViewController
+}
+
+public struct DescribedViewControllerWillAppear: DescribedViewControllerEvent {
+    public let viewController: DescribedViewController
+    public let animated: Bool
+}
+
+public struct DescribedViewControllerDidAppear: DescribedViewControllerEvent {
+    public let viewController: DescribedViewController
+    public let animated: Bool
+}
+
+public struct DescribedViewControllerDidUpdate: DescribedViewControllerEvent {
+    public let viewController: DescribedViewController
+    public let viewDescription: ViewControllerDescription
+}

--- a/WorkflowUI/Sources/Observation/ScreenViewControllerEvents.swift
+++ b/WorkflowUI/Sources/Observation/ScreenViewControllerEvents.swift
@@ -1,0 +1,32 @@
+
+import ViewEnvironment
+
+public protocol ScreenViewControllerEvent<ScreenType> {
+    associatedtype ScreenType: Screen
+
+    var viewController: ScreenViewController<ScreenType> { get }
+}
+
+public struct ScreenWillLayoutSubviews<ScreenType: Screen>: ScreenViewControllerEvent {
+    public let viewController: ScreenViewController<ScreenType>
+}
+
+public struct ScreenDidLayoutSubviews<ScreenType: Screen>: ScreenViewControllerEvent {
+    public let viewController: ScreenViewController<ScreenType>
+}
+
+public struct ScreenWillAppear<ScreenType: Screen>: ScreenViewControllerEvent {
+    public let viewController: ScreenViewController<ScreenType>
+    public let animated: Bool
+}
+
+public struct ScreenDidAppear<ScreenType: Screen>: ScreenViewControllerEvent {
+    public let viewController: ScreenViewController<ScreenType>
+    public let animated: Bool
+}
+
+public struct ScreenDidUpdate<ScreenType: Screen>: ScreenViewControllerEvent {
+    public let viewController: ScreenViewController<ScreenType>
+    public let previousScreen: ScreenType
+    public let previousViewEnvironment: ViewEnvironment
+}

--- a/WorkflowUI/Sources/Observation/WorkflowUIObserver.swift
+++ b/WorkflowUI/Sources/Observation/WorkflowUIObserver.swift
@@ -1,0 +1,98 @@
+
+#if canImport(UIKit)
+
+import Foundation
+import UIKit
+import ViewEnvironment
+import Workflow
+@_spi(WorkflowGlobalObservation) import Workflow
+
+public protocol WorkflowUIObserver {
+    func observeScreenEvent<EventType: ScreenViewControllerEvent, ScreenType: Screen>(_ event: EventType) where EventType.ScreenType == ScreenType
+
+    func observeDescribedViewControllerEvent<EventType: DescribedViewControllerEvent>(_ event: EventType)
+}
+
+public extension WorkflowUIObserver {
+    func observeScreenEvent<EventType: ScreenViewControllerEvent, ScreenType: Screen>(_ event: EventType) where EventType.ScreenType == ScreenType {}
+
+    func observeDescribedViewControllerEvent<EventType: DescribedViewControllerEvent>(_ event: EventType) {}
+}
+
+final class ChainedWorkflowUIObserver: WorkflowUIObserver {
+    let observers: [WorkflowUIObserver]
+
+    init(observers: [WorkflowUIObserver]) {
+        self.observers = observers
+    }
+
+    func observeScreenEvent<EventType: ScreenViewControllerEvent, ScreenType: Screen>(_ event: EventType) where EventType.ScreenType == ScreenType {
+        for observer in observers {
+            observer.observeScreenEvent(event)
+        }
+    }
+
+    func observeDescribedViewControllerEvent<EventType: DescribedViewControllerEvent>(_ event: EventType) {
+        for observer in observers {
+            observer.observeDescribedViewControllerEvent(event)
+        }
+    }
+}
+
+extension Array where Element == WorkflowUIObserver {
+    func chained() -> WorkflowUIObserver {
+        if count == 1 {
+            // no wrapping needed if a single element
+            return self[0]
+        } else {
+            return ChainedWorkflowUIObserver(observers: self)
+        }
+    }
+}
+
+// MARK: - Global Observation (SPI)
+
+@_spi(WorkflowGlobalObservation)
+public protocol UIObserversInterceptor {
+    /// Provides a single access point to provide the final list of `WorkflowObserver` used by the runtime.
+    /// This may be used to ensure a known set of observers is used in a particular order for all
+    /// `WorkflowHost`s created over the life of a program.
+    /// - Parameter initialObservers: Array of observers passed to a `WorkflowHost` constructor
+    /// - Returns: The array of `WorkflowObserver`s to be used by the `WorkflowHost`
+    func workflowObservers(for initialObservers: [WorkflowUIObserver]) -> [WorkflowUIObserver]
+}
+
+@_spi(WorkflowGlobalObservation)
+extension UIObserversInterceptor {
+    public func chainedObservers(for initialObservers: [WorkflowUIObserver]) -> WorkflowUIObserver {
+        return workflowObservers(for: initialObservers).chained()
+    }
+}
+
+@_spi(WorkflowGlobalObservation)
+extension WorkflowObservation {
+    private static var _sharedUIInterceptorStorage: UIObserversInterceptor = NoOpUIObserversInterceptor()
+
+    /// The `DefaultObserversProvider` used by all runtimes.
+    public static var sharedUIObserversInterceptor: UIObserversInterceptor! {
+        get {
+            _sharedUIInterceptorStorage
+        }
+        set {
+            guard newValue != nil else {
+                _sharedUIInterceptorStorage = NoOpUIObserversInterceptor()
+                return
+            }
+
+            _sharedUIInterceptorStorage = newValue
+        }
+    }
+
+    private struct NoOpUIObserversInterceptor: UIObserversInterceptor {
+        func workflowObservers(for initialObservers: [WorkflowUIObserver]) -> [WorkflowUIObserver] {
+            initialObservers
+        }
+    }
+}
+
+#endif

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -17,6 +17,7 @@
 #if canImport(UIKit)
 
 import UIKit
+@_spi(WorkflowGlobalObservation) import Workflow
 
 /// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
 /// given screen type.
@@ -44,6 +45,16 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
 
     public private(set) final var environment: ViewEnvironment
 
+    public var observer: WorkflowUIObserver?
+
+    private var chainedObserver: WorkflowUIObserver {
+        if let observer {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [observer])
+        } else {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [])
+        }
+    }
+
     public required init(screen: ScreenType, environment: ViewEnvironment) {
         self.screen = screen
         self.environment = environment
@@ -55,12 +66,33 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override open func viewWillAppear(_ animated: Bool) {
+        chainedObserver.observeScreenEvent(ScreenWillAppear(viewController: self, animated: animated))
+        super.viewWillAppear(animated)
+    }
+
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        chainedObserver.observeScreenEvent(ScreenDidAppear(viewController: self, animated: animated))
+    }
+
+    override open func viewWillLayoutSubviews() {
+        chainedObserver.observeScreenEvent(ScreenWillLayoutSubviews(viewController: self))
+        super.viewWillLayoutSubviews()
+    }
+
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        chainedObserver.observeScreenEvent(ScreenDidLayoutSubviews(viewController: self))
+    }
+
     public final func update(screen: ScreenType, environment: ViewEnvironment) {
         let previousScreen = self.screen
         self.screen = screen
         let previousEnvironment = self.environment
         self.environment = environment
         screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+        chainedObserver.observeScreenEvent(ScreenDidUpdate(viewController: self, previousScreen: previousScreen, previousViewEnvironment: previousEnvironment))
     }
 
     /// Subclasses should override this method in order to update any relevant UI bits when the screen model changes.

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -17,9 +17,20 @@
 #if canImport(UIKit)
 
 import UIKit
+@_spi(WorkflowGlobalObservation) import Workflow
 
 public final class DescribedViewController: UIViewController {
     var currentViewController: UIViewController
+
+    public var observer: WorkflowUIObserver?
+
+    private var chainedObserver: WorkflowUIObserver {
+        if let observer {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [observer])
+        } else {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [])
+        }
+    }
 
     public init(description: ViewControllerDescription) {
         self.currentViewController = description.buildViewController()
@@ -60,6 +71,7 @@ public final class DescribedViewController: UIViewController {
 
             updatePreferredContentSizeIfNeeded()
         }
+        chainedObserver.observeDescribedViewControllerEvent(DescribedViewControllerDidUpdate(viewController: self, viewDescription: description))
     }
 
     public func update<S: Screen>(screen: S, environment: ViewEnvironment) {
@@ -75,9 +87,25 @@ public final class DescribedViewController: UIViewController {
         updatePreferredContentSizeIfNeeded()
     }
 
+    override public func viewWillAppear(_ animated: Bool) {
+        chainedObserver.observeDescribedViewControllerEvent(DescribedViewControllerWillAppear(viewController: self, animated: animated))
+        super.viewWillAppear(animated)
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        chainedObserver.observeDescribedViewControllerEvent(DescribedViewControllerDidAppear(viewController: self, animated: animated))
+    }
+
+    override public func viewWillLayoutSubviews() {
+        chainedObserver.observeDescribedViewControllerEvent(DescribedViewControllerWillLayoutSubviews(viewController: self))
+        super.viewWillLayoutSubviews()
+    }
+
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         currentViewController.view.frame = view.bounds
+        chainedObserver.observeDescribedViewControllerEvent(DescribedViewControllerDidLayoutSubviews(viewController: self))
     }
 
     override public var childForStatusBarStyle: UIViewController? {


### PR DESCRIPTION
Compare with https://github.com/square/workflow-swift/pull/208 and https://github.com/square/workflow-swift/pull/210

## Pros

* More concise observer protocol definition
* Easily portable to other observation systems (ex. FRP frameworks) by passing the types through
* Can easily be extended / customized to support listening to only a single event type
* Adding fields to an existing event is backwards compatible
* Adding new events is backwards compatible

## Cons

* No way to pattern match over a concrete list of possible events
* Adding a new case to the enum is backwards incompatible
* Does not match existing observation APIs for `Workflow`

