### PR TITLE
[chore]: add WorkflowSwiftUIExperimental to list of pods to push

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ For Squares, membership is managed through the `Workflow Swift Owners` registry 
     bundle exec pod trunk push WorkflowReactiveSwiftTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowRxSwiftTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowSwiftUI.podspec --synchronous
-    bundle exec pod trunk push  WorkflowSwiftUIExperimental.podspec --synchronous
+    bundle exec pod trunk push WorkflowSwiftUIExperimental.podspec --synchronous
     bundle exec pod trunk push WorkflowCombine.podspec --synchronous
     bundle exec pod trunk push WorkflowCombineTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowConcurrency.podspec --synchronous

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,6 +44,7 @@ For Squares, membership is managed through the `Workflow Swift Owners` registry 
     bundle exec pod trunk push WorkflowReactiveSwiftTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowRxSwiftTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowSwiftUI.podspec --synchronous
+    bundle exec pod trunk push  WorkflowSwiftUIExperimental.podspec --synchronous
     bundle exec pod trunk push WorkflowCombine.podspec --synchronous
     bundle exec pod trunk push WorkflowCombineTesting.podspec --synchronous
     bundle exec pod trunk push WorkflowConcurrency.podspec --synchronous


### PR DESCRIPTION
WorkflowSwiftUIExperimental is a new pod that should also be pushed to trunk when releasing. This updated the releasing instructions accordingly.