### PR TITLE
WIP WorkflowUI Observation with enum

### DIFF
--- a/WorkflowUI/Sources/Observation/DescribedViewControllerEvents.swift
+++ b/WorkflowUI/Sources/Observation/DescribedViewControllerEvents.swift
@@ -1,0 +1,12 @@
+
+import ViewEnvironment
+
+extension DescribedViewController {
+    public enum Event {
+        case viewWillLayoutSubviews
+        case viewDidLayoutSubviews
+        case viewWillAppear(animated: Bool)
+        case viewDidAppear(animated: Bool)
+        case didUpdateDescription(ViewControllerDescription)
+    }
+}

--- a/WorkflowUI/Sources/Observation/ScreenViewControllerEvents.swift
+++ b/WorkflowUI/Sources/Observation/ScreenViewControllerEvents.swift
@@ -1,0 +1,12 @@
+
+import ViewEnvironment
+
+extension ScreenViewController {
+    public enum Event {
+        case viewWillLayoutSubviews
+        case viewDidLayoutSubviews
+        case viewWillAppear(animated: Bool)
+        case viewDidAppear(animated: Bool)
+        case didUpdate(previousScreen: ScreenType, previousViewEnvironment: ViewEnvironment)
+    }
+}

--- a/WorkflowUI/Sources/Observation/WorkflowUIObserver.swift
+++ b/WorkflowUI/Sources/Observation/WorkflowUIObserver.swift
@@ -1,0 +1,107 @@
+
+#if canImport(UIKit)
+
+import Foundation
+import UIKit
+import ViewEnvironment
+import Workflow
+@_spi(WorkflowGlobalObservation) import Workflow
+
+public protocol WorkflowUIObserver {
+    func observe<ScreenType: Screen>(
+        _ event: ScreenViewController<ScreenType>.Event,
+        viewController: ScreenViewController<ScreenType>
+    )
+
+    func observe(_ event: DescribedViewController.Event, viewController: DescribedViewController)
+}
+
+public extension WorkflowUIObserver {
+    func observe<ScreenType: Screen>(
+        _ event: ScreenViewController<ScreenType>.Event,
+        viewController: ScreenViewController<ScreenType>
+    ) {}
+
+    func observe(_ event: DescribedViewController.Event, viewController: DescribedViewController) {}
+}
+
+final class ChainedWorkflowUIObserver: WorkflowUIObserver {
+    let observers: [WorkflowUIObserver]
+
+    init(observers: [WorkflowUIObserver]) {
+        self.observers = observers
+    }
+
+    func observe<ScreenType: Screen>(
+        _ event: ScreenViewController<ScreenType>.Event,
+        viewController: ScreenViewController<ScreenType>
+    ) {
+        for observer in observers {
+            observer.observe(event, viewController: viewController)
+        }
+    }
+
+    func observe(_ event: DescribedViewController.Event, viewController: DescribedViewController) {
+        for observer in observers {
+            observer.observe(event, viewController: viewController)
+        }
+    }
+}
+
+extension Array where Element == WorkflowUIObserver {
+    func chained() -> WorkflowUIObserver {
+        if count == 1 {
+            // no wrapping needed if a single element
+            return self[0]
+        } else {
+            return ChainedWorkflowUIObserver(observers: self)
+        }
+    }
+}
+
+// MARK: - Global Observation (SPI)
+
+@_spi(WorkflowGlobalObservation)
+public protocol UIObserversInterceptor {
+    /// Provides a single access point to provide the final list of `WorkflowObserver` used by the runtime.
+    /// This may be used to ensure a known set of observers is used in a particular order for all
+    /// `WorkflowHost`s created over the life of a program.
+    /// - Parameter initialObservers: Array of observers passed to a `WorkflowHost` constructor
+    /// - Returns: The array of `WorkflowObserver`s to be used by the `WorkflowHost`
+    func workflowObservers(for initialObservers: [WorkflowUIObserver]) -> [WorkflowUIObserver]
+}
+
+@_spi(WorkflowGlobalObservation)
+extension UIObserversInterceptor {
+    public func chainedObservers(for initialObservers: [WorkflowUIObserver]) -> WorkflowUIObserver {
+        return workflowObservers(for: initialObservers).chained()
+    }
+}
+
+@_spi(WorkflowGlobalObservation)
+extension WorkflowObservation {
+    private static var _sharedUIInterceptorStorage: UIObserversInterceptor = NoOpUIObserversInterceptor()
+
+    /// The `DefaultObserversProvider` used by all runtimes.
+    public static var sharedUIObserversInterceptor: UIObserversInterceptor! {
+        get {
+            _sharedUIInterceptorStorage
+        }
+        set {
+            guard newValue != nil else {
+                _sharedUIInterceptorStorage = NoOpUIObserversInterceptor()
+                return
+            }
+
+            _sharedUIInterceptorStorage = newValue
+        }
+    }
+
+    private struct NoOpUIObserversInterceptor: UIObserversInterceptor {
+        func workflowObservers(for initialObservers: [WorkflowUIObserver]) -> [WorkflowUIObserver] {
+            initialObservers
+        }
+    }
+}
+
+#endif

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -17,6 +17,7 @@
 #if canImport(UIKit)
 
 import UIKit
