### PR TITLE
[fix]: make WorkflowHostingController background color clear

### DIFF
--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -110,7 +110,7 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
     override public func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .white
+        view.backgroundColor = .clear
 
         rootViewController.view.frame = view.bounds
         view.addSubview(rootViewController.view)


### PR DESCRIPTION
> **Note**: This PR is targeting the [`feature/viewenvironmentui`](https://github.com/square/workflow-swift/tree/feature/viewenvironmentui) branch and depends on #218.

# Overview

This PR is part of the larger effort to add support for automatic `ViewEnvironment` bridging between `UIKit` propagation and `WorkflowUI` propagation within `WorkflowUI`.

See [the associated proposal](https://www.notion.so/marketdesignsystem/Proposal-WorkflowUI-ViewEnvironment-Propagation-in-UIKit-0aec81d8c40545baa2ed7bacd938a6b7#879e5ce5c3f948d59174c9d18a7e6441) for more information.

While this change may seem unrelated to the view environment bridging work, it was added to this feature branch since it allows replacement of `DescribedViewController` usages with `WorkflowHostingController`s without loading the view earlier than you may have needed to previously. `WorkflowHostingController` rendering a single screen is one way to achieve automatic bridging of the `ViewEnvironment` from a vanilla propagation path to a `Screen` which can be useful in contexts like snapshot testing harnesses. While we may want to provide an automatic bridging container specific to `Screen`'s, this work is currently considered out of scope for this feature branch (although that's open to reconsideration)—see the [this section in the proposal for more information on this topic](https://www.notion.so/marketdesignsystem/Proposal-WorkflowUI-ViewEnvironment-Propagation-in-UIKit-0aec81d8c40545baa2ed7bacd938a6b7?pvs=4#88929f975aa0483885d89aca1d159b4b).

`DescribedViewController`'s `backgroundColor` is `.clear`, which is an intuitive value when considering that it should appear identical to the content it is wrapping—it shouldn't place an opaque `.white` background underneath. I'd argue the same applies to `WorkflowHostingController`.

Today, if you want to set the `WorkflowHostingController`'s `backgroundColor` to `.clear`, you'd need to load the view first (`workflowHostingController.view.backgroundColor = .clear`)—there is no way override the background color otherwise. Loading the view early like this can be problematic in some cases, e.g. when attempting to utilize a `WorkflowHostingController` in snapshot testing infrastructure where you may want to build up a `UIViewController` hierarchy before loading the view at all in case it references values in the vanilla `ViewEnvironment` propagation path which need to be mutated above it.

# Square Integration PRs

https://github.com/squareup/market/pull/6286
https://github.com/squareup/ios-register/pull/86301

# Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation