### PR TITLE
Remove redundant `canImport` conditions

### DIFF
--- a/WorkflowCombine/Sources/Publisher+Extensions.swift
+++ b/WorkflowCombine/Sources/Publisher+Extensions.swift
@@ -5,8 +5,6 @@
 //  Created by Soo Rin Park on 11/3/21.
 //
 
-#if canImport(Combine)
-
 import Combine
 import Foundation
 import Workflow
@@ -29,5 +27,3 @@ extension Publisher where Failure == Never {
         PublisherWorkflow(publisher: self).asAnyWorkflow()
     }
 }
-
-#endif

--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(Combine)
-
 import Combine
 import Foundation
 import Workflow
@@ -45,5 +43,3 @@ struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowP
         }
     }
 }
-
-#endif

--- a/WorkflowCombine/Sources/Worker.swift
+++ b/WorkflowCombine/Sources/Worker.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(Combine)
-
 import Combine
 import Foundation
 import Workflow
@@ -94,5 +92,3 @@ extension Worker where Self: Equatable {
         self == otherWorker
     }
 }
-
-#endif

--- a/WorkflowSwiftUI/Sources/WorkflowView.swift
+++ b/WorkflowSwiftUI/Sources/WorkflowView.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(SwiftUI) && canImport(Combine)
-
 import Combine
 import ReactiveSwift
 import SwiftUI
