### PR TITLE
[chore]: move ViewEnvironment's EnvironmentValues key to the ViewEnvironment module

### DIFF
--- a/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
+++ b/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
+#if canImport(SwiftUI)
+
 import SwiftUI
-import WorkflowUI
 
-private struct ViewEnvironmentKey: EnvironmentKey {
-    static let defaultValue: ViewEnvironment = .empty
-}
-
-public extension EnvironmentValues {
-    var viewEnvironment: ViewEnvironment {
+extension EnvironmentValues {
+    public var viewEnvironment: ViewEnvironment {
         get { self[ViewEnvironmentKey.self] }
         set { self[ViewEnvironmentKey.self] = newValue }
     }
+
+    private struct ViewEnvironmentKey: EnvironmentKey {
+        static let defaultValue: ViewEnvironment = .empty
+    }
 }
+
+#endif


### PR DESCRIPTION
# Why?

Moving this environment value key to `ViewEnvironment` means that modules that aren't dependent on WorkflowUI (like MarketSwiftUI) are able to access `ViewEnvironment` keys on the SwiftUI `EnvironmentValues`. Market will use this key to access the `MarketContext` on the `ViewEnvironment` which is bridged by either our Market SwiftUI Hosting Controller or the standard WorkflowUI SwiftUI Screen depending on context rather than having to manually bridge the `MarketContext` in addition to the `ViewEnvironment`, and have the potential for the `MarketContext`s in both environments to get out of sync.

The integration in Market can be found here: https://github.com/squareup/market/pull/7763

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation


[UI-5335](https://block.atlassian.net/browse/UI-5335)
