### PR TITLE
Add WorkflowSwiftUIExperimental 

### DIFF
--- a/Development.podspec
+++ b/Development.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.dependency 'WorkflowRxSwift'
   s.dependency 'WorkflowCombine'
   s.dependency 'WorkflowConcurrency'
+  s.dependency 'WorkflowSwiftUIExperimental'
   s.dependency 'ViewEnvironment'
   s.dependency 'ViewEnvironmentUI'
   

--- a/WorkflowSwiftUIExperimental.podspec
+++ b/WorkflowSwiftUIExperimental.podspec
@@ -1,0 +1,25 @@
+require_relative('version')
+
+Pod::Spec.new do |s|
+    s.name         = 'WorkflowSwiftUIExperimental'
+    s.version      = '0.1'
+    s.summary      = 'Infrastructure for Workflow-powered SwiftUI'
+    s.homepage     = 'https://www.github.com/square/workflow-swift'
+    s.license      = 'Apache License, Version 2.0'
+    s.author       = 'Square'
+    s.source       = { :git => 'https://github.com/square/workflow-swift.git', :tag => "swiftui-experimental/v#{s.version}" }
+
+    # 1.7 is needed for `swift_versions` support
+    s.cocoapods_version = '>= 1.7.0'
+
+    s.swift_versions = [WORKFLOW_SWIFT_VERSION]
+    s.ios.deployment_target = WORKFLOW_IOS_DEPLOYMENT_TARGET
+    s.osx.deployment_target = WORKFLOW_MACOS_DEPLOYMENT_TARGET
+
+    s.source_files = 'WorkflowSwiftUIExperimental/Sources/*.swift'
+
+    s.dependency 'Workflow'
+    s.dependency 'WorkflowUI'
+
+    s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+  end

--- a/WorkflowSwiftUIExperimental.podspec
+++ b/WorkflowSwiftUIExperimental.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
 
     s.source_files = 'WorkflowSwiftUIExperimental/Sources/*.swift'
 
-    s.dependency 'Workflow'
-    s.dependency 'WorkflowUI'
+    s.dependency 'Workflow', WORKFLOW_VERSION
+    s.dependency 'WorkflowUI', WORKFLOW_VERSION
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   end

--- a/WorkflowSwiftUIExperimental/README.md
+++ b/WorkflowSwiftUIExperimental/README.md
@@ -1,0 +1,11 @@
+# WorkflowSwiftUIExperimental
+
+Experimental extensions to Workflow for writing Screens in SwiftUI.
+
+## Versioning
+
+Because this module is experimental, it is versioned separately from other modules in Workflow. You should bump its version as part of any pull request that changes it, and need not bump its version in PRs that change only other modules.
+
+Per semantic versioning, its major version remains at `0`, and only its minor version is incremented. Any increase in the minor version may come with breaking changes.
+
+To bump the minor version, update `s.version` in `WorkflowSwiftUIExperimental.podspec`.

--- a/WorkflowSwiftUIExperimental/Sources/EnvironmentValues+ViewEnvironment.swift
+++ b/WorkflowSwiftUIExperimental/Sources/EnvironmentValues+ViewEnvironment.swift
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+import WorkflowUI
+
+private struct ViewEnvironmentKey: EnvironmentKey {
+    static let defaultValue: ViewEnvironment = .empty
+}
+
+public extension EnvironmentValues {
+    var viewEnvironment: ViewEnvironment {
+        get { self[ViewEnvironmentKey.self] }
+        set { self[ViewEnvironmentKey.self] = newValue }
+    }
+}

--- a/WorkflowSwiftUIExperimental/Sources/ObservableValue+Binding.swift
+++ b/WorkflowSwiftUIExperimental/Sources/ObservableValue+Binding.swift
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+import SwiftUI
+
+public extension ObservableValue {
+    func binding<T>(
+        get: @escaping (Value) -> T,
+        set: @escaping (Value) -> (T) -> Void
+    ) -> Binding<T> {
+        // This convoluted way of creating a `Binding`, relative to `Binding.init(get:set:)`, is
+        // a workaround borrowed from TCA for a SwiftUI issue:
+        // https://github.com/pointfreeco/swift-composable-architecture/pull/770
+        ObservedObject(wrappedValue: self)
+            .projectedValue[get: .init(rawValue: get), set: .init(rawValue: set)]
+    }
+
+    private subscript<T>(
+        get get: HashableWrapper<(Value) -> T>,
+        set set: HashableWrapper<(Value) -> (T) -> Void>
+    ) -> T {
+        get { get.rawValue(value) }
+        set { set.rawValue(value)(newValue) }
+    }
+
+    private struct HashableWrapper<Value>: Hashable {
+        let rawValue: Value
+        static func == (lhs: Self, rhs: Self) -> Bool { false }
+        func hash(into hasher: inout Hasher) {}
+    }
+}
+
+#endif