+@_spi(WorkflowGlobalObservation) import Workflow
 
 /// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
 /// given screen type.
@@ -44,6 +45,16 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
 
     public private(set) final var environment: ViewEnvironment
 
+    public var observer: WorkflowUIObserver?
+
+    private var chainedObserver: WorkflowUIObserver {
+        if let observer {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [observer])
+        } else {
+            return WorkflowObservation.sharedUIObserversInterceptor.chainedObservers(for: [])
+        }
+    }
+
     public required init(screen: ScreenType, environment: ViewEnvironment) {
         self.screen = screen
         self.environment = environment
@@ -55,12 +66,33 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override open func viewWillAppear(_ animated: Bool) {
+        chainedObserver.observe(Event.viewWillAppear(animated: animated), viewController: self)
+        super.viewWillAppear(animated)
+    }
+
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        chainedObserver.observe(Event.viewDidAppear(animated: animated), viewController: self)
+    }
+
+    override open func viewWillLayoutSubviews() {
+        chainedObserver.observe(Event.viewWillLayoutSubviews, viewController: self)
+        super.viewWillLayoutSubviews()
+    }
+
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        chainedObserver.observe(Event.viewDidLayoutSubviews, viewController: self)
+    }
+
     public final func update(screen: ScreenType, environment: ViewEnvironment) {
         let previousScreen = self.screen
         self.screen = screen
         let previousEnvironment = self.environment
         self.environment = environment
         screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+        chainedObserver.observe(Event.didUpdate(previousScreen: previousScreen, previousViewEnvironment: previousEnvironment), viewController: self)
     }
 
     /// Subclasses should override this method in order to update any relevant UI bits when the screen model changes.


### PR DESCRIPTION
Compare with https://github.com/square/workflow-swift/pull/208 and https://github.com/square/workflow-swift/pull/209

## Pros

* Concise observer protocol definition
* Concise list of events
* Enum enables switching over all possible events
* Somewhat portable to other observation systems (ex. FRP frameworks)

## Cons

* Adding a new field to an existing enum is backwards incompatible
* Adding a new case to the enum is backwards incompatible
* Enums lack the ability to have standard fields for all cases (ex. base class with set of properties). This can be worked around by injecting things into the observation **function** instead of the enum case, but then the enum case is less reusable in other contexts as you would need to forward the extra data along with it
* Consumers all must `switch` over every event which may reduce performance and add friction (ex. if I only want to listen for `viewDidAppear`)
* Does not match existing observation APIs for `Workflow`
