### PR TITLE
[fix]: add render context validation check to makeSink

### DIFF
--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -67,6 +67,16 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
+    /// Creates a `Sink` that can be used to send `Action`s.
+    ///
+    /// Sinks are the primary mechanism for feeding State-changing events into the Workflow runtime.
+    /// Upon receipt of an action, the associated Workflow (node) in the tree will have its State
+    /// potentially transformed, and then any subsequent Output will be propagated to its parent node until
+    /// the root of the Workflow tree is reached. At this point the tree will be re-rendered to reflect any
+    /// State changes that occurred.
+    ///
+    /// - Parameter actionType: The type of Action this Sink may process
+    /// - Returns: A Sink capable of relaying `Action` instances to the Workflow runtime
     public func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action: WorkflowAction, Action.WorkflowType == WorkflowType {
         fatalError()
     }
@@ -114,6 +124,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         }
 
         override func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where WorkflowType == Action.WorkflowType, Action: WorkflowAction {
+            assertStillValid()
             return implementation.makeSink(of: actionType)
         }
 


### PR DESCRIPTION
### Issue

the `makeSink(...)` method of the concrete `RenderContext` implementation did not include the same validation assertion that all other methods of the type have. this could lead to issues where a context was retained outside of a `render(...)` method and if it was used to make a sink outside that method, we would not detect that unexpected state.

### Description

- adds a `assertStillValid` check to the `makeSink` method
- adds doc comments for the method

note: personally i think we should aim to go a bit further and make the validation assertion a precondition as well as destroy the reference to the internal context when the externally-accessible context is invalidated. but that sort of change likely requires gathering some data about places that might currently break if we were to fail more 'aggressively' in that scenario.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