--- a/WorkflowSwiftUIExperimental/Sources/ObservableValue.swift
+++ b/WorkflowSwiftUIExperimental/Sources/ObservableValue.swift
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Combine
+import Workflow
+
+@dynamicMemberLookup
+public final class ObservableValue<Value>: ObservableObject {
+    private var internalValue: Value
+    private let subject = PassthroughSubject<Value, Never>()
+    private var cancellable: AnyCancellable?
+    private var isDuplicate: ((Value, Value) -> Bool)?
+    public private(set) var value: Value {
+        get {
+            return internalValue
+        }
+        set {
+            subject.send(newValue)
+        }
+    }
+
+    public private(set) lazy var objectWillChange = ObservableObjectPublisher()
+    private var parentCancellable: AnyCancellable?
+
+    public static func makeObservableValue(
+        _ value: Value,
+        isDuplicate: ((Value, Value) -> Bool)? = nil
+    ) -> (ObservableValue, Sink<Value>) {
+        let observableValue = ObservableValue(value: value, isDuplicate: isDuplicate)
+        let sink = Sink { newValue in
+            observableValue.value = newValue
+        }
+
+        return (observableValue, sink)
+    }
+
+    private init(value: Value, isDuplicate: ((Value, Value) -> Bool)?) {
+        self.internalValue = value
+        self.isDuplicate = isDuplicate
+        self.cancellable = valuePublisher()
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                self.objectWillChange.send()
+                self.internalValue = newValue
+            }
+        // Allows removeDuplicates operator to have the initial value.
+        subject.send(value)
+    }
+
+    //// Scopes the ObservableValue to a subset of Value to LocalValue given the supplied closure while allowing to optionally remove duplicates.
+    /// - Parameters:
+    ///   - toLocalValue: A closure that takes a Value and returns a LocalValue.
+    ///   - isDuplicate: An optional closure that checks to see if a LocalValue is a duplicate.
+    /// - Returns: a scoped ObservableValue of LocalValue.
+    public func scope<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue, isDuplicate: ((LocalValue, LocalValue) -> Bool)? = nil) -> ObservableValue<LocalValue> {
+        return scopeToLocalValue(toLocalValue, isDuplicate: isDuplicate)
+    }
+
+    /// Scopes the ObservableValue to a subset of Value to LocalValue given the supplied closure and removes duplicate values using Equatable.
+    /// - Parameter toLocalValue: A closure that takes a Value and returns a LocalValue.
+    /// - Returns: a scoped ObservableValue of LocalValue.
+    public func scope<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue) -> ObservableValue<LocalValue> where LocalValue: Equatable {
+        return scopeToLocalValue(toLocalValue, isDuplicate: { $0 == $1 })
+    }
+
+    /// Returns the value at the given keypath of ``Value``.
+    ///
+    /// In combination with `@dynamicMemberLookup`, this allows us to write `model.myProperty` instead of
+    /// `model.value.myProperty` where `model` has type `ObservableValue<T>`.
+    public subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+        internalValue[keyPath: keyPath]
+    }
+
+    private func scopeToLocalValue<LocalValue>(_ toLocalValue: @escaping (Value) -> LocalValue, isDuplicate: ((LocalValue, LocalValue) -> Bool)? = nil) -> ObservableValue<LocalValue> {
+        let localObservableValue = ObservableValue<LocalValue>(
+            value: toLocalValue(internalValue),
+            isDuplicate: isDuplicate
+        )
+        localObservableValue.parentCancellable = valuePublisher().sink(receiveValue: { newValue in
+            localObservableValue.value = toLocalValue(newValue)
+        })
+        return localObservableValue
+    }
+
+    private func valuePublisher() -> AnyPublisher<Value, Never> {
+        guard let isDuplicate = isDuplicate else {
+            return subject.eraseToAnyPublisher()
+        }
+
+        return subject.removeDuplicates(by: isDuplicate).eraseToAnyPublisher()
+    }
+}

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(UIKit)
+
+import SwiftUI
+import Workflow
+import WorkflowUI
+
+public protocol SwiftUIScreen: Screen {
+    associatedtype Content: View
+
+    @ViewBuilder
+    static func makeView(model: ObservableValue<Self>) -> Content
+
+    static var isDuplicate: ((Self, Self) -> Bool)? { get }
+}
+
+public extension SwiftUIScreen {
+    static var isDuplicate: ((Self, Self) -> Bool)? { return nil }
+}
+
+public extension SwiftUIScreen where Self: Equatable {
+    static var isDuplicate: ((Self, Self) -> Bool)? { { $0 == $1 } }
+}
+
+public extension SwiftUIScreen {
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        ViewControllerDescription(
+            type: ModeledHostingController<Self, WithModel<Self, EnvironmentInjectingView<Content>>>.self,
+            environment: environment,
+            build: {
+                let (model, modelSink) = ObservableValue.makeObservableValue(self, isDuplicate: Self.isDuplicate)
+                let (viewEnvironment, envSink) = ObservableValue.makeObservableValue(environment)
+                return ModeledHostingController(
+                    modelSink: modelSink,
+                    viewEnvironmentSink: envSink,
+                    rootView: WithModel(model, content: { model in
+                        EnvironmentInjectingView(
+                            viewEnvironment: viewEnvironment,
+                            content: Self.makeView(model: model)
+                        )
+                    })
+                )
+            },
+            update: {
+                $0.modelSink.send(self)
+                $0.viewEnvironmentSink.send(environment)
+            }
+        )
+    }
+}
+
+private struct EnvironmentInjectingView<Content: View>: View {
+    @ObservedObject var viewEnvironment: ObservableValue<ViewEnvironment>
+    let content: Content
+
+    var body: some View {
+        content
+            .environment(\.viewEnvironment, viewEnvironment.value)
+    }
+}
+
+private final class ModeledHostingController<Model, Content: View>: UIHostingController<Content> {
+    let modelSink: Sink<Model>
+    let viewEnvironmentSink: Sink<ViewEnvironment>
+
+    init(modelSink: Sink<Model>, viewEnvironmentSink: Sink<ViewEnvironment>, rootView: Content) {
+        self.modelSink = modelSink
+        self.viewEnvironmentSink = viewEnvironmentSink
+
+        super.init(rootView: rootView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not implemented")
+    }
+}
+
+#endif

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -26,15 +26,15 @@ public protocol SwiftUIScreen: Screen {
     @ViewBuilder
     static func makeView(model: ObservableValue<Self>) -> Content
 
-    static var isDuplicate: ((Self, Self) -> Bool)? { get }
+    static var isEquivalent: ((Self, Self) -> Bool)? { get }
 }
 
 public extension SwiftUIScreen {
-    static var isDuplicate: ((Self, Self) -> Bool)? { return nil }
+    static var isEquivalent: ((Self, Self) -> Bool)? { return nil }
 }
 
 public extension SwiftUIScreen where Self: Equatable {
-    static var isDuplicate: ((Self, Self) -> Bool)? { { $0 == $1 } }
+    static var isEquivalent: ((Self, Self) -> Bool)? { { $0 == $1 } }
 }
 
 public extension SwiftUIScreen {
@@ -43,7 +43,7 @@ public extension SwiftUIScreen {
             type: ModeledHostingController<Self, WithModel<Self, EnvironmentInjectingView<Content>>>.self,
             environment: environment,
             build: {
-                let (model, modelSink) = ObservableValue.makeObservableValue(self, isDuplicate: Self.isDuplicate)
+                let (model, modelSink) = ObservableValue.makeObservableValue(self, isEquivalent: Self.isEquivalent)
                 let (viewEnvironment, envSink) = ObservableValue.makeObservableValue(environment)
                 return ModeledHostingController(
                     modelSink: modelSink,

--- a/WorkflowSwiftUIExperimental/Sources/WithModel.swift
+++ b/WorkflowSwiftUIExperimental/Sources/WithModel.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SwiftUI
+
+struct WithModel<Model, Content: View>: View {
+    @ObservedObject private var model: ObservableValue<Model>
+    private let content: (ObservableValue<Model>) -> Content
+
+    init(
+        _ model: ObservableValue<Model>,
+        @ViewBuilder content: @escaping (ObservableValue<Model>) -> Content
+    ) {
+        self.model = model
+        self.content = content
+    }
+
+    var body: Content {
+        content(model)
+    }
+}


### PR DESCRIPTION
This adds a `WorkflowSwiftUIExperimental` module containing a set of core reusable types for implementing Workflow screens using SwiftUI.

These types are experimental and not recommended for use in production, but have reoccurred unchanged in a series prototypes over the last year. They were previously copy-pasted in each prototype, and more recently lived in a [WorkflowSwiftUIExperimental repo](https://github.com/squareup/WorkflowSwiftUIExperimental).

Moving them to this repository will allow future prototypes to be written as branches of Workflow, which may include both new sample code and changes to the WorkflowSwiftUIExperimental and Workflow types themselves.

For now this module will be [disallowed as a dependency in Register](https://github.com/squareup/ios-register/pull/91039/commits/fc7a4006c16ef7b892582ebd8f9a250067037120).

## Overview

The public types are:

- `SwiftUIScreen`, a protocol that is adopted by a Workflow rendering that provides screen content in the form of a SwiftUI View, analogous to `BlueprintScreen`
- `ObservableValue<Value>`, an object held by the SwiftUI View through which it receives state from and sends actions to a Workflow, analogous to TCA’s ViewStore or AirBnb’s store

This PR does not include extensions that have appeared in some prototypes, including:
- [Equatable action sinks](https://github.com/square/workflow-swift/pull/225)
- [Representing two-way bindings at the Screen level](https://github.com/square/workflow-swift/pull/225)
- [iOS 17 Observation](https://github.com/squareup/WorkflowSwiftUIExperimental/pull/3)
