### PR TITLE
Ensure all adapted environment methods are public

### DIFF
--- a/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
+++ b/WorkflowUI/Sources/Screen/AdaptedEnvironmentScreen.swift
@@ -101,7 +101,7 @@ extension Screen {
     }
 
     /// Wraps this screen in an `AdaptedEnvironmentScreen` with the given keypath and value.
-    func adaptedEnvironment<Value>(
+    public func adaptedEnvironment<Value>(
         keyPath: WritableKeyPath<ViewEnvironment, Value>,
         value: Value
     ) -> AdaptedEnvironmentScreen<Self> {
@@ -109,7 +109,7 @@ extension Screen {
     }
 
     /// Wraps this screen in an `AdaptedEnvironmentScreen` with the given configuration block.
-    func adaptedEnvironment(
+    public func adaptedEnvironment(
         adapting: @escaping (inout ViewEnvironment) -> Void
     ) -> AdaptedEnvironmentScreen<Self> {
         AdaptedEnvironmentScreen(wrapping: self, adapting: adapting)


### PR DESCRIPTION
Oops, my bad on this one... These should be public.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
