### PR TITLE
[feat]: add 'screen container' API

### DIFF
--- a/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
+++ b/WorkflowUI/Sources/Hosting/WorkflowHostingController.swift
@@ -208,4 +208,12 @@ extension WorkflowHostingController: ViewEnvironmentObserving {
     }
 }
 
+// MARK: ScreenContaining
+
+extension WorkflowHostingController: ScreenContaining {
+    public var containedScreen: any Screen {
+        workflowHost.rendering.value
+    }
+}
+
 #endif

--- a/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -42,4 +42,12 @@ extension Screen {
     }
 }
 
+// MARK: ScreenContaining
+
+extension AnyScreen: ScreenContaining {
+    public var containedScreen: any Screen {
+        wrappedScreen
+    }
+}
+
 #endif

--- a/WorkflowUI/Sources/Screen/ScreenContaining.swift
+++ b/WorkflowUI/Sources/Screen/ScreenContaining.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit)
+
+import Foundation
+import UIKit
+
+/// Defines a type that semantically 'contains' a `Screen`, but erases its associated static type information.
+///
+/// This enables referring to `any ScreenViewController` which is not possible without a protocol
+/// like this because `ScreenViewController` is generic over its screen type and it's not possible to check
+/// `viewController is ScreenViewController` without also specifying a specific screen type.
+public protocol ScreenContaining {
+    /// The underlying Screen the conforming type contains
+    var containedScreen: any Screen { get }
+}
+
+extension ScreenContaining {
+    /// Iteratively traverses a sequence of `containedScreen` values until one is found that does _not_
+    /// conform to `ScreenContaining`. Put another way, this returns the first `containedScreen`
+    /// that is a `Screen` and _not_ a `ScreenContaining` type.
+    public func findInnermostScreen() -> any Screen {
+        var result = containedScreen
+
+        while let nextContainer = result as? ScreenContaining {
+            result = nextContainer.containedScreen
+        }
+
+        return result
+    }
+}
+
+#endif

--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -88,4 +88,12 @@ extension ScreenViewController {
     }
 }
 
+// MARK: ScreenContaining
+
+extension ScreenViewController: ScreenContaining {
+    public var containedScreen: any Screen {
+        screen
+    }
+}
+
 #endif

--- a/WorkflowUI/Tests/ScreenContainingTests.swift
+++ b/WorkflowUI/Tests/ScreenContainingTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+import WorkflowUI
+
+final class ScreenContainingTests: XCTestCase {
+    func test_findInnermostScreen_depth1() {
+        let parent = ContainerScreen(child: LeafScreen(identifier: "1"))
+
+        let innermost = parent.findInnermostScreen() as? LeafScreen
+        XCTAssertEqual(innermost?.identifier, "1")
+    }
+
+    func test_findInnermostScreen_depth3() {
+        let child = LeafScreen(identifier: "3")
+        let parent = ContainerScreen(child: child)
+        let grandParent = ContainerScreen(child: parent)
+        let greatGrandParent = ContainerScreen(child: grandParent)
+
+        let innermost = greatGrandParent.findInnermostScreen() as? LeafScreen
+        XCTAssertEqual(innermost?.identifier, "3")
+    }
+}
+
+private struct ContainerScreen: NoopScreen {
+    var child: Screen
+}
+
+extension ContainerScreen: ScreenContaining {
+    var containedScreen: Screen { child }
+}
+
+private struct LeafScreen: NoopScreen {
+    var identifier: String
+}
+
+private protocol NoopScreen: Screen {}
+extension NoopScreen {
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        fatalError()
+    }
+}


### PR DESCRIPTION
## Motivation

in some circumstances it is helpful to know when a type is serving as a logical 'container' for a rendering, and in particular a container of a `Screen`. the types currently exposed by WorkflowUI which serve this purpose are the following:

1. `AnyScreen`
1. `WorkflowHostingController<ScreenType, Output>`
1. `ScreenViewController<ScreenType>`

since both the hosting controller & screen view controller are generic, there is no way to dynamically check if an arbitrary, type-erased type is an instance without also specifying the generic parameters. this makes certain types of dynamic introspection clunky or impossible depending on code structure. to illustrate the point, consider the following somewhat contrived example:

```swift
func makeUninspectableScreenVC() -> UIViewController {
    struct LocalScreen: Screen { ... } // Screen conformance symbol is only visible in this function
    return ScreenViewController(screen: LocalScreen(), environment: .empty)
}

let isSVC = makeUninspectableScreenVC() is ScreenViewController<???> // no generic can be specified here that makes this true
```
we'd like our logical 'Screen container' types to share an interface that allows access to the underlying screen information, which can help with debugging and other runtime data collection.

## Changes

- adds the `ScreenContaining` protocol. this has a single requirement that conformances must provide a `containedScreen` value, returning an `any Screen` type that is the semantically 'contained' screen
- adds conformances to this protocol to the existing screen containers in WorkflowUI
- adds a utility protocol extension to traverse a chain of containers to find the 'leaf' screen

## Checklist

- [x] Unit Tests
- [x] ~UI Tests~
- [x] ~Snapshot Tests (iOS only)~
- [x] I have made corresponding changes to the documentation
