### PR TITLE
[WIP] Use Observation in WorkflowSwiftUI

### DIFF
--- a/Samples/SwiftUITestbed/Sources/MainScreen.swift
+++ b/Samples/SwiftUITestbed/Sources/MainScreen.swift
@@ -31,7 +31,7 @@ extension MainWorkflow.Rendering: SwiftUIScreen, Screen {
 }
 
 private struct MainScreenView: View {
-    var model: Store<MainWorkflow.State>
+    @BindableStore var model: Store<MainWorkflow.State>
 
     @Environment(\.viewEnvironment.marketStylesheet) private var styles: MarketStylesheet
     @Environment(\.viewEnvironment.marketContext) private var context: MarketContext
@@ -49,10 +49,7 @@ private struct MainScreenView: View {
 
             TextField(
                 "Text",
-                text: Binding(
-                    get: { model.title },
-                    set: { _ in fatalError("TODO") }
-                )
+                text: $model.title
             )
             .focused($focusedField, equals: .title)
             .onAppear { focusedField = .title }
@@ -61,10 +58,7 @@ private struct MainScreenView: View {
                 style: context.stylesheets.testbed.toggleRow,
                 label: "All Caps",
                 isEnabled: model.allCapsToggleIsEnabled,
-                isOn: Binding(
-                    get: { model.allCapsToggleIsOn },
-                    set: { _ in fatalError("TODO") }
-                )
+                isOn: $model.allCapsToggleIsOn
             )
 
             Spacer(minLength: styles.spacings.spacing50)

--- a/Samples/SwiftUITestbed/Sources/MainScreen.swift
+++ b/Samples/SwiftUITestbed/Sources/MainScreen.swift
@@ -38,7 +38,7 @@ struct MainScreen: SwiftUIScreen {
 }
 
 private struct MainScreenView: View {
-    @ObservedObject var model: ObservableValue<MainScreen>
+    var model: ObservableValue<MainScreen>
 
     @Environment(\.viewEnvironment.marketStylesheet) private var styles: MarketStylesheet
     @Environment(\.viewEnvironment.marketContext) private var context: MarketContext

--- a/Samples/SwiftUITestbed/Sources/MainScreen.swift
+++ b/Samples/SwiftUITestbed/Sources/MainScreen.swift
@@ -25,13 +25,17 @@ import WorkflowUI
 // conformance of type 'ViewModel<State, Action>' to protocol 'SwiftUIScreen'
 // does not imply conformance to inherited protocol 'Screen'"
 extension MainWorkflow.Rendering: SwiftUIScreen, Screen {
-    static func makeView(store: Store<State>, sendAction: @escaping (Action) -> Void) -> some View {
-        MainScreenView(model: store)
+    var model: Model {
+        self
+    }
+
+    public static func makeView(store: Store<MainWorkflow.State, MainWorkflow.Action>) -> some View {
+        MainView(store: store)
     }
 }
 
-private struct MainScreenView: View {
-    @BindableStore var model: Store<MainWorkflow.State>
+private struct MainView: View {
+    @BindableStore var store: Store<MainWorkflow.State, MainWorkflow.Action>
 
     @Environment(\.viewEnvironment.marketStylesheet) private var styles: MarketStylesheet
     @Environment(\.viewEnvironment.marketContext) private var context: MarketContext
@@ -49,7 +53,7 @@ private struct MainScreenView: View {
 
             TextField(
                 "Text",
-                text: $model.title
+                text: $store.title
             )
             .focused($focusedField, equals: .title)
             .onAppear { focusedField = .title }
@@ -57,8 +61,8 @@ private struct MainScreenView: View {
             ToggleRow(
                 style: context.stylesheets.testbed.toggleRow,
                 label: "All Caps",
-                isEnabled: model.allCapsToggleIsEnabled,
-                isOn: $model.allCapsToggleIsOn
+                isEnabled: store.allCapsToggleIsEnabled,
+                isOn: $store.allCapsToggleIsOn
             )
 
             Spacer(minLength: styles.spacings.spacing50)
@@ -68,12 +72,12 @@ private struct MainScreenView: View {
 
             Button(
                 "Push Screen",
-                action: { fatalError("TODO") }
+                action: store.action(.pushScreen)
             )
 
             Button(
                 "Present Screen",
-                action: { fatalError("TODO") }
+                action: store.action(.presentScreen)
             )
 
             Button(

--- a/Samples/SwiftUITestbed/Sources/MainWorkflow.swift
+++ b/Samples/SwiftUITestbed/Sources/MainWorkflow.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import ComposableArchitecture // for ObservableState
 import MarketWorkflowUI
 import Workflow
 
@@ -25,6 +26,7 @@ struct MainWorkflow: Workflow {
         case presentScreen
     }
 
+    @ObservableState
     struct State {
         var title: String
         var isAllCaps: Bool
@@ -64,21 +66,23 @@ struct MainWorkflow: Workflow {
         }
     }
 
-    typealias Rendering = MainScreen
+    typealias Rendering = ViewModel<State, Action>
 
     func render(state: State, context: RenderContext<Self>) -> Rendering {
-        let sink = context.makeSink(of: Action.self)
-
-        return MainScreen(
-            title: state.title,
-            didChangeTitle: { sink.send(.changeTitle($0)) },
-            allCapsToggleIsOn: state.isAllCaps,
-            allCapsToggleIsEnabled: !state.title.isEmpty,
-            didChangeAllCapsToggle: { sink.send(.changeAllCaps($0)) },
-            didTapPushScreen: { sink.send(.pushScreen) },
-            didTapPresentScreen: { sink.send(.presentScreen) },
-            didTapClose: didClose
+        ViewModel(
+            state: state,
+            sendAction: context.makeSink(of: Action.self).send
         )
+    }
+}
+
+extension MainWorkflow.State {
+    var allCapsToggleIsOn: Bool {
+        isAllCaps
+    }
+
+    var allCapsToggleIsEnabled: Bool {
+        !title.isEmpty
     }
 }
 

--- a/Samples/SwiftUITestbed/Sources/MainWorkflow.swift
+++ b/Samples/SwiftUITestbed/Sources/MainWorkflow.swift
@@ -78,7 +78,8 @@ struct MainWorkflow: Workflow {
 
 extension MainWorkflow.State {
     var allCapsToggleIsOn: Bool {
-        isAllCaps
+        get { isAllCaps }
+        set { fatalError("TODO") }
     }
 
     var allCapsToggleIsEnabled: Bool {

--- a/Samples/SwiftUITestbed/Sources/Observation/BindableStore.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/BindableStore.swift
@@ -17,18 +17,18 @@ import SwiftUI
 @available(watchOS, deprecated: 10, renamed: "Bindable")
 @propertyWrapper
 @dynamicMemberLookup
-public struct BindableStore<State: ObservableState> {
-    public var wrappedValue: Store<State>
-    public init(wrappedValue: Store<State>) {
+struct BindableStore<State: ObservableState, Action> {
+    var wrappedValue: Store<State, Action>
+    init(wrappedValue: Store<State, Action>) {
         self.wrappedValue = wrappedValue
     }
 
-    public var projectedValue: BindableStore<State> {
+    var projectedValue: BindableStore<State, Action> {
         self
     }
 
-    public subscript<Subject>(
-        dynamicMember keyPath: ReferenceWritableKeyPath<Store<State>, Subject>
+    subscript<Subject>(
+        dynamicMember keyPath: ReferenceWritableKeyPath<Store<State, Action>, Subject>
     ) -> Binding<Subject> {
         Binding(
             get: { self.wrappedValue[keyPath: keyPath] },

--- a/Samples/SwiftUITestbed/Sources/Observation/BindableStore.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/BindableStore.swift
@@ -1,0 +1,38 @@
+// Copied from https://github.com/pointfreeco/swift-composable-architecture/blob/acfbab4290adda4e47026d059db36361958d495c/Sources/ComposableArchitecture/Observation/BindableStore.swift
+
+import ComposableArchitecture
+import SwiftUI
+
+/// A property wrapper type that supports creating bindings to the mutable properties of a
+/// ``Store``.
+///
+/// Use this property wrapper in iOS 16, macOS 13, tvOS 16, watchOS 9, and earlier, when `@Bindable`
+/// is unavailable, to derive bindings to properties of your features.
+///
+/// If you are targeting iOS 17, macOS 14, tvOS 17, watchOS 9, or later, then you can replace
+/// ``BindableStore`` with SwiftUI's `@Bindable`.
+@available(iOS, deprecated: 17, renamed: "Bindable")
+@available(macOS, deprecated: 14, renamed: "Bindable")
+@available(tvOS, deprecated: 17, renamed: "Bindable")
+@available(watchOS, deprecated: 10, renamed: "Bindable")
+@propertyWrapper
+@dynamicMemberLookup
+public struct BindableStore<State: ObservableState> {
+    public var wrappedValue: Store<State>
+    public init(wrappedValue: Store<State>) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public var projectedValue: BindableStore<State> {
+        self
+    }
+
+    public subscript<Subject>(
+        dynamicMember keyPath: ReferenceWritableKeyPath<Store<State>, Subject>
+    ) -> Binding<Subject> {
+        Binding(
+            get: { self.wrappedValue[keyPath: keyPath] },
+            set: { self.wrappedValue[keyPath: keyPath] = $0 }
+        )
+    }
+}

--- a/Samples/SwiftUITestbed/Sources/Observation/Binding+Observation.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/Binding+Observation.swift
@@ -1,0 +1,43 @@
+// Copied from https://github.com/pointfreeco/swift-composable-architecture/blob/acfbab4290adda4e47026d059db36361958d495c/Sources/ComposableArchitecture/Observation/Binding%2BObservation.swift
+
+import ComposableArchitecture
+import SwiftUI
+
+// NB: These overloads ensure runtime warnings aren't emitted for errant SwiftUI bindings.
+#if DEBUG
+extension Binding {
+    public subscript<State: ObservableState, Member: Equatable>(
+        dynamicMember keyPath: WritableKeyPath<State, Member>
+    ) -> Binding<Member>
+        where Value == Store<State> {
+        Binding<Member>(
+            get: { self.wrappedValue.state[keyPath: keyPath] },
+            set: { _ in fatalError("TODO") }
+        )
+    }
+}
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension Bindable {
+    public subscript<State: ObservableState, Member: Equatable>(
+        dynamicMember keyPath: WritableKeyPath<State, Member>
+    ) -> Binding<Member>
+        where Value == Store<State> {
+        Binding<Member>(
+            get: { self.wrappedValue.state[keyPath: keyPath] },
+            set: { _ in fatalError("TODO") }
+        )
+    }
+}
+
+extension BindableStore {
+    public subscript<Member: Equatable>(
+        dynamicMember keyPath: WritableKeyPath<State, Member>
+    ) -> Binding<Member> {
+        Binding<Member>(
+            get: { self.wrappedValue.state[keyPath: keyPath] },
+            set: { _ in fatalError("TODO") }
+        )
+    }
+}
+#endif

--- a/Samples/SwiftUITestbed/Sources/Observation/Binding+Observation.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/Binding+Observation.swift
@@ -6,10 +6,14 @@ import SwiftUI
 // NB: These overloads ensure runtime warnings aren't emitted for errant SwiftUI bindings.
 #if DEBUG
 extension Binding {
-    public subscript<State: ObservableState, Member: Equatable>(
+    subscript<
+        State: ObservableState,
+        Action,
+        Member: Equatable
+    >(
         dynamicMember keyPath: WritableKeyPath<State, Member>
     ) -> Binding<Member>
-        where Value == Store<State> {
+        where Value == Store<State, Action> {
         Binding<Member>(
             get: { self.wrappedValue.state[keyPath: keyPath] },
             set: { _ in fatalError("TODO") }
@@ -19,10 +23,10 @@ extension Binding {
 
 @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
 extension Bindable {
-    public subscript<State: ObservableState, Member: Equatable>(
+    subscript<State: ObservableState, Action, Member: Equatable>(
         dynamicMember keyPath: WritableKeyPath<State, Member>
     ) -> Binding<Member>
-        where Value == Store<State> {
+        where Value == Store<State, Action> {
         Binding<Member>(
             get: { self.wrappedValue.state[keyPath: keyPath] },
             set: { _ in fatalError("TODO") }

--- a/Samples/SwiftUITestbed/Sources/Observation/Store.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/Store.swift
@@ -1,0 +1,60 @@
+import ComposableArchitecture
+
+@dynamicMemberLookup
+public final class Store<State: ObservableState>: Perceptible {
+    private var _state: State
+    let _$observationRegistrar = PerceptionRegistrar()
+
+    fileprivate(set) var state: State {
+        get {
+            _$observationRegistrar.access(self, keyPath: \.state)
+            return _state
+        }
+        set {
+            if !_$isIdentityEqual(state, newValue) {
+                _$observationRegistrar.withMutation(of: self, keyPath: \.state) {
+                    _state = newValue
+                }
+            } else {
+                _state = newValue
+            }
+        }
+    }
+
+    private init(state: State) {
+        self._state = state
+    }
+}
+
+public extension Store {
+    static func make(initialState: State) -> (Store, (State) -> Void) {
+        let store = Store(state: initialState)
+        let sink = { store.state = $0 }
+        return (store, sink)
+    }
+
+    subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
+        state[keyPath: keyPath]
+    }
+}
+
+extension Store: Equatable {
+    public static func == (lhs: Store, rhs: Store) -> Bool {
+        lhs === rhs
+    }
+}
+
+extension Store: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+}
+
+extension Store: Identifiable {}
+
+#if canImport(Observation)
+import Observation
+
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension Store: Observable {}
+#endif

--- a/Samples/SwiftUITestbed/Sources/Observation/Store.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/Store.swift
@@ -1,4 +1,4 @@
-import ComposableArchitecture
+import ComposableArchitecture // for ObservableState and Perception
 
 @dynamicMemberLookup
 public final class Store<State: ObservableState>: Perceptible {
@@ -29,8 +29,8 @@ public final class Store<State: ObservableState>: Perceptible {
 public extension Store {
     static func make(initialState: State) -> (Store, (State) -> Void) {
         let store = Store(state: initialState)
-        let sink = { store.state = $0 }
-        return (store, sink)
+        let setState = { store.state = $0 }
+        return (store, setState)
     }
 
     subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {

--- a/Samples/SwiftUITestbed/Sources/Observation/SwiftUIScreen.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/SwiftUIScreen.swift
@@ -1,0 +1,76 @@
+#if canImport(UIKit)
+
+import ComposableArchitecture // for ObservableState
+import SwiftUI
+import Workflow
+import WorkflowUI
+
+struct ViewModel<State: ObservableState, Action> {
+    let state: State
+    let sendAction: (Action) -> Void
+}
+
+protocol SwiftUIScreen: Screen {
+    associatedtype State: ObservableState
+    associatedtype Action
+    associatedtype Content: View
+
+    var state: State { get }
+    var sendAction: (Action) -> Void { get }
+
+    @ViewBuilder
+    static func makeView(store: Store<State>, sendAction: @escaping (Action) -> Void) -> Content
+}
+
+extension SwiftUIScreen {
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        ViewControllerDescription(
+            type: ModeledHostingController<Self.State, EnvironmentInjectingView<Content>>.self,
+            environment: environment,
+            build: {
+                let (store, setState) = Store.make(initialState: state)
+                return ModeledHostingController(
+                    setState: setState,
+                    rootView: EnvironmentInjectingView(
+                        environment: environment,
+                        content: Self.makeView(
+                            store: store,
+                            sendAction: { _ in
+                                fatalError("TODO")
+                            }
+                        )
+                    )
+                )
+            },
+            update: { hostingController in
+                hostingController.setState(state)
+                // TODO: update viewEnvironment
+            }
+        )
+    }
+}
+
+private struct EnvironmentInjectingView<Content: View>: View {
+    var environment: ViewEnvironment
+    let content: Content
+
+    var body: some View {
+        content
+            .environment(\.viewEnvironment, environment)
+    }
+}
+
+private final class ModeledHostingController<State, Content: View>: UIHostingController<Content> {
+    let setState: (State) -> Void
+
+    init(setState: @escaping (State) -> Void, rootView: Content) {
+        self.setState = setState
+        super.init(rootView: rootView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not implemented")
+    }
+}
+
+#endif

--- a/Samples/SwiftUITestbed/Sources/Observation/ViewModel.swift
+++ b/Samples/SwiftUITestbed/Sources/Observation/ViewModel.swift
@@ -1,0 +1,6 @@
+import ComposableArchitecture
+
+struct ViewModel<State: ObservableState, Action> {
+    let state: State
+    let sendAction: (Action) -> Void
+}


### PR DESCRIPTION
An experimental adaptation of [TCA's Observation beta](https://github.com/pointfreeco/swift-composable-architecture/discussions/2594) for Workflow.

## Development
Since CocoaPods doesn't support SPM package dependencies, you need to manually add package dependencies to `Development.xcodeproj` after each `pod gen`.

We currently depend on commit `acfbab4290adda4e47026d059db36361958d495c` from the `observation-beta` branch of [swift-composable-architecture](https://github.com/pointfreeco/swift-composable-architecture).

![image](https://github.com/square/workflow-swift/assets/106167956/40b06ec4-85cd-4418-9a31-e8cb69dc0510)

For some reason this manually-added dependency works only in sample app targets. In framework targets, `import` statements yield an error llike:
> No such module 'ComposableArchitecture'