### PR TITLE
Expose Publisher.asAnyWorkflow as public API

### DIFF
--- a/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorker.swift
+++ b/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorker.swift
@@ -17,7 +17,7 @@ extension DemoWorkflow {
 
         // This publisher publishes the current date on a timer that fires every second
         func run() -> AnyPublisher<Output, Never> {
-            Timer.publish(every: 1, on: .main, in: .common)
+            Timer.publish(every: 2, on: .main, in: .common)
                 .autoconnect()
                 .map { Action(publishedDate: $0) }
                 .eraseToAnyPublisher()

--- a/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorkflow.swift
+++ b/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorkflow.swift
@@ -46,11 +46,22 @@ extension DemoWorkflow {
 // MARK: Rendering
 
 extension DemoWorkflow {
-    // TODO: Change this to your actual rendering type
     typealias Rendering = DemoScreen
 
     func render(state: DemoWorkflow.State, context: RenderContext<DemoWorkflow>) -> Rendering {
+        // Combine-based worker example
         DemoWorker()
+            .rendered(in: context)
+
+        // Directly consume a Publisher
+        Timer.publish(every: 2, on: .main, in: .common)
+            .autoconnect()
+            .delay(for: 1.0, scheduler: DispatchQueue.main)
+            .asAnyWorkflow()
+            .onOutput { state, output in
+                state.date = Date()
+                return nil
+            }
             .rendered(in: context)
 
         dateFormatter.dateStyle = .long

--- a/WorkflowCombine/Sources/Publisher+Extensions.swift
+++ b/WorkflowCombine/Sources/Publisher+Extensions.swift
@@ -25,7 +25,7 @@ extension Publisher where Failure == Never {
         asAnyWorkflow().mapOutput(transform)
     }
 
-    func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
+    public func asAnyWorkflow() -> AnyWorkflow<Void, Output> {
         PublisherWorkflow(publisher: self).asAnyWorkflow()
     }
 }

--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -21,17 +21,17 @@ import Foundation
 import Workflow
 
 struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowPublisher.Failure == Never {
-    public typealias Output = WorkflowPublisher.Output
-    public typealias State = Void
-    public typealias Rendering = Void
+    typealias Output = WorkflowPublisher.Output
+    typealias State = Void
+    typealias Rendering = Void
 
     let publisher: WorkflowPublisher
 
-    public init(publisher: WorkflowPublisher) {
+    init(publisher: WorkflowPublisher) {
         self.publisher = publisher
     }
 
-    public func render(state: State, context: RenderContext<Self>) -> Rendering {
+    func render(state: State, context: RenderContext<Self>) -> Rendering {
         let sink = context.makeSink(of: AnyWorkflowAction.self)
         context.runSideEffect(key: "") { [publisher] lifetime in
             let cancellable = publisher


### PR DESCRIPTION
Without this API consuming a `Publisher` inside a workflow is only possible by either rendering it directly via `.render(in:)` or by first calling `mapOutput`:

```swift
somePublisher
    .mapOutput { $0 } // workaround for not being able to call `asAnyWorkflow()`
    .onOutput { state, output in
         // ...
    }.rendered(in: context)
```