### PR TITLE
Resolved Swift 5.9 compilation warning related to UnsafeRawPointer object conversion

### DIFF
--- a/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
+++ b/ViewEnvironmentUI/Sources/ViewEnvironmentPropagating.swift
@@ -401,11 +401,11 @@ public final class ViewEnvironmentUpdateObservationLifetime {
 }
 
 private enum ViewEnvironmentPropagatingNSObjectAssociatedKeys {
-    static var needsEnvironmentUpdate = NSObject()
-    static var needsUpdateObservers = NSObject()
-    static var ancestorOverride = NSObject()
-    static var descendantsOverride = NSObject()
-    static var customizations = NSObject()
+    static var needsEnvironmentUpdate: UInt8 = 0
+    static var needsUpdateObservers: UInt8 = 0
+    static var ancestorOverride: UInt8 = 0
+    static var descendantsOverride: UInt8 = 0
+    static var customizations: UInt8 = 0
 }
 
 extension ViewEnvironmentPropagating {


### PR DESCRIPTION
[Swift 5.9](https://github.com/apple/swift/blob/main/CHANGELOG.md#swift-59) introduced a [new warning](https://github.com/apple/swift/issues/64927) related to object conversions to `UnsafeRawPointer`.

<details>

<img width="1951" alt="image" src="https://github.com/square/workflow-swift/assets/430436/9c3ed6e0-882b-4946-b41d-d369a90356d3">

</details>

This updates the key type on associated object invocations to be a `UInt8` which avoids the warning.

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
