### PR TITLE
[chore]: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 * @square/foundation-ios
 
-/WorkflowUI/ @square/ui-systems-ios
+/WorkflowUI/ @square/foundation-ios @square/ui-systems-ios


### PR DESCRIPTION
update codeownership so that the `foundation-ios` team is still added as a reviewer on WorkflowUI changes

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