@@ -94,7 +92,7 @@ extension WorkflowView where T.Output == Never, T.Rendering == Content {
 // update mechanism via `updateUIViewController(_:context:)`. If we were to manage a `WorkflowHost` instance directly
 // within a SwiftUI view we would need to update the host with the updated workflow from our implementation of `body`.
 // Performing work within the body accessor is strongly discouraged, so we jump back into UIKit for a second here.
-fileprivate struct IntermediateView<T: Workflow, Content: View> {
+private struct IntermediateView<T: Workflow, Content: View> {
     var workflow: T
     var onOutput: (T.Output) -> Void
     var content: (T.Rendering) -> Content
@@ -270,7 +268,7 @@ fileprivate final class WorkflowHostingViewController<T: Workflow, Content: View
 // Assigning `rootView` on a `UIHostingController` causes unwanted animated transitions.
 // To avoid this, we never change the root view, but we pass down an `ObservableObject`
 // so that we can still update the hierarchy as the workflow emits new renderings.
-fileprivate final class RootViewProvider<T: View>: ObservableObject {
+private final class RootViewProvider<T: View>: ObservableObject {
     @Published var view: T
 
     init(view: T) {
@@ -278,12 +276,10 @@ fileprivate final class RootViewProvider<T: View>: ObservableObject {
     }
 }
 
-fileprivate struct RootView<T: View>: View {
+private struct RootView<T: View>: View {
     @ObservedObject var provider: RootViewProvider<T>
 
     var body: some View {
         provider.view
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import ReactiveSwift
 import UIKit
 import Workflow
@@ -149,5 +147,3 @@ public final class WorkflowHostingController<ScreenType, Output>: UIViewControll
         preferredContentSize = newPreferredContentSize
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
+++ b/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import Foundation
 import ViewEnvironment
 
@@ -115,5 +113,3 @@ extension Screen {
         AdaptedEnvironmentScreen(wrapping: self, adapting: adapting)
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 public struct AnyScreen: Screen {
@@ -41,5 +39,3 @@ extension Screen {
         AnyScreen(self)
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/Screen/Screen.swift
+++ b/WorkflowUI/Sources/Screen/Screen.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 /// Screens are the building blocks of an interactive application.
@@ -51,5 +49,3 @@ extension Screen {
         viewControllerDescription(environment: environment).buildViewController()
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 /// Generic base class that can be subclassed in order to to define a UI implementation that is powered by the
@@ -84,5 +82,3 @@ extension ScreenViewController {
         )
     }
 }
-
-#endif

--- a/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/DescribedViewController.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 public final class DescribedViewController: UIViewController {
@@ -126,4 +124,3 @@ public final class DescribedViewController: UIViewController {
         preferredContentSize = newPreferredContentSize
     }
 }
-#endif

--- a/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 extension UpdateChildScreenViewController where Self: UIViewController {
@@ -119,5 +117,3 @@ extension UpdateChildScreenViewController where Self: UIViewController {
 public protocol UpdateChildScreenViewController {}
 
 extension UIViewController: UpdateChildScreenViewController {}
-
-#endif

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 
 /// A ViewControllerDescription acts as a "recipe" for building and updating a specific `UIViewController`.
@@ -167,5 +165,3 @@ extension ViewControllerDescription {
         }
     }
 }
-
-#endif

--- a/WorkflowUI/Tests/AdaptedEnvironmentScreenTests.swift
+++ b/WorkflowUI/Tests/AdaptedEnvironmentScreenTests.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 import XCTest
 @testable import WorkflowUI
@@ -39,15 +37,15 @@ class AdaptedEnvironmentScreenTests: XCTestCase {
     }
 }
 
-fileprivate enum TestingKey1: ViewEnvironmentKey {
+private enum TestingKey1: ViewEnvironmentKey {
     static let defaultValue: String? = nil
 }
 
-fileprivate enum TestingKey2: ViewEnvironmentKey {
+private enum TestingKey2: ViewEnvironmentKey {
     static let defaultValue: String? = nil
 }
 
-fileprivate struct TestScreen: Screen {
+private struct TestScreen: Screen {
     var read: (ViewEnvironment) -> Void
 
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
@@ -58,5 +56,3 @@ fileprivate struct TestScreen: Screen {
 
     private class ViewController: ScreenViewController<TestScreen> {}
 }
-
-#endif

--- a/WorkflowUI/Tests/DescribedViewControllerTests.swift
+++ b/WorkflowUI/Tests/DescribedViewControllerTests.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import XCTest
 
 import ReactiveSwift
@@ -239,7 +237,7 @@ class DescribedViewControllerTests: XCTestCase {
 
 // MARK: - Helper Types
 
-fileprivate enum TestScreen: Screen, Equatable {
+private enum TestScreen: Screen, Equatable {
     case counter(Int)
     case message(String)
 
@@ -260,7 +258,7 @@ fileprivate enum TestScreen: Screen, Equatable {
     }
 }
 
-fileprivate class WorkflowHostingController: UIViewController {
+private class WorkflowHostingController: UIViewController {
     let describedViewController: DescribedViewController
 
     var preferredContentSizeSignal: Signal<CGSize, Never> { return signal.skipRepeats() }
@@ -295,7 +293,7 @@ fileprivate class WorkflowHostingController: UIViewController {
     }
 }
 
-fileprivate class CounterViewController: UIViewController {
+private class CounterViewController: UIViewController {
     var count: Int {
         didSet {
             preferredContentSize.width = CGFloat(count * 10)
@@ -313,7 +311,7 @@ fileprivate class CounterViewController: UIViewController {
     }
 }
 
-fileprivate class MessageViewController: UIViewController {
+private class MessageViewController: UIViewController {
     var message: String {
         didSet {
             preferredContentSize.width = CGFloat(message.count * 10)
@@ -330,5 +328,3 @@ fileprivate class MessageViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 }
-
-#endif

--- a/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
+++ b/WorkflowUI/Tests/UIViewControllerExtensionTests.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import UIKit
 import XCTest
 @testable import WorkflowUI
@@ -98,7 +96,7 @@ class UIViewControllerExtensionTests: XCTestCase {
     }
 }
 
-fileprivate enum TestingEvent: Equatable {
+private enum TestingEvent: Equatable {
     // View Controller Events
 
     case child_viewWillAppear(identifier: String, animated: Bool)
@@ -267,5 +265,3 @@ private class VCBase: UIViewController {
         recordEvent(.child_didMoveTo(identifier: identifier, parent: parent))
     }
 }
-
-#endif

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import XCTest
 
 import ReactiveSwift
 import Workflow
 @testable import WorkflowUI
 
-fileprivate class BlankViewController: UIViewController {}
+private class BlankViewController: UIViewController {}
 
-@objc fileprivate protocol MyProtocol {
+@objc private protocol MyProtocol {
     func update()
 }
 
@@ -166,5 +164,3 @@ class ViewControllerDescription_KindIdentifierTests: XCTestCase {
         XCTAssertFalse(kind1.canUpdate(viewController: vc2))
     }
 }
-
-#endif

--- a/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
+++ b/WorkflowUI/Tests/WorkflowHostingControllerTests.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if canImport(UIKit)
-
 import XCTest
 
 import ReactiveSwift
@@ -23,7 +21,7 @@ import Workflow
 import WorkflowReactiveSwift
 @testable import WorkflowUI
 
-fileprivate struct TestScreen: Screen {
+private struct TestScreen: Screen {
     var string: String
 
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
@@ -31,7 +29,7 @@ fileprivate struct TestScreen: Screen {
     }
 }
 
-fileprivate final class TestScreenViewController: ScreenViewController<TestScreen> {
+private final class TestScreenViewController: ScreenViewController<TestScreen> {
     var onScreenChange: (() -> Void)?
 
     override func screenDidChange(from previousScreen: TestScreen, previousEnvironment: ViewEnvironment) {
@@ -156,7 +154,7 @@ class WorkflowHostingControllerTests: XCTestCase {
     }
 }
 
-fileprivate struct SubscribingWorkflow: Workflow {
+private struct SubscribingWorkflow: Workflow {
     var subscription: Signal<Int, Never>
 
     typealias State = Int
@@ -180,7 +178,7 @@ fileprivate struct SubscribingWorkflow: Workflow {
     }
 }
 
-fileprivate struct PassthroughWorkflow: Workflow {
+private struct PassthroughWorkflow: Workflow {
     var value: String
 
     typealias State = Void
@@ -192,7 +190,7 @@ fileprivate struct PassthroughWorkflow: Workflow {
     }
 }
 
-fileprivate struct EchoWorkflow: Workflow {
+private struct EchoWorkflow: Workflow {
     var value: Int
 
     typealias State = Void
@@ -218,5 +216,3 @@ fileprivate struct EchoWorkflow: Workflow {
         return TestScreen(string: "\(value)")
     }
 }
-
-#endif

--- a/WorkflowUI/Tests/XCTestCase+Extensions.swift
+++ b/WorkflowUI/Tests/XCTestCase+Extensions.swift
@@ -5,8 +5,6 @@
 //  Created by Kyle Van Essen on 9/1/22.
 //
 
-#if canImport(UIKit)
-
 import Foundation
 import UIKit
 import XCTest
@@ -62,5 +60,3 @@ extension XCTestCase {
         }
     }
 }
-
-#endif


### PR DESCRIPTION
Prior to this PR, every declaration in WorkflowUI is wrapped in `#if canImport(UIKit)`. This allows a platform without UIKit (such as macOS) to import WorkflowUI, but doing so would be pointless as it would import zero symbols.

Likewise with WorkflowCombine and `#if canImport(UIKit)`.

This PR removes all of those `canImport` conditions. This is technically a breaking change for hypothetical clients that been importing those frameworks without receiving symbols from them. Those clients should delete those `import` statements.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
