### PR TITLE
[WIP] SwiftUIScreen with action sink

### DIFF
--- a/Development.podspec
+++ b/Development.podspec
@@ -73,6 +73,7 @@ Pod::Spec.new do |s|
     test_spec.dependency 'BackStackContainer'
     test_spec.dependency 'ModalContainer'
     test_spec.dependency 'AlertContainer'
+    test_spec.dependency 'WorkflowSwiftUI'
     test_spec.requires_app_host = true
     test_spec.app_host_name = 'Development/SampleTicTacToe'
     test_spec.source_files = 'Samples/TicTacToe/Tests/**/*.swift'

--- a/Development.podspec
+++ b/Development.podspec
@@ -63,6 +63,7 @@ Pod::Spec.new do |s|
     app_spec.dependency 'BackStackContainer'
     app_spec.dependency 'ModalContainer'
     app_spec.dependency 'AlertContainer'
+    app_spec.dependency 'WorkflowSwiftUI'
   end
 
   s.test_spec 'TicTacToeTests' do |test_spec|

--- a/Package.swift
+++ b/Package.swift
@@ -133,7 +133,7 @@ let package = Package(
         ),
         .target(
             name: "WorkflowSwiftUI",
-            dependencies: ["Workflow"],
+            dependencies: ["Workflow", "WorkflowUI"],
             path: "WorkflowSwiftUI/Sources"
         ),
 

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -15,6 +15,7 @@
  */
 
 import SwiftUI
