### PR TITLE
[chore]: relax swiftui experimental dependency constraints & bump version

### DIFF
--- a/WorkflowSwiftUIExperimental.podspec
+++ b/WorkflowSwiftUIExperimental.podspec
@@ -2,7 +2,7 @@ require_relative('version')
 
 Pod::Spec.new do |s|
     s.name         = 'WorkflowSwiftUIExperimental'
-    s.version      = '0.1'
+    s.version      = '0.2'
     s.summary      = 'Infrastructure for Workflow-powered SwiftUI'
     s.homepage     = 'https://www.github.com/square/workflow-swift'
     s.license      = 'Apache License, Version 2.0'
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
 
     s.source_files = 'WorkflowSwiftUIExperimental/Sources/*.swift'
 
-    s.dependency 'Workflow', WORKFLOW_VERSION
-    s.dependency 'WorkflowUI', WORKFLOW_VERSION
+    s.dependency 'Workflow', "~> #{WORKFLOW_MAJOR_VERSION}.0"
+    s.dependency 'WorkflowUI', "~> #{WORKFLOW_MAJOR_VERSION}.0"
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   end

--- a/version.rb
+++ b/version.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-# The primary version number for Workflow-related pods
-WORKFLOW_VERSION ||= '3.6.0'
+# The primary version numbers for Workflow-related pods
+WORKFLOW_MAJOR_VERSION ||= '3'
+WORKFLOW_MINOR_VERSION ||= '6'
+WORKFLOW_PATCH_VERSION ||= '0'
+WORKFLOW_VERSION ||= "#{WORKFLOW_MAJOR_VERSION}.#{WORKFLOW_MINOR_VERSION}.#{WORKFLOW_PATCH_VERSION}"
 
 # iOS deployment target
 WORKFLOW_IOS_DEPLOYMENT_TARGET ||= '14.0'


### PR DESCRIPTION
### Description

the current experimental swift ui target is versioned independently from the other pods. this change relaxes the version requirements for its dependencies to allow any minor or patch changes to be made without this podspec having to be changed.
