### PR TITLE
[fix]: improve fatal error diagnostic message in RenderTester

### DIFF
--- a/WorkflowCombine/TestingTests/TestingTests.swift
+++ b/WorkflowCombine/TestingTests/TestingTests.swift
@@ -76,7 +76,7 @@ class WorkflowCombineTestingTests: XCTestCase {
         let tester = TestWorkflow()
             .renderTester(initialState: .init(mode: .worker(input: "test"), output: ""))
 
-        expectingFailure(#"Unexpected workflow of type WorkerWorkflow<TestWorker> with key """#) {
+        expectingFailure(#"unexpected Workflow of type WorkerWorkflow<TestWorker> with key """#) {
             tester.render { _ in }
         }
     }

--- a/WorkflowConcurrency/TestingTests/TestingTests.swift
+++ b/WorkflowConcurrency/TestingTests/TestingTests.swift
@@ -75,7 +75,7 @@ class WorkflowConcurrencyTestingTests: XCTestCase {
         let tester = TestWorkflow()
             .renderTester(initialState: .init(mode: .worker(input: "test"), output: ""))
 
-        expectingFailure(#"Unexpected workflow of type WorkerWorkflow<TestWorker> with key """#) {
+        expectingFailure(#"unexpected Workflow of type WorkerWorkflow<TestWorker> with key """#) {
             tester.render { _ in }
         }
     }

--- a/WorkflowReactiveSwift/TestingTests/TestingTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/TestingTests.swift
@@ -76,7 +76,7 @@ class WorkflowReactiveSwiftTestingTests: XCTestCase {
         let tester = TestWorkflow()
             .renderTester(initialState: .init(mode: .worker(input: "test"), output: ""))
 
-        expectingFailure(#"Unexpected workflow of type WorkerWorkflow<TestWorker> with key """#) {
+        expectingFailure(#"unexpected Workflow of type WorkerWorkflow<TestWorker> with key """#) {
             tester.render { _ in }
         }
     }

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -66,14 +66,15 @@ extension RenderTester {
                     If this child Workflow is expected, please add a call to `expectWorkflow(...)` with the appropriate parameters before invoking `render()`.
                     """
                 }
-                XCTFail("Unexpected workflow of type \(Child.self) with key \"\(key)\". \(diagnosticMessage)", file: file, line: line)
+                let failureMessage = "Attempted to render unexpected Workflow of type \(Child.self) with key \"\(key)\". \(diagnosticMessage)"
+                XCTFail(failureMessage, file: file, line: line)
 
                 // We can “recover” from missing Void-rendering workflows since there’s only one possible value to return
                 if Child.Rendering.self == Void.self {
                     // Couldn’t find a nicer way to do this polymorphically
                     return () as! Child.Rendering
                 }
-                fatalError("Unable to continue.")
+                fatalError("Unable to compose final Rendering. \(failureMessage)")
             }
             let (inserted, _) = usedWorkflowKeys.insert(WorkflowKey(type: ObjectIdentifier(Child.self), key: key))
             if !inserted {

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -112,7 +112,7 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         let tester = TestWorkflow()
             .renderTester(initialState: .voidWorkflow)
 
-        expectingFailure(#"Unexpected workflow of type VoidWorkflow with key "". If this child Workflow is expected, please add a call to `expectWorkflow(...)` with the appropriate parameters before invoking `render()`."#) {
+        expectingFailure(#"unexpected Workflow of type VoidWorkflow with key "". If this child Workflow is expected, please add a call to `expectWorkflow(...)` with the appropriate parameters before invoking `render()`."#) {
             tester.render { _ in }
         }
     }


### PR DESCRIPTION
### Issue

when the `RenderTester`'s `RenderContext` cannot produce a value for the expected rendering type, it must abort program execution. the informative error message that is used to populate a test failure description isn't as easily discoverable in Xcode's diagnostic overlay in this case.

### Description

update the messaging in these circumstances

now looks like:
<img width="66%" src="https://github.com/square/workflow-swift/assets/2119834/47174852-f7ad-4f58-9597-a3c405f5202a">


## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
