### PR TITLE
[fix]: address some RenderTester limitations with optionals

### DIFF
--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -21,17 +21,19 @@ import XCTest
 @testable import WorkflowReactiveSwift
 
 extension RenderTester {
-    /// Expect a `SignalProducer`.
+    /// Expect a `SignalProducer` with an optional output.
     ///
     /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
     ///
     ///  ⚠️ N.B. If you are testing a case in which multiple `SignalProducerWorkflow`s are expected, **only one of them** may have a non-nil `producingOutput` parameter.
     ///
     /// - Parameters:
+    ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`. Typically this will be correctly inferred by the type system, but may need to be explicitly specified if particular optionality is desired.
     ///   - producingOutput: An output that should be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
     public func expectSignalProducer<OutputType>(
-        producingOutput output: OutputType? = nil,
+        outputType: OutputType.Type = OutputType.self,
+        producingOutput: OutputType? = nil,
         key: String = "",
         file: StaticString = #file, line: UInt = #line
     ) -> RenderTester<WorkflowType> {
@@ -39,25 +41,7 @@ extension RenderTester {
             type: SignalProducerWorkflow<OutputType>.self,
             key: key,
             producingRendering: (),
-            producingOutput: output,
-            assertions: { _ in }
-        )
-    }
-
-    /// Expect a `SignalProducer` with the specified `outputType` that produces no `Output`.
-    ///
-    /// - Parameters:
-    ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`.
-    ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expectSignalProducer<OutputType>(
-        outputType: OutputType.Type,
-        key: String = "",
-        file: StaticString = #file, line: UInt = #line
-    ) -> RenderTester<WorkflowType> {
-        expectWorkflow(
-            type: SignalProducerWorkflow<OutputType>.self,
-            key: key,
-            producingRendering: (),
+            producingOutput: producingOutput,
             assertions: { _ in }
         )
     }

--- a/WorkflowReactiveSwift/TestingTests/SignalProducerTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/SignalProducerTests.swift
@@ -50,6 +50,16 @@ class SignalProducerTests: XCTestCase {
             .render {}
     }
 
+    func test_signalProducerWorkflow_optionalOutput() {
+        OptionalOutputWorkflow()
+            .renderTester()
+            .expectSignalProducer(
+                outputType: Int?.self, // comment this out & test fails
+                producingOutput: nil as Int?
+            )
+            .render {}
+    }
+
     private struct TestWorkflow: Workflow {
         typealias State = Void
         typealias Rendering = Void
@@ -62,6 +72,18 @@ class SignalProducerTests: XCTestCase {
                     .mapOutput { _ in AnyWorkflowAction<TestWorkflow>.noAction }
                     .running(in: context, key: key)
             }
+        }
+    }
+
+    private struct OptionalOutputWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Void
+        typealias Output = Int?
+
+        func render(state: State, context: RenderContext<Self>) -> Rendering {
+            SignalProducer(value: Int?.some(1))
+                .mapOutput { _ in AnyWorkflowAction<Self>.noAction }
+                .rendered(in: context)
         }
     }
 }

--- a/WorkflowRxSwift/Testing/ObservableTesting.swift
+++ b/WorkflowRxSwift/Testing/ObservableTesting.swift
@@ -24,9 +24,11 @@ extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
 
     /// - Parameters:
-    ///   - worker: The worker to be expected
-    ///   - output: An output that should be returned when this worker is requested, if any.
+    ///   - outputType: The `OutputType` of the expected `ObservableWorkflow`.
+    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
     public func expectObservable<OutputType>(
+        outputType: OutputType.Type = OutputType.self,
         producingOutput output: OutputType? = nil,
         key: String = "",
         file: StaticString = #file, line: UInt = #line

--- a/WorkflowRxSwift/TestingTests/ObservableTests.swift
+++ b/WorkflowRxSwift/TestingTests/ObservableTests.swift
@@ -28,7 +28,18 @@ class ObservableTests: XCTestCase {
             .render {}
     }
 
-    struct TestWorkflow: Workflow {
+    func test_observableWorkflow_optionalOutputType() {
+        OptionalOutputWorkflow()
+            .renderTester()
+            .expectObservable(
+                outputType: Int?.self, // comment this out & test fails
+                producingOutput: nil as Int?,
+                key: "123"
+            )
+            .render {}
+    }
+
+    private struct TestWorkflow: Workflow {
         typealias State = Void
         typealias Rendering = Void
 
@@ -36,6 +47,19 @@ class ObservableTests: XCTestCase {
             Observable.from([1])
                 .mapOutput { _ in AnyWorkflowAction<TestWorkflow>.noAction }
                 .running(in: context, key: "123")
+        }
+    }
+
+    private struct OptionalOutputWorkflow: Workflow {
+        typealias State = Void
+        typealias Rendering = Void
+        typealias Output = Int?
+
+        func render(state: State, context: RenderContext<Self>) -> Rendering {
+            Observable.from([1])
+                .map { Int?.some($0) }
+                .mapOutput { _ in AnyWorkflowAction<Self>.noAction }
+                .rendered(in: context, key: "123")
         }
     }
 }


### PR DESCRIPTION
### Issue

due to generic type inference behavior, certain `RenderTester` utilities made it impossible (or at least convoluted) to test underlying Workflows that had outputs of Optional type.

### Description

- audited existing `RenderTester` extensions
- added optional type parameters to methods that lacked a way to specify the expected generic types directly

## Checklist

- [x] Unit Tests
~- [ ] UI Tests~ n/a
~- [ ] Snapshot Tests (iOS only)~ n/a
~- [ ] I have made corresponding changes to the documentation~ n/a
