### PR TITLE
[gardening]: batch swiftlint calls for all modified files

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/bash
-git diff --diff-filter=d --staged --name-only | grep -e '\.swift$' | while read line; do
-  swift run swiftformat "${line}" --quiet;
-  git add "$line";
-done
+
+swift_files=$(git diff --diff-filter=d --staged --name-only -- '*.swift')
+
+echo $swift_files | xargs swift run swiftformat --quiet
+
+echo $swift_files | xargs git add

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,11 @@
---indent 4
+# file config
 
+--swiftversion 5.7
 --exclude Pods,Tooling,**Dummy.swift
+
+# format config
+
+--indent 4
 
 --wraparguments before-first
 --importgrouping testable-bottom


### PR DESCRIPTION
### Issue

the current pre-commit hook builds & runs swiftformat on every lint-able file, which can take a relatively long time if many changes have been made

### Description

- updates commit hook script to make one call to swiftformat with all the files to lint
- adds a `swiftversion` config specifying 5.7 as the language version the linter will use when running

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
