### PR TITLE
[fix]: update WorkflowHostingController on layout if ancestor hierarchy has changed

### DIFF
--- a/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
+++ b/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
@@ -272,6 +272,45 @@ extension ViewEnvironmentPropagating {
             objc_setAssociatedObject(self, &AssociatedKeys.descendantsOverride, newValue, .OBJC_ASSOCIATION_RETAIN)
         }
     }
+
+    /// Returns an `Equatable` representation of the `ViewEnvironmentPropagating` environment
+    /// ancestor tree path.
+    ///
+    /// This can be useful, for example, if you need to determine if any ancestor was inserted or
+    /// removed above this node.
+    ///
+    /// The `Equatable` implementation of this type compares the tree as an array of object
+    /// identifiers for each node.
+    ///
+    @_spi(ViewEnvironmentWiring)
+    public var environmentAncestorPath: EnvironmentAncestorPath {
+        var path = EnvironmentAncestorPath()
+
+        if let first = environmentAncestor {
+            for node in sequence(first: first, next: \.environmentAncestor) {
+                path.nodes.append(ObjectIdentifier(node))
+            }
+        }
+
+        return path
+    }
+
+    @_spi(ViewEnvironmentWiring)
+    public typealias EnvironmentAncestorPath = ViewEnvironmentPropagatingAncestorPath
+}
+
+/// An `Equatable` representation of the `ViewEnvironmentPropagating` environment ancestor tree
+/// path.
+///
+/// This can be useful, for example, if you need to determine if any ancestor was inserted or
+/// removed above this node.
+///
+/// The `Equatable` implementation of this type compares the tree as an array of object
+/// identifiers for each node.
+///
+@_spi(ViewEnvironmentWiring)
+public struct ViewEnvironmentPropagatingAncestorPath: Equatable {
+    var nodes: [ObjectIdentifier] = []
 }
 
 /// A closure that is called when the `ViewEnvironment` needs to be updated.

--- a/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
+++ b/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
@@ -279,8 +279,8 @@ extension ViewEnvironmentPropagating {
     /// This can be useful, for example, if you need to determine if any ancestor was inserted or
     /// removed above this node.
     ///
-    /// The `Equatable` implementation of this type compares the tree as an array of object
-    /// identifiers for each node.
+    /// The `Equatable` implementation of this type compares the tree as an array of weak
+    /// references.
     ///
     @_spi(ViewEnvironmentWiring)
     public var environmentAncestorPath: EnvironmentAncestorPath {
@@ -305,8 +305,7 @@ extension ViewEnvironmentPropagating {
 /// This can be useful, for example, if you need to determine if any ancestor was inserted or
 /// removed above this node.
 ///
-/// The `Equatable` implementation of this type compares the tree as an array of object
-/// identifiers for each node.
+/// The `Equatable` implementation of this type compares the tree as an array of weak references.
 ///
 @_spi(ViewEnvironmentWiring)
 public struct ViewEnvironmentPropagatingAncestorPath: Equatable {


### PR DESCRIPTION
# Problem

When a `WorkflowHostingController` is added to a `UIViewController` hierarchy, we need to ensure that we re-render the `Screen` using an updated `ViewEnvironment`, since the environment from the ancestor path above that `WorkflowHostingController` could contain customizations that are not present in the `WorkflowHostingController` itself.

Currently, it is expected that consumers would call `setNeedsEnvironmentUpdate()` when adding a `WorkflowHostingController` as a child, but this is fragile and hard to enforce/validate, especially in legacy code.

Omitting this `setNeedsEnvironmentUpdate()` can cause issues where content would be rendered on screen using invalid `ViewEnvironment` values on the first rendering. On a later environment update, we'd likely see this environment reflect the correct values, but we want to avoid showing content with bad `ViewEnvironment` information whenever possible. An example of this issue can be seen in [this Slack thread from a in issue reported in `ios-register`](https://square.slack.com/archives/CTJ4UNLHF/p1687895879847009).

# Solution

While consumers should still try to call `setNeedsEnvironmentUpdate()` whenever the environment changes (either through an update in value or an update in path), this PR attempts to catch mistakes and legacy usecases by tracking the ancestor tree node path when state updates and layouts occur, and if that path changes, we'll ensure an update occurs on the next layout pass.

# Integration

I've smoke tested this change in `ios-register` and `market` and no changes are needed upstream to support this fix. Here are the integration PRs (with no real code changes) that show passing CI jobs:

`ios-register`: https://github.com/squareup/ios-register/pull/88056
`market`: https://github.com/squareup/market/pull/6547