### PR TITLE
Exhaustive RenderTester state assertion

### DIFF
--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -43,22 +43,6 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         return self
     }
 
-    /// Exhaustive state testing against the initial state.
-    /// - Parameters:
-    ///   - changes: A function that receives the initial state
-    ///   and is expected to mutate it to match the new state.
-    @discardableResult
-    public func assertState(
-        file: StaticString = #file,
-        line: UInt = #line,
-        changes: (inout WorkflowType.State) throws -> Void
-    ) rethrows -> RenderTesterResult<WorkflowType> where WorkflowType.State: Equatable {
-        var initialState = self.initialState
-        try changes(&initialState)
-        XCTAssertEqual(initialState, state, "Initial state did not match new state", file: file, line: line)
-        return self
-    }
-
     /// Asserts that no actions were produced
     @discardableResult
     public func assertNoAction(
@@ -136,6 +120,22 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> {
         XCTAssertEqual(state, expectedState, file: file, line: line)
+        return self
+    }
+
+    /// Exhaustive state testing against the initial state.
+    /// - Parameters:
+    ///   - changes: A function that receives the initial state
+    ///   and is expected to mutate it to match the new state.
+    @discardableResult
+    public func assertStateModifications(
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ modifications: (inout WorkflowType.State) throws -> Void
+    ) rethrows -> RenderTesterResult<WorkflowType> {
+        var initialState = self.initialState
+        try modifications(&initialState)
+        XCTAssertEqual(state, initialState, "Expected state does not match", file: file, line: line)
         return self
     }
 }

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -125,7 +125,7 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
 
     /// Exhaustive state testing against the initial state.
     /// - Parameters:
-    ///   - changes: A function that receives the initial state
+    ///   - modifications: A function that receives the initial state
     ///   and is expected to mutate it to match the new state.
     @discardableResult
     public func assertStateModifications(

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -275,6 +275,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         try assertions(rendering)
 
         return RenderTesterResult<WorkflowType>(
+            initialState: state,
             state: contextImplementation.state,
             appliedAction: contextImplementation.appliedAction,
             output: contextImplementation.producedOutput

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -340,6 +340,18 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             }
         }
     }
+
+    func test_assertState() {
+        let result = TestWorkflow()
+            .renderTester(initialState: .idle)
+            .render { _ in }
+
+        expectingFailure("Initial state did not match new state") {
+            result.assertState { state in
+                state = .sideEffect(key: "nah")
+            }
+        }
+    }
 }
 
 private struct TestWorkflow: Workflow {

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -346,8 +346,8 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             .renderTester(initialState: .idle)
             .render { _ in }
 
-        expectingFailure("Initial state did not match new state") {
-            result.assertState { state in
+        expectingFailure("Expected state does not match") {
+            result.assertStateModifications { state in
                 state = .sideEffect(key: "nah")
             }
         }

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -185,7 +185,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .verifyState { state in
                 XCTAssertEqual("Failed", state.text)
             }
-            .assertState { state in
+            .assertStateModifications { state in
                 state.text = "Failed"
             }
     }

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -185,6 +185,9 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .verifyState { state in
                 XCTAssertEqual("Failed", state.text)
             }
+            .assertState { state in
+                state.text = "Failed"
+            }
     }
 }
 


### PR DESCRIPTION
- Before: To perform exhaustive state assertions with a RenderTester you have to manually keep track of the initial state.
- After: Added RenderTesterResult/assertState which makes it easy to perform exhaustive state assertions by mutating the initial state


## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