+import Workflow
 import WorkflowSwiftUI
 
 struct LoginScreen: SwiftUIScreen, Equatable {

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -31,7 +31,7 @@ struct LoginScreen: SwiftUIScreen, Equatable {
                 "email@address.com",
                 text: model.binding(
                     get: \.email,
-                    set: { screen in { screen.actionSink.send(.emailUpdated($0)) } }
+                    set: Action.emailUpdated
                 )
             )
             .autocapitalization(.none)
@@ -42,7 +42,7 @@ struct LoginScreen: SwiftUIScreen, Equatable {
                 "password",
                 text: model.binding(
                     get: \.password,
-                    set: { screen in { screen.actionSink.send(.passwordUpdated($0)) } }
+                    set: Action.passwordUpdated
                 ),
                 onCommit: { model.value.actionSink.send(.login) }
             )

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import Workflow
-import WorkflowUI
+import SwiftUI
+import WorkflowSwiftUI
 
-struct LoginScreen: Screen {
+struct LoginScreen: SwiftUIScreen {
     var title: String
     var email: String
     var onEmailChanged: (String) -> Void
@@ -25,117 +25,32 @@ struct LoginScreen: Screen {
     var onPasswordChanged: (String) -> Void
     var onLoginTapped: () -> Void
 
-    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-        return ViewControllerDescription(
-            environment: environment,
-            build: { LoginViewController() },
-            update: { $0.update(with: self) }
-        )
-    }
-}
+    static func makeView(model: ObservableValue<LoginScreen>) -> some View {
+        VStack(spacing: 16) {
+            Text(model.title)
 
-private final class LoginViewController: UIViewController {
-    private let welcomeLabel: UILabel = UILabel(frame: .zero)
-    private let emailField: UITextField = UITextField(frame: .zero)
-    private let passwordField: UITextField = UITextField(frame: .zero)
-    private let button: UIButton = UIButton(frame: .zero)
-    private var onEmailChanged: (String) -> Void = { _ in }
-    private var onPasswordChanged: (String) -> Void = { _ in }
-    private var onLoginTapped: () -> Void = {}
+            TextField(
+                "email@address.com",
+                text: model.binding(
+                    get: \.email,
+                    set: \.onEmailChanged
+                )
+            )
+            .autocapitalization(.none)
+            .autocorrectionDisabled()
+            .textContentType(.emailAddress)
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+            SecureField(
+                "password",
+                text: model.binding(
+                    get: \.password,
+                    set: \.onPasswordChanged
+                ),
+                onCommit: model.onLoginTapped
+            )
 
-        view.backgroundColor = .white
-
-        welcomeLabel.textAlignment = .center
-
-        emailField.placeholder = "email@address.com"
-        emailField.autocapitalizationType = .none
-        emailField.autocorrectionType = .no
-        emailField.textContentType = .emailAddress
-        emailField.backgroundColor = UIColor(white: 0.92, alpha: 1.0)
-        emailField.addTarget(self, action: #selector(textDidChange(sender:)), for: .editingChanged)
-
-        passwordField.placeholder = "password"
-        passwordField.isSecureTextEntry = true
-        passwordField.backgroundColor = UIColor(white: 0.92, alpha: 1.0)
-        passwordField.addTarget(self, action: #selector(textDidChange(sender:)), for: .editingChanged)
-
-        button.backgroundColor = UIColor(red: 41 / 255, green: 150 / 255, blue: 204 / 255, alpha: 1.0)
-        button.setTitle("Login", for: .normal)
-        button.addTarget(self, action: #selector(buttonTapped(sender:)), for: .touchUpInside)
-
-        view.addSubview(welcomeLabel)
-        view.addSubview(emailField)
-        view.addSubview(passwordField)
-        view.addSubview(button)
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        let inset: CGFloat = 12.0
-        let height: CGFloat = 44.0
-        var yOffset = (view.bounds.size.height - (3 * height + inset)) / 2.0
-
-        welcomeLabel.frame = CGRect(
-            x: view.bounds.origin.x,
-            y: view.bounds.origin.y,
-            width: view.bounds.size.width,
-            height: yOffset
-        )
-
-        emailField.frame = CGRect(
-            x: view.bounds.origin.x,
-            y: yOffset,
-            width: view.bounds.size.width,
-            height: height
-        )
-        .insetBy(dx: inset, dy: 0.0)
-
-        yOffset += height + inset
-
-        passwordField.frame = CGRect(
-            x: view.bounds.origin.x,
-            y: yOffset,
-            width: view.bounds.size.width,
-            height: height
-        )
-        .insetBy(dx: inset, dy: 0.0)
-
-        yOffset += height + inset
-
-        button.frame = CGRect(
-            x: view.bounds.origin.x,
-            y: yOffset,
-            width: view.bounds.size.width,
-            height: height
-        )
-        .insetBy(dx: inset, dy: 0.0)
-    }
-
-    func update(with screen: LoginScreen) {
-        welcomeLabel.text = screen.title
-        emailField.text = screen.email
-        passwordField.text = screen.password
-        onEmailChanged = screen.onEmailChanged
-        onPasswordChanged = screen.onPasswordChanged
-        onLoginTapped = screen.onLoginTapped
-    }
-
-    @objc private func textDidChange(sender: UITextField) {
-        guard let text = sender.text else {
-            return
+            Button("Login", action: model.onLoginTapped)
         }
-        if sender == emailField {
-            onEmailChanged(text)
-        } else if sender == passwordField {
-            onPasswordChanged(text)
-        }
-    }
-
-    @objc private func buttonTapped(sender: UIButton) {
-        onLoginTapped()
+        .frame(maxWidth: 400)
     }
 }

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -17,13 +17,11 @@
 import SwiftUI
 import WorkflowSwiftUI
 
-struct LoginScreen: SwiftUIScreen {
+struct LoginScreen: SwiftUIScreen, Equatable {
+    var actionSink: ScreenActionSink<LoginWorkflow.Action>
     var title: String
     var email: String
-    var onEmailChanged: (String) -> Void
     var password: String
-    var onPasswordChanged: (String) -> Void
-    var onLoginTapped: () -> Void
 
     static func makeView(model: ObservableValue<LoginScreen>) -> some View {
         VStack(spacing: 16) {
@@ -33,7 +31,7 @@ struct LoginScreen: SwiftUIScreen {
                 "email@address.com",
                 text: model.binding(
                     get: \.email,
-                    set: \.onEmailChanged
+                    set: { screen in { screen.actionSink.send(.emailUpdated($0)) } }
                 )
             )
             .autocapitalization(.none)
@@ -44,12 +42,12 @@ struct LoginScreen: SwiftUIScreen {
                 "password",
                 text: model.binding(
                     get: \.password,
-                    set: \.onPasswordChanged
+                    set: { screen in { screen.actionSink.send(.passwordUpdated($0)) } }
                 ),
-                onCommit: model.onLoginTapped
+                onCommit: { model.value.actionSink.send(.login) }
             )
 
-            Button("Login", action: model.onLoginTapped)
+            Button("Login", action: { model.value.actionSink.send(.login) })
         }
         .frame(maxWidth: 400)
     }

--- a/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginScreen.swift
@@ -44,10 +44,10 @@ struct LoginScreen: SwiftUIScreen, Equatable {
                     get: \.password,
                     set: Action.passwordUpdated
                 ),
-                onCommit: { model.value.actionSink.send(.login) }
+                onCommit: model.action(.login)
             )
 
-            Button("Login", action: { model.value.actionSink.send(.login) })
+            Button("Login", action: model.action(.login))
         }
         .frame(maxWidth: 400)
     }

--- a/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -73,7 +73,7 @@ extension LoginWorkflow {
 
     func render(state: LoginWorkflow.State, context: RenderContext<LoginWorkflow>) -> Rendering {
         LoginScreen(
-            actionSink: .init(context.makeSink(of: Action.self)),
+            actionSink: context.makeSink(),
             title: "Welcome! Please log in to play TicTacToe!",
             email: state.email,
             password: state.password

--- a/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -72,21 +72,11 @@ extension LoginWorkflow {
     typealias Rendering = LoginScreen
 
     func render(state: LoginWorkflow.State, context: RenderContext<LoginWorkflow>) -> Rendering {
-        let sink = context.makeSink(of: Action.self)
-
-        return LoginScreen(
+        LoginScreen(
+            actionSink: .init(context.makeSink(of: Action.self)),
             title: "Welcome! Please log in to play TicTacToe!",
             email: state.email,
-            onEmailChanged: { email in
-                sink.send(.emailUpdated(email))
-            },
-            password: state.password,
-            onPasswordChanged: { password in
-                sink.send(.passwordUpdated(password))
-            },
-            onLoginTapped: {
-                sink.send(.login)
-            }
+            password: state.password
         )
     }
 }

--- a/Samples/TicTacToe/Tests/AuthenticationWorkflowTests.swift
+++ b/Samples/TicTacToe/Tests/AuthenticationWorkflowTests.swift
@@ -183,12 +183,10 @@ class AuthenticationWorkflowTests: XCTestCase {
             .expectWorkflow(
                 type: LoginWorkflow.self,
                 producingRendering: LoginScreen(
+                    actionSink: .noop(),
                     title: "",
                     email: "",
-                    onEmailChanged: { _ in },
-                    password: "",
-                    onPasswordChanged: { _ in },
-                    onLoginTapped: {}
+                    password: ""
                 )
             )
             .render { screen in
@@ -210,12 +208,10 @@ class AuthenticationWorkflowTests: XCTestCase {
             .expectWorkflow(
                 type: LoginWorkflow.self,
                 producingRendering: LoginScreen(
+                    actionSink: .noop(),
                     title: "",
                     email: "",
-                    onEmailChanged: { _ in },
-                    password: "",
-                    onPasswordChanged: { _ in },
-                    onLoginTapped: {}
+                    password: ""
                 )
             )
             .expect(
@@ -244,12 +240,10 @@ class AuthenticationWorkflowTests: XCTestCase {
             .expectWorkflow(
                 type: LoginWorkflow.self,
                 producingRendering: LoginScreen(
+                    actionSink: .noop(),
                     title: "",
                     email: "",
-                    onEmailChanged: { _ in },
-                    password: "",
-                    onPasswordChanged: { _ in },
-                    onLoginTapped: {}
+                    password: ""
                 )
             )
             .expect(
@@ -275,12 +269,10 @@ class AuthenticationWorkflowTests: XCTestCase {
             .expectWorkflow(
                 type: LoginWorkflow.self,
                 producingRendering: LoginScreen(
+                    actionSink: .noop(),
                     title: "",
                     email: "",
-                    onEmailChanged: { _ in },
-                    password: "",
-                    onPasswordChanged: { _ in },
-                    onLoginTapped: {}
+                    password: ""
                 )
             )
             .render { screen in

--- a/Samples/Tutorial/AppHost/Sources/AppDelegate.swift
+++ b/Samples/Tutorial/AppHost/Sources/AppDelegate.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import TutorialBase
+import Tutorial5
 import UIKit
 
 @UIApplicationMain

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
@@ -14,60 +14,29 @@
  * limitations under the License.
  */
 
-import TutorialViews
-import Workflow
-import WorkflowUI
+import SwiftUI
+import WorkflowSwiftUI
 
-struct TodoEditScreen: Screen {
+struct TodoEditScreen: SwiftUIScreen, Equatable {
     // The title of this todo item.
     var title: String
     // The contents, or "note" of the todo.
     var note: String
 
-    // Callback for when the title or note changes
-    var onTitleChanged: (String) -> Void
-    var onNoteChanged: (String) -> Void
+    var actionSink: ScreenActionSink<TodoEditWorkflow.Action>
 
-    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
-        return TodoEditViewController.description(for: self, environment: environment)
-    }
-}
+    static func makeView(model: ObservableValue<TodoEditScreen>) -> some View {
+        VStack {
+            TextField("Title", text: model.binding(
+                get: \.title,
+                set: Action.titleChanged
+            ))
+                .font(.title)
 
-final class TodoEditViewController: ScreenViewController<TodoEditScreen> {
-    private var todoEditView: TodoEditView!
-
-    required init(screen: TodoEditScreen, environment: ViewEnvironment) {
-        super.init(screen: screen, environment: environment)
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        todoEditView = TodoEditView(frame: view.bounds)
-        view.addSubview(todoEditView)
-
-        updateView(with: screen)
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        todoEditView.frame = view.bounds.inset(by: view.safeAreaInsets)
-    }
-
-    override func screenDidChange(from previousScreen: TodoEditScreen, previousEnvironment: ViewEnvironment) {
-        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
-
-        guard isViewLoaded else { return }
-
-        updateView(with: screen)
-    }
-
-    private func updateView(with screen: TodoEditScreen) {
-        // Update the view with the data from the screen.
-        todoEditView.title = screen.title
-        todoEditView.note = screen.note
-        todoEditView.onTitleChanged = screen.onTitleChanged
-        todoEditView.onNoteChanged = screen.onNoteChanged
+            TextEditor(text: model.binding(
+                get: \.note,
+                set: Action.noteChanged
+            ))
+        }.padding()
     }
 }

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
@@ -15,6 +15,7 @@
  */
 
 import SwiftUI
+import Workflow
 import WorkflowSwiftUI
 
 struct TodoEditScreen: SwiftUIScreen, Equatable {

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -116,12 +116,7 @@ extension TodoEditWorkflow {
         let todoEditScreen = TodoEditScreen(
             title: state.todo.title,
             note: state.todo.note,
-            onTitleChanged: { title in
-                sink.send(.titleChanged(title))
-            },
-            onNoteChanged: { note in
-                sink.send(.noteChanged(note))
-            }
+            actionSink: .init(sink)
         )
 
         let backStackItem = BackStackScreen.Item(

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
@@ -151,7 +151,7 @@ class RootWorkflowTests: XCTestCase {
             }
 
             // Update the title.
-            editScreen.onTitleChanged("New Title")
+            editScreen.actionSink.send(.titleChanged("New Title"))
         }
 
         // Save the selected todo.

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
@@ -16,6 +16,7 @@
 
 import BackStackContainer
 import Workflow
+import WorkflowSwiftUI
 import WorkflowTesting
 import WorkflowUI
 import XCTest
@@ -78,8 +79,7 @@ class TodoWorkflowTests: XCTestCase {
                     screen: TodoEditScreen(
                         title: "Title",
                         note: "Note",
-                        onTitleChanged: { _ in },
-                        onNoteChanged: { _ in }
+                        actionSink: .noop()
                     ).asAnyScreen()
                 ),
                 // Simulate it emitting an output of `.save` to update the state.

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Tutorial5.podspec
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Tutorial5.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.dependency 'TutorialViews'
   s.dependency 'Workflow'
   s.dependency 'WorkflowUI'
+  s.dependency 'WorkflowSwiftUI'
   s.dependency 'BackStackContainer'
   s.dependency 'WorkflowReactiveSwift'
 

--- a/Samples/Tutorial/Podfile
+++ b/Samples/Tutorial/Podfile
@@ -6,6 +6,7 @@ platform :ios, WORKFLOW_IOS_DEPLOYMENT_TARGET
 target 'Tutorial' do
     pod 'Workflow', path: '../../Workflow.podspec', :testspecs => ['Tests']
     pod 'WorkflowUI', path: '../../WorkflowUI.podspec', :testspecs => ['Tests']
+    pod 'WorkflowSwiftUI', path: '../../WorkflowSwiftUI.podspec'
     pod 'ViewEnvironment', path: '../../ViewEnvironment.podspec'
     pod 'ViewEnvironmentUI', path: '../../ViewEnvironmentUI.podspec', :testspecs => ['Tests']
     pod 'WorkflowReactiveSwift', path: '../../WorkflowReactiveSwift.podspec', :testspecs => ['Tests']

--- a/Workflow/Sources/ScreenActionSink.swift
+++ b/Workflow/Sources/ScreenActionSink.swift
@@ -17,8 +17,8 @@
 /// A sink intended specifically to fulfill the `actionSink` requirement of ``SwiftUIScreen``. In order that the
 /// `SwiftUIScreen` can automatically be `Equatable`, this sink is `Equatable` and always compares equal.
 ///
-// TODO: Should this really _always_ compare equal? Can we pass in some identity when initializing? Maybe some identifier from the
-/// `RenderContext`, or even just the source location where the sink was initialized?
+/// *TODO:* Should this really _always_ compare equal? Can we pass in some identity when initializing? Maybe some identifier from
+/// the `RenderContext`, or even just the source location where the sink was initialized?
 public struct ScreenActionSink<Value>: Equatable {
     private let sink: Sink<Value>
 
@@ -39,4 +39,8 @@ public struct ScreenActionSink<Value>: Equatable {
     public static func == (lhs: ScreenActionSink<Value>, rhs: ScreenActionSink<Value>) -> Bool {
         true
     }
+}
+
+public extension RenderContext {
+    var actionSink: ScreenActionSink {}
 }

--- a/Workflow/Sources/ScreenActionSink.swift
+++ b/Workflow/Sources/ScreenActionSink.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import Workflow
-
 /// A sink intended specifically to fulfill the `actionSink` requirement of ``SwiftUIScreen``. In order that the
 /// `SwiftUIScreen` can automatically be `Equatable`, this sink is `Equatable` and always compares equal.
 ///

--- a/Workflow/Sources/ScreenActionSink.swift
+++ b/Workflow/Sources/ScreenActionSink.swift
@@ -42,5 +42,7 @@ public struct ScreenActionSink<Value>: Equatable {
 }
 
 public extension RenderContext {
-    var actionSink: ScreenActionSink {}
+    func makeSink<Action: WorkflowAction>() -> ScreenActionSink<Action> where Action.WorkflowType == WorkflowType {
+        ScreenActionSink(makeSink(of: Action.self))
+    }
 }

--- a/WorkflowSwiftUI.podspec
+++ b/WorkflowSwiftUI.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
     s.source_files = 'WorkflowSwiftUI/Sources/*.swift'
 
     s.dependency 'Workflow', "#{s.version}"
+    s.dependency 'WorkflowUI', "#{s.version}"
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 

--- a/WorkflowSwiftUI/Sources/EnvironmentValues+ViewEnvironment.swift
+++ b/WorkflowSwiftUI/Sources/EnvironmentValues+ViewEnvironment.swift
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+import WorkflowUI
+
+private struct ViewEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ViewEnvironment = .empty
+}
+
+public extension EnvironmentValues {
+    var viewEnvironment: ViewEnvironment {
+        get { self[ViewEnvironmentKey.self] }
+        set { self[ViewEnvironmentKey.self] = newValue }
+    }
+}

--- a/WorkflowSwiftUI/Sources/ObservableValue+Binding.swift
+++ b/WorkflowSwiftUI/Sources/ObservableValue+Binding.swift
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+import SwiftUI
+
+public extension ObservableValue {
+    func binding<T>(
+        get: @escaping (Value) -> T,
+        set: @escaping (Value) -> (T) -> Void
+    ) -> Binding<T> {
+        // This convoluted way of creating a `Binding`, relative to `Binding.init(get:set:)`, is
+        // a workaround borrowed from TCA for a SwiftUI issue:
+        // https://github.com/pointfreeco/swift-composable-architecture/pull/770
+        ObservedObject(wrappedValue: self)
+            .projectedValue[get: .init(rawValue: get), set: .init(rawValue: set)]
+    }
+
+    private subscript<T>(
+        get get: HashableWrapper<(Value) -> T>,
+        set set: HashableWrapper<(Value) -> (T) -> Void>
+    ) -> T {
+        get { get.rawValue(value) }
+        set { set.rawValue(value)(newValue) }
+    }
+
+    private struct HashableWrapper<Value>: Hashable {
+        let rawValue: Value
+        static func == (lhs: Self, rhs: Self) -> Bool { false }
+        func hash(into hasher: inout Hasher) {}
+    }
+}
+
+#endif

--- a/WorkflowSwiftUI/Sources/ObservableValue+Binding.swift
+++ b/WorkflowSwiftUI/Sources/ObservableValue+Binding.swift
@@ -45,4 +45,16 @@ public extension ObservableValue {
     }
 }
 
+public extension ObservableValue where Value: SwiftUIScreen {
+    func binding<T>(
+        get: @escaping (Value) -> T,
+        set: @escaping (T) -> (Value.Action)
+    ) -> Binding<T> {
+        binding(
+            get: get,
+            set: { screen in { screen.actionSink.send(set($0)) } }
+        )
+    }
+}
+
 #endif

--- a/WorkflowSwiftUI/Sources/ObservableValue.swift
+++ b/WorkflowSwiftUI/Sources/ObservableValue.swift
@@ -104,3 +104,14 @@ public final class ObservableValue<Value>: ObservableObject {
         return subject.removeDuplicates(by: isDuplicate).eraseToAnyPublisher()
     }
 }
+
+#if canImport(UIKit)
+
+public extension ObservableValue where Value: SwiftUIScreen {
+    func action(_ action: Value.Action) -> () -> Void {
+        // TODO: Should this closure capture the current `actionSink` instead?
+        { [weak self] in self?.value.actionSink.send(action) }
+    }
+}
+
+#endif

--- a/WorkflowSwiftUI/Sources/ObservableValue.swift
+++ b/WorkflowSwiftUI/Sources/ObservableValue.swift
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import Workflow
+
+@dynamicMemberLookup
+public final class ObservableValue<Value>: ObservableObject {
+    private var internalValue: Value
+    private let subject = PassthroughSubject<Value, Never>()
+    private var cancellable: AnyCancellable?
+    private var isDuplicate: ((Value, Value) -> Bool)?
+    public private(set) var value: Value {
+        get {
+            return internalValue
+        }
+        set {
+            subject.send(newValue)
+        }
+    }
+
+    public private(set) lazy var objectWillChange = ObservableObjectPublisher()
+    private var parentCancellable: AnyCancellable?
+
+    public static func makeObservableValue(
+        _ value: Value,
+        isDuplicate: ((Value, Value) -> Bool)? = nil
+    ) -> (ObservableValue, Sink<Value>) {
+        let observableValue = ObservableValue(value: value, isDuplicate: isDuplicate)
+        let sink = Sink { newValue in
+            observableValue.value = newValue
+        }
+
+        return (observableValue, sink)
+    }
+
+    private init(value: Value, isDuplicate: ((Value, Value) -> Bool)?) {
+        self.internalValue = value
+        self.isDuplicate = isDuplicate
+        self.cancellable = valuePublisher()
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                self.objectWillChange.send()
+                self.internalValue = newValue
+            }
+        // Allows removeDuplicates operator to have the initial value.
+        subject.send(value)
+    }
+
+    //// Scopes the ObservableValue to a subset of Value to LocalValue given the supplied closure while allowing to optionally remove duplicates.
+    /// - Parameters:
+    ///   - toLocalValue: A closure that takes a Value and returns a LocalValue.
+    ///   - isDuplicate: An optional closure that checks to see if a LocalValue is a duplicate.
+    /// - Returns: a scoped ObservableValue of LocalValue.
+    public func scope<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue, isDuplicate: ((LocalValue, LocalValue) -> Bool)? = nil) -> ObservableValue<LocalValue> {
+        return scopeToLocalValue(toLocalValue, isDuplicate: isDuplicate)
+    }
+
+    /// Scopes the ObservableValue to a subset of Value to LocalValue given the supplied closure and removes duplicate values using Equatable.
+    /// - Parameter toLocalValue: A closure that takes a Value and returns a LocalValue.
+    /// - Returns: a scoped ObservableValue of LocalValue.
+    public func scope<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue) -> ObservableValue<LocalValue> where LocalValue: Equatable {
+        return scopeToLocalValue(toLocalValue, isDuplicate: { $0 == $1 })
+    }
+
+    /// Returns the value at the given keypath of ``Value``.
+    ///
+    /// In combination with `@dynamicMemberLookup`, this allows us to write `model.myProperty` instead of
+    /// `model.value.myProperty` where `model` has type `ObservableValue<T>`.
+    public subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+        internalValue[keyPath: keyPath]
+    }
+
+    private func scopeToLocalValue<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue, isDuplicate: ((LocalValue, LocalValue) -> Bool)? = nil) -> ObservableValue<LocalValue> {
+        let localObservableValue = ObservableValue<LocalValue>(
+            value: toLocalValue(internalValue),
+            isDuplicate: isDuplicate
+        )
+        localObservableValue.parentCancellable = valuePublisher().sink(receiveValue: { newValue in
+            localObservableValue.value = toLocalValue(newValue)
+        })
+        return localObservableValue
+    }
+
+    private func valuePublisher() -> AnyPublisher<Value, Never> {
+        guard let isDuplicate = isDuplicate else {
+            return subject.eraseToAnyPublisher()
+        }
+
+        return subject.removeDuplicates(by: isDuplicate).eraseToAnyPublisher()
+    }
+}

--- a/WorkflowSwiftUI/Sources/ScreenActionSink.swift
+++ b/WorkflowSwiftUI/Sources/ScreenActionSink.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Workflow
+
+/// A sink intended specifically to fulfill the `actionSink` requirement of ``SwiftUIScreen``. In order that the
+/// `SwiftUIScreen` can automatically be `Equatable`, this sink is `Equatable` and always compares equal.
+///
+// TODO: Should this really _always_ compare equal? Can we pass in some identity when initializing? Maybe some identifier from the
+/// `RenderContext`, or even just the source location where the sink was initialized?
+public struct ScreenActionSink<Value>: Equatable {
+    private let sink: Sink<Value>
+
+    public init(_ sink: Sink<Value>) {
+        self.sink = sink
+    }
+
+    public func send(_ value: Value) {
+        sink.send(value)
+    }
+
+    public static func noop<T>() -> ScreenActionSink<T> {
+        ScreenActionSink<T>(Sink { _ in })
+    }
+
+    // MARK: Equatable
+
+    public static func == (lhs: ScreenActionSink<Value>, rhs: ScreenActionSink<Value>) -> Bool {
+        true
+    }
+}

--- a/WorkflowSwiftUI/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUI/Sources/SwiftUIScreen.swift
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+import SwiftUI
+import Workflow
+import WorkflowUI
+
+public protocol SwiftUIScreen: Screen {
+    associatedtype Content: View
+
+    @ViewBuilder
+    static func makeView(model: ObservableValue<Self>) -> Content
+
+    static var isDuplicate: ((Self, Self) -> Bool)? { get }
+}
+
+public extension SwiftUIScreen {
+    static var isDuplicate: ((Self, Self) -> Bool)? { return nil }
+}
+
+public extension SwiftUIScreen where Self: Equatable {
+    static var isDuplicate: ((Self, Self) -> Bool)? { { $0 == $1 } }
+}
+
+public extension SwiftUIScreen {
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        ViewControllerDescription(
+            type: ModeledHostingController<Self, WithModel<Self, EnvironmentInjectingView<Content>>>.self,
+            environment: environment,
+            build: {
+                let (model, modelSink) = ObservableValue.makeObservableValue(self, isDuplicate: Self.isDuplicate)
+                let (viewEnvironment, envSink) = ObservableValue.makeObservableValue(environment)
+                return ModeledHostingController(
+                    modelSink: modelSink,
+                    viewEnvironmentSink: envSink,
+                    rootView: WithModel(model, content: { model in
+                        EnvironmentInjectingView(
+                            viewEnvironment: viewEnvironment,
+                            content: Self.makeView(model: model)
+                        )
+                    })
+                )
+            },
+            update: {
+                $0.modelSink.send(self)
+                $0.viewEnvironmentSink.send(environment)
+            }
+        )
+    }
+}
+
+private struct EnvironmentInjectingView<Content: View>: View {
+    @ObservedObject var viewEnvironment: ObservableValue<ViewEnvironment>
+    let content: Content
+
+    var body: some View {
+        content
+            .environment(\.viewEnvironment, viewEnvironment.value)
+    }
+}
+
+private final class ModeledHostingController<Model, Content: View>: UIHostingController<Content> {
+    let modelSink: Sink<Model>
+    let viewEnvironmentSink: Sink<ViewEnvironment>
+
+    init(modelSink: Sink<Model>, viewEnvironmentSink: Sink<ViewEnvironment>, rootView: Content) {
+        self.modelSink = modelSink
+        self.viewEnvironmentSink = viewEnvironmentSink
+
+        super.init(rootView: rootView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not implemented")
+    }
+}
+
+#endif

--- a/WorkflowSwiftUI/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUI/Sources/SwiftUIScreen.swift
@@ -22,9 +22,12 @@ import WorkflowUI
 
 public protocol SwiftUIScreen: Screen {
     associatedtype Content: View
+    associatedtype Action
 
     @ViewBuilder
     static func makeView(model: ObservableValue<Self>) -> Content
+
+    var actionSink: ScreenActionSink<Action> { get }
 
     static var isDuplicate: ((Self, Self) -> Bool)? { get }
 }

--- a/WorkflowSwiftUI/Sources/WithModel.swift
+++ b/WorkflowSwiftUI/Sources/WithModel.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+struct WithModel<Model, Content: View>: View {
+    @ObservedObject private var model: ObservableValue<Model>
+    private let content: (ObservableValue<Model>) -> Content
+
+    init(
+        _ model: ObservableValue<Model>,
+        @ViewBuilder content: @escaping (ObservableValue<Model>) -> Content
+    ) {
+        self.model = model
+        self.content = content
+    }
+
+    var body: Content {
+        content(model)
+    }
+}


### PR DESCRIPTION
This PR demonstrates rewriting some Workflow-backed screens from UIKit to SwiftUI, significantly simplifying their implementations:
- `LoginScreen` from the TicTacToe example
- `TodoEditScreen` from Tutorial 5

It does so by:
1. Following the approach described in the [Binding SwiftUI Views to Workflow Renderings](https://docs.google.com/document/d/1DemHF9RViaNBUkp4T3rPqigGK2pZBJqtsyVVudncZCY/edit#heading=h.fbtihzhp50j) design doc, replacing the `Rendering`s' `Screen` conformances with `SwiftUIScreen` conformances.
2. Altering the `Rendering`s themselves to hold a single, `Equatable` action sink rather than multiple callback functions, allowing the `Rendering` itself to derive `Equatable`.

## Commits

The PR is designed to be read commit-by-commit:

### c7d51b623518a1bd219d302ff0f8ebb70ff4dc79: Introduce WorkflowSwiftUI types

Pastes in some types from previous Workflow SwiftUI experiments, nearly unchanged, that are discussed in the [Binding SwiftUI Views to Workflow Renderings](https://docs.google.com/document/d/1DemHF9RViaNBUkp4T3rPqigGK2pZBJqtsyVVudncZCY/edit#heading=h.fbtihzhp50j) design doc. Most importantly:
- `SwiftUIScreen`, the protocol that a `Screen` may conform to if it wishes to provide a SwiftUI `View` in lieu of a `ViewControllerDescription`
- `ObservableValue`, which exposes `Rendering`s from the `Workflow` to the SwiftUI `View`

### 2fbfc5e2e91ab316a17d178a315c156f0ca4a12d: Make `LoginScreen` a `SwiftUIScreen`

Replaces `LoginScreen`'s `Screen` conformance with a `SwiftUIScreen` conformance. This already simplifies the implementation significantly, but the next few commits simplify it further.

### 0340049e1e80261193db11dfe2fe27782470c8f3: Replace callbacks with action sink

Replaces the callback functions in `LoginScreen` with a single `ScreenActionSink`, allowing `LoginScreen` to derive `Equatable`. The also simplifies `LoginWorkflow` and its tests a bit.

### f039b474084fbf76c85c98f2cc9ede36e9a18b1e, 7a9164a4f3a5e37e443b1fb3b1a6c223b4dd83d6: Syntactic sugar

Introduces extensions on `ObservableValue` that make data bindings in the `View` more concise.

### 53fc65b53fc9d77a73bc532ac7dfb9ae6e41cd9a: Make `TodoEditScreen` a `SwiftUIScreen`

Rewrite another screen to SwiftUI, taking advantage again of all types and extensions described above.

## Further reading

#228 adds additional syntactic sugar for exposing two-way bindings to properties on the `State`.