### PR TITLE
[fix]: support nil output in RenderTester Publisher extension

### DIFF
--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -23,11 +23,12 @@ import XCTest
 @testable import WorkflowCombine
 
 extension RenderTester {
-    /// Expect a `Publisher`s.
+    /// Expect a `Publisher`-based Workflow.
     ///
     /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
     ///
     /// - Parameters:
+    ///   - publisher: Type of the Publisher-based Workflow to expect
     ///   - producingOutput: An output that should be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
     public func expect<PublisherType: Publisher>(

--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -32,7 +32,7 @@ extension RenderTester {
     ///   - key: Key to expect this `Workflow` to be rendered with.
     public func expect<PublisherType: Publisher>(
         publisher: PublisherType.Type,
-        output: PublisherType.Output,
+        producingOutput output: PublisherType.Output? = nil,
         key: String = ""
     ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
         expectWorkflow(
@@ -41,6 +41,19 @@ extension RenderTester {
             producingRendering: (),
             producingOutput: output,
             assertions: { _ in }
+        )
+    }
+
+    @available(*, deprecated, renamed: "expect(publisher:producingOutput:key:)")
+    public func expect<PublisherType: Publisher>(
+        publisher: PublisherType.Type,
+        output: PublisherType.Output,
+        key: String = ""
+    ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
+        expect(
+            publisher: publisher,
+            producingOutput: output,
+            key: key
         )
     }
 }

--- a/WorkflowCombine/TestingTests/PublisherTests.swift
+++ b/WorkflowCombine/TestingTests/PublisherTests.swift
@@ -18,7 +18,7 @@ class PublisherTests: XCTestCase {
             .renderTester()
             .expect(
                 publisher: Publishers.Sequence<[Int], Never>.self,
-                output: 1,
+                producingOutput: 1,
                 key: "123"
             )
             .render {}

--- a/WorkflowCombine/TestingTests/PublisherTests.swift
+++ b/WorkflowCombine/TestingTests/PublisherTests.swift
@@ -16,8 +16,24 @@ class PublisherTests: XCTestCase {
     func testPublisherWorkflow() {
         TestWorkflow()
             .renderTester()
-            .expect(publisher: Publishers.Sequence<[Int], Never>.self, output: 1, key: "123")
+            .expect(
+                publisher: Publishers.Sequence<[Int], Never>.self,
+                output: 1,
+                key: "123"
+            )
             .render {}
+    }
+
+    func test_publisher_no_output() {
+        TestWorkflow()
+            .renderTester()
+            .expect(
+                publisher: Publishers.Sequence<[Int], Never>.self,
+                producingOutput: nil,
+                key: "123"
+            )
+            .render {}
+            .assertNoAction()
     }
 
     struct TestWorkflow: Workflow {


### PR DESCRIPTION
### Issue

- the `WorkflowCombine` `RenderTester` extensions didn't allow `nil` output

### Description

- add a new method to support `nil` output and match the naming convention of analogous methods
- deprecate old method
- update tests

addresses https://github.com/square/workflow-swift/issues/235

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
