### PR TITLE
[feat]: Add support for automatic ViewEnvironment bridging in WorkflowUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ let package = Package(
 
         .target(
             name: "WorkflowUI",
-            dependencies: ["Workflow", "ViewEnvironment"],
+            dependencies: ["Workflow", "ViewEnvironment", "ViewEnvironmentUI"],
             path: "WorkflowUI/Sources"
         ),
         .testTarget(

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -27,6 +27,7 @@ struct LoginScreen: Screen {
 
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         return ViewControllerDescription(
+            environment: environment,
             build: { LoginViewController() },
             update: { $0.update(with: self) }
         )

--- a/Samples/Tutorial/Podfile
+++ b/Samples/Tutorial/Podfile
@@ -7,6 +7,7 @@ target 'Tutorial' do
     pod 'Workflow', path: '../../Workflow.podspec', :testspecs => ['Tests']
     pod 'WorkflowUI', path: '../../WorkflowUI.podspec', :testspecs => ['Tests']
     pod 'ViewEnvironment', path: '../../ViewEnvironment.podspec'
+    pod 'ViewEnvironmentUI', path: '../../ViewEnvironmentUI.podspec', :testspecs => ['Tests']
     pod 'WorkflowReactiveSwift', path: '../../WorkflowReactiveSwift.podspec', :testspecs => ['Tests']
     pod 'BackStackContainer', path: '../BackStackContainer/BackStackContainer.podspec'
 

--- a/ViewEnvironmentUI/Tests/ViewEnvironmentObservingTests.swift
+++ b/ViewEnvironmentUI/Tests/ViewEnvironmentObservingTests.swift
@@ -1,3 +1,6 @@
+#if canImport(UIKit)
+
+import UIKit
 import ViewEnvironment
 import XCTest
 
@@ -404,3 +407,5 @@ extension ViewEnvironmentObservingTests {
         required init?(coder: NSCoder) { fatalError("") }
     }
 }
+
+#endif

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
 
     s.dependency 'Workflow', "#{s.version}"
     s.dependency 'ViewEnvironment', "#{s.version}"
+    s.dependency 'ViewEnvironmentUI', "#{s.version}"
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -18,7 +18,7 @@
 
 import ReactiveSwift
 import UIKit
-import ViewEnvironmentUI
+@_spi(ViewEnvironmentWiring) import ViewEnvironmentUI
 import Workflow
 
 /// Drives view controllers from a root Workflow.
@@ -63,6 +63,11 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
 
         super.init(nibName: nil, bundle: nil)
 
+        // Do not automatically forward environment did change notifications to the rendered screen's backing view
+        // controller. Instead rely on `ViewControllerDescription` to call `setNeedsEnvironmentUpdate()` when updates
+        // occur.
+        environmentDescendantsOverride = { [] }
+
         addChild(rootViewController)
         rootViewController.didMove(toParent: self)
 
@@ -75,10 +80,6 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
 
                 self.update(screen: screen, environment: self.environment)
             }
-
-        // Inform the rendered screen's backing view controller hierarchy that its environment can now be re-requested
-        // with the appropriate customizations now that it has been added as a child view controller.
-        rootViewController.setNeedsEnvironmentUpdate()
     }
 
     /// Updates the root Workflow in this container.

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -30,15 +30,16 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
         return workflowHost.output
     }
 
+    /// An environment customization that will be applied to the environment of the root screen.
+    public var customizeEnvironment: CustomizeEnvironment {
+        didSet { setNeedsEnvironmentUpdate() }
+    }
+
     private(set) var rootViewController: UIViewController
 
     private let workflowHost: WorkflowHost<AnyWorkflow<ScreenType, Output>>
 
     private let (lifetime, token) = Lifetime.make()
