### PR TITLE
RxSwift 6.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.1.1"),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.2.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.6.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.44.14"),
     ],
     targets: [

--- a/WorkflowReactiveSwift.podspec
+++ b/WorkflowReactiveSwift.podspec
@@ -27,5 +27,7 @@ Pod::Spec.new do |s|
     test_spec.framework = 'XCTest'
     test_spec.library = 'swiftos'
     test_spec.dependency 'WorkflowTesting', "#{s.version}"
+
+    test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
   end
 end

--- a/WorkflowReactiveSwift.podspec
+++ b/WorkflowReactiveSwift.podspec
@@ -20,6 +20,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'Workflow', "#{s.version}"
 
+  s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'WorkflowReactiveSwift/Tests/**/*.swift'
     test_spec.framework = 'XCTest'

--- a/WorkflowRxSwift.podspec
+++ b/WorkflowRxSwift.podspec
@@ -19,10 +19,9 @@ Pod::Spec.new do |s|
     s.source_files = 'WorkflowRxSwift/Sources/**/*.swift'
 
     s.dependency 'Workflow', "#{s.version}"
-    s.dependency 'RxSwift', '~> 6.2'
+    s.dependency 'RxSwift', '~> 6.6'
 
-    # https://github.com/ReactiveX/RxSwift/pull/2475
-    # s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
     s.test_spec 'Tests' do |test_spec|
         test_spec.source_files = 'WorkflowRxSwift/Tests/**/*.swift'

--- a/WorkflowRxSwift.podspec
+++ b/WorkflowRxSwift.podspec
@@ -29,5 +29,7 @@ Pod::Spec.new do |s|
         test_spec.library = 'swiftos'
         test_spec.dependency 'WorkflowTesting', "#{s.version}"
         test_spec.dependency 'WorkflowReactiveSwift', "#{s.version}"
+
+        test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
     end
 end

--- a/WorkflowRxSwiftTesting.podspec
+++ b/WorkflowRxSwiftTesting.podspec
@@ -21,7 +21,6 @@ Pod::Spec.new do |s|
     s.dependency 'Workflow', "#{s.version}"
     s.dependency 'WorkflowRxSwift', "#{s.version}"
     s.dependency 'WorkflowTesting', "#{s.version}"
-    s.dependency 'RxSwift'
 
     s.framework = 'XCTest'
 


### PR DESCRIPTION
This bumps RxSwift to v6.6, which now declares extension safety.
I then updated the Podspec to declare explicit extension safety.
I apparently had missed ReactiveSwift in [the first PR](https://github.com/square/workflow-swift/pull/171).

## Checklist

All tasks are n/a

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