-
-    public var customizeEnvironment: CustomizeEnvironment {
-        didSet { setNeedsEnvironmentUpdate() }
-    }
 
     public init<W: AnyWorkflowConvertible>(
         workflow: W,

--- a/WorkflowUI/Sources/ModuleExports.swift
+++ b/WorkflowUI/Sources/ModuleExports.swift
@@ -1,1 +1,2 @@
 @_exported import ViewEnvironment
+@_exported import ViewEnvironmentUI

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -79,6 +79,7 @@ extension ScreenViewController {
         ViewControllerDescription(
             performInitialUpdate: performInitialUpdate,
             type: self,
+            environment: environment,
             build: { self.init(screen: screen, environment: environment) },
             update: { $0.update(screen: screen, environment: environment) }
         )

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -17,6 +17,8 @@
 #if canImport(UIKit)
 
 import UIKit
+import ViewEnvironment
+@_spi(ViewEnvironmentWiring) import ViewEnvironmentUI
 
 /// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
 /// given screen type.
@@ -25,7 +27,7 @@ import UIKit
 /// ```
 /// struct MyScreen: Screen {
 ///     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-///         return MyScreenViewController.description(for: self)
+///         return MyScreenViewController.description(for: self, environment: environment)
 ///     }
 /// }
 ///
@@ -42,11 +44,11 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         return ScreenType.self
     }
 
-    public private(set) final var environment: ViewEnvironment
+    private var previousEnvironment: ViewEnvironment
 
     public required init(screen: ScreenType, environment: ViewEnvironment) {
         self.screen = screen
-        self.environment = environment
+        self.previousEnvironment = environment
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -55,11 +57,11 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public final func update(screen: ScreenType, environment: ViewEnvironment) {
+    public final func update(screen: ScreenType) {
         let previousScreen = self.screen
         self.screen = screen
-        let previousEnvironment = self.environment
-        self.environment = environment
+        let previousEnvironment = self.previousEnvironment
+        self.previousEnvironment = environment
         screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
     }
 
@@ -81,7 +83,7 @@ extension ScreenViewController {
             type: self,
             environment: environment,
             build: { self.init(screen: screen, environment: environment) },
-            update: { $0.update(screen: screen, environment: environment) }
+            update: { $0.update(screen: screen) }
         )
     }
 }

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -148,7 +148,7 @@ public struct ViewControllerDescription {
     private func configureAncestor(of viewController: UIViewController) {
         guard let ancestorOverride = viewController.environmentAncestorOverride else {
             // If no ancestor is currently present establish the initial ancestor override
-            establishAncestorOverride(for: viewController)
+            overrideAncestor(of: viewController)
             return
         }
 
@@ -165,10 +165,10 @@ public struct ViewControllerDescription {
         // We must nil this out first or we'll hit an assertion which protects against overriding the ancestor when
         // some other system has already attempted to provide an override.
         viewController.environmentAncestorOverride = nil
-        establishAncestorOverride(for: viewController)
+        overrideAncestor(of: viewController)
     }
 
-    private func establishAncestorOverride(for viewController: UIViewController) {
+    private func overrideAncestor(of viewController: UIViewController) {
         let ancestor = PropagationNode(
             viewController: viewController,
             environment: environment

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -169,6 +169,10 @@ public struct ViewControllerDescription {
     }
 
     private func overrideAncestor(of viewController: UIViewController) {
+        // Here we intentionally retain the node by capturing it in the `environmentAncestorOverride` closure, making 
+        // the view controller effectively retain this node.
+        // The `viewController` passed into this `PropagationNode` is not retained by the node (it's a weak 
+        // reference).
         let ancestor = PropagationNode(
             viewController: viewController,
             environment: environment
@@ -220,6 +224,9 @@ extension ViewControllerDescription {
 extension ViewControllerDescription {
     fileprivate struct PropagationNode: ViewEnvironmentObserving {
 
+        // Since the viewController retains a reference to this node (via capture in the `environmentAncestorOverride`
+        // closure) we use a weak reference here to avoid a retain cycle, and leave retainment of the view controller 
+        // up to the consumer of the `ViewControllerDescription` (e.g. the parent view controller).
         weak var viewController: UIViewController?
 
         let environment: ViewEnvironment

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -109,7 +109,7 @@ public struct ViewControllerDescription {
             // Note that this also configures the environment ancestor node.
             update(viewController: viewController)
         } else {
-            configureAncestor(for: viewController)
+            configureAncestor(of: viewController)
         }
 
         return viewController
@@ -140,12 +140,12 @@ public struct ViewControllerDescription {
             """
         )
 
-        configureAncestor(for: viewController)
+        configureAncestor(of: viewController)
 
         update(viewController)
     }
 
-    private func configureAncestor(for viewController: UIViewController) {
+    private func configureAncestor(of viewController: UIViewController) {
         guard let ancestorOverride = viewController.environmentAncestorOverride else {
             // If no ancestor is currently present establish the initial ancestor override
             establishAncestorOverride(for: viewController)

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -247,12 +247,14 @@ fileprivate enum TestScreen: Screen, Equatable {
         switch self {
         case .counter(let count):
             return ViewControllerDescription(
+                environment: environment,
                 build: { CounterViewController(count: count) },
                 update: { $0.count = count }
             )
 
         case .message(let message):
             return ViewControllerDescription(
+                environment: environment,
                 build: { MessageViewController(message: message) },
                 update: { $0.message = message }
             )

--- a/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
+++ b/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
@@ -155,6 +155,7 @@ private struct Screen1: Screen {
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         ViewControllerDescription(
             type: VC1.self,
+            environment: environment,
             build: { VC1(identifier: "1", recordEvent: recordEvent) },
             update: { $0.recordEvent = recordEvent }
         )
@@ -167,6 +168,7 @@ private struct Screen2: Screen {
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         ViewControllerDescription(
             type: VC2.self,
+            environment: environment,
             build: { VC2(identifier: "2", recordEvent: recordEvent) },
             update: { $0.recordEvent = recordEvent }
         )

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -25,18 +25,23 @@ import WorkflowReactiveSwift
 
 fileprivate struct TestScreen: Screen {
     var string: String
+    var onEnvironmentDidChange: ((ViewEnvironment) -> Void)?
 
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         return TestScreenViewController.description(for: self, environment: environment)
     }
 }
 
-fileprivate final class TestScreenViewController: ScreenViewController<TestScreen> {
+fileprivate final class TestScreenViewController: ScreenViewController<TestScreen>, ViewEnvironmentObserving {
     var onScreenChange: (() -> Void)?
 
     override func screenDidChange(from previousScreen: TestScreen, previousEnvironment: ViewEnvironment) {
         super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
         onScreenChange?()
+    }
+
+    func environmentDidChange() {
+        screen.onEnvironmentDidChange?(environment)
     }
 }
 
@@ -154,6 +159,60 @@ class WorkflowHostingControllerTests: XCTestCase {
 
         disposable?.dispose()
     }
+
+    func test_environment_bridging() throws {
+        struct TestKey: ViewEnvironmentKey {
+            static var defaultValue: Int = 0
+        }
+
+        var changedEnvironments: [ViewEnvironment] = []
+        let firstWorkflow = EnvironmentObservingWorkflow(
+            value: "first",
+            onEnvironmentDidChange: { env in
+                changedEnvironments.append(env)
+            }
+        )
+        let container = WorkflowHostingController(
+            workflow: firstWorkflow,
+            customizeEnvironment: { $0[TestKey.self] = 1 }
+        )
+
+        // Expect a `setNeedsEnvironmentUpdate()` in the `container`'s initializer.
+        XCTAssertEqual(changedEnvironments.count, 1)
+        do {
+            let environment = try XCTUnwrap(changedEnvironments.first)
+            XCTAssertEqual(environment[TestKey.self], 1)
+        }
+
+        // Test ancestor propagation
+        struct AncestorKey: ViewEnvironmentKey {
+            static var defaultValue: String = ""
+        }
+
+        let ancestorVC = EnvironmentCustomizingViewController { $0[AncestorKey.self] = "1" }
+        ancestorVC.addChild(container)
+        container.didMove(toParent: ancestorVC)
+        XCTAssertEqual(changedEnvironments.count, 1)
+
+        ancestorVC.setNeedsEnvironmentUpdate()
+        XCTAssertEqual(changedEnvironments.count, 2)
+        do {
+            let environment = try XCTUnwrap(changedEnvironments.last)
+            XCTAssertEqual(environment[AncestorKey.self], "1")
+            XCTAssertEqual(environment[TestKey.self], 1)
+        }
+
+        // Test an environment update. This does not implicitly trigger an environment update in this VC.
+        ancestorVC.customizeEnvironment = { $0[AncestorKey.self] = "2" }
+        // Updating customizeEnvironment on the WorkflowHostingController should trigger an environment update
+        container.customizeEnvironment = { $0[TestKey.self] = 2 }
+        XCTAssertEqual(changedEnvironments.count, 3)
+        do {
+            let environment = try XCTUnwrap(changedEnvironments.last)
+            XCTAssertEqual(environment[AncestorKey.self], "2")
+            XCTAssertEqual(environment[TestKey.self], 2)
+        }
+    }
 }
 
 fileprivate struct SubscribingWorkflow: Workflow {
@@ -216,6 +275,35 @@ fileprivate struct EchoWorkflow: Workflow {
             .mapOutput { AnyWorkflowAction(sendingOutput: $0) }
             .running(in: context)
         return TestScreen(string: "\(value)")
+    }
+}
+
+fileprivate struct EnvironmentObservingWorkflow: Workflow {
+    var value: String
+    var onEnvironmentDidChange: (ViewEnvironment) -> Void
+
+    typealias State = Void
+
+    typealias Output = Never
+
+    func render(state: State, context: RenderContext<Self>) -> TestScreen {
+        return TestScreen(string: value, onEnvironmentDidChange: onEnvironmentDidChange)
+    }
+}
+
+fileprivate final class EnvironmentCustomizingViewController: UIViewController, ViewEnvironmentObserving {
+
+    var customizeEnvironment: (inout ViewEnvironment) -> Void
+
+    init(customizeEnvironment: @escaping (inout ViewEnvironment) -> Void) {
+        self.customizeEnvironment = customizeEnvironment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func customize(environment: inout ViewEnvironment) {
+        customizeEnvironment(&environment)
     }
 }
 

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 
 import ReactiveSwift
+import UIKit
 import Workflow
 import WorkflowReactiveSwift
 @testable import WorkflowUI

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -177,10 +177,11 @@ class WorkflowHostingControllerTests: XCTestCase {
             customizeEnvironment: { $0[TestKey.self] = 1 }
         )
 
-        // Expect a `setNeedsEnvironmentUpdate()` in the `container`'s initializer.
-        XCTAssertEqual(changedEnvironments.count, 1)
+        // Expect a `setNeedsEnvironmentUpdate()` in the `ViewControllerDescription`'s build method and the
+        // `container`'s initializer.
+        XCTAssertEqual(changedEnvironments.count, 2)
         do {
-            let environment = try XCTUnwrap(changedEnvironments.first)
+            let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[TestKey.self], 1)
         }
 
@@ -192,10 +193,10 @@ class WorkflowHostingControllerTests: XCTestCase {
         let ancestorVC = EnvironmentCustomizingViewController { $0[AncestorKey.self] = "1" }
         ancestorVC.addChild(container)
         container.didMove(toParent: ancestorVC)
-        XCTAssertEqual(changedEnvironments.count, 1)
+        XCTAssertEqual(changedEnvironments.count, 2)
 
         ancestorVC.setNeedsEnvironmentUpdate()
-        XCTAssertEqual(changedEnvironments.count, 2)
+        XCTAssertEqual(changedEnvironments.count, 4)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "1")
@@ -206,7 +207,7 @@ class WorkflowHostingControllerTests: XCTestCase {
         ancestorVC.customizeEnvironment = { $0[AncestorKey.self] = "2" }
         // Updating customizeEnvironment on the WorkflowHostingController should trigger an environment update
         container.customizeEnvironment = { $0[TestKey.self] = 2 }
-        XCTAssertEqual(changedEnvironments.count, 3)
+        XCTAssertEqual(changedEnvironments.count, 6)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "2")

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -161,7 +161,7 @@ class WorkflowHostingControllerTests: XCTestCase {
     }
 
     func test_environment_bridging() throws {
-        struct WorkflowHostKeyKey: ViewEnvironmentKey {
+        struct WorkflowHostKey: ViewEnvironmentKey {
             static var defaultValue: Int = 0
         }
         struct ScreenKey: ViewEnvironmentKey {
@@ -180,7 +180,7 @@ class WorkflowHostingControllerTests: XCTestCase {
                 .mapRendering {
                     $0.adaptedEnvironment(key: ScreenKey.self, value: true)
                 },
-            customizeEnvironment: { $0[WorkflowHostKeyKey.self] = 1 }
+            customizeEnvironment: { $0[WorkflowHostKey.self] = 1 }
         )
 
         // Expect a `setNeedsEnvironmentUpdate()` in the `ViewControllerDescription`'s build method and the
@@ -188,7 +188,7 @@ class WorkflowHostingControllerTests: XCTestCase {
         XCTAssertEqual(changedEnvironments.count, 1)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
-            XCTAssertEqual(environment[WorkflowHostKeyKey.self], 1)
+            XCTAssertEqual(environment[WorkflowHostKey.self], 1)
             XCTAssertEqual(environment[ScreenKey.self], true)
         }
 
@@ -207,19 +207,19 @@ class WorkflowHostingControllerTests: XCTestCase {
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "1")
-            XCTAssertEqual(environment[WorkflowHostKeyKey.self], 1)
+            XCTAssertEqual(environment[WorkflowHostKey.self], 1)
             XCTAssertEqual(environment[ScreenKey.self], true)
         }
 
         // Test an environment update. This does not implicitly trigger an environment update in this VC.
         ancestorVC.customizeEnvironment = { $0[AncestorKey.self] = "2" }
         // Updating customizeEnvironment on the WorkflowHostingController should trigger an environment update
-        container.customizeEnvironment = { $0[WorkflowHostKeyKey.self] = 2 }
+        container.customizeEnvironment = { $0[WorkflowHostKey.self] = 2 }
         XCTAssertEqual(changedEnvironments.count, 3)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "2")
-            XCTAssertEqual(environment[WorkflowHostKeyKey.self], 2)
+            XCTAssertEqual(environment[WorkflowHostKey.self], 2)
             XCTAssertEqual(environment[ScreenKey.self], true)
         }
     }

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -179,7 +179,7 @@ class WorkflowHostingControllerTests: XCTestCase {
 
         // Expect a `setNeedsEnvironmentUpdate()` in the `ViewControllerDescription`'s build method and the
         // `container`'s initializer.
-        XCTAssertEqual(changedEnvironments.count, 2)
+        XCTAssertEqual(changedEnvironments.count, 1)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[TestKey.self], 1)
@@ -193,10 +193,10 @@ class WorkflowHostingControllerTests: XCTestCase {
         let ancestorVC = EnvironmentCustomizingViewController { $0[AncestorKey.self] = "1" }
         ancestorVC.addChild(container)
         container.didMove(toParent: ancestorVC)
-        XCTAssertEqual(changedEnvironments.count, 2)
+        XCTAssertEqual(changedEnvironments.count, 1)
 
         ancestorVC.setNeedsEnvironmentUpdate()
-        XCTAssertEqual(changedEnvironments.count, 4)
+        XCTAssertEqual(changedEnvironments.count, 2)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "1")
@@ -207,7 +207,7 @@ class WorkflowHostingControllerTests: XCTestCase {
         ancestorVC.customizeEnvironment = { $0[AncestorKey.self] = "2" }
         // Updating customizeEnvironment on the WorkflowHostingController should trigger an environment update
         container.customizeEnvironment = { $0[TestKey.self] = 2 }
-        XCTAssertEqual(changedEnvironments.count, 6)
+        XCTAssertEqual(changedEnvironments.count, 3)
         do {
             let environment = try XCTUnwrap(changedEnvironments.last)
             XCTAssertEqual(environment[AncestorKey.self], "2")


### PR DESCRIPTION
> **Note**: This PR is targeting the [`feature/viewenvironmentui`](https://github.com/square/workflow-swift/tree/feature/viewenvironmentui) branch and depends on #205.

# Overview

This PR adds deep integration of `ViewEnvironmentUI` to `WorkflowUI`. This deep integration makes working with contexts that need to bridge between both systems _much_ easier. For example, applications that have not fully adopted Workflow but utilize the `ViewEnvironment` for theme propagation via `ViewEnvironmentUI` (as is true in Square's ios-register codebase).

This PR is part of the larger effort to add support for automatic `ViewEnvironment` bridging between `UIKit` propagation and `WorkflowUI` propagation within `WorkflowUI`.

See [the associated proposal](https://www.notion.so/marketdesignsystem/Proposal-WorkflowUI-ViewEnvironment-Propagation-in-UIKit-0aec81d8c40545baa2ed7bacd938a6b7#879e5ce5c3f948d59174c9d18a7e6441) for more information.

# Changes

This PR integrates `ViewEnvironmentUI` vanilla UIKit `ViewEnvironment` propagation support into `WorkflowUI`. This includes:
* Automatic bridging of the `ViewEnvironment` from `UIViewController` propagation into `Screen`'s `ViewEnvironment` within `WorkflowHostingController`.
* Automatic bridging of the `ViewEnvironment` from `Screen`'s `ViewEnvironment` into `UIViewController` propagation within `ViewControllerDescription`.

With these new features came some minor API adjustments:
* `ViewControllerDescription` now takes in a `ViewEnvironment` as a parameter. This environment is added into an ancestor propagation node above the described view controller so that it can be served to any `UIViewController` `ViewEnvironment` queries (performed via `ViewEnvironmentUI`'s propagation system).
* `WorkflowHostingController` now takes a `customizeEnvironment` closure instead of a `rootViewEnvironment`. This makes it possible to configure environment properties as the `ViewEnvironment` is bridged into the `Screen` hierarchy without fully overwriting the entire `ViewEnvironment`.
* `ScreenViewController` no longer takes an `environment` in its `update(...)` function. The `Environment` is now managed by the `ViewControllerDescription` for the `Screen` that it's backing. The `environment` parameter is still present in the initializer for `ScreenViewController` as it can be convenient to have valid environment state before the ancestor propagation node is configured above it (which is configured after initialization completes).

# Square Integration PRs

https://github.com/squareup/market/pull/6224
https://github.com/squareup/ios-register/pull/85648

# Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation