### PR TITLE
Removed unnecessary nested generic type

### DIFF
--- a/WorkflowTesting/Sources/Internal/RenderExpectations.swift
+++ b/WorkflowTesting/Sources/Internal/RenderExpectations.swift
@@ -48,7 +48,7 @@ extension RenderTester {
 }
 
 extension RenderTester {
-    internal class ExpectedSideEffect<WorkflowType: Workflow> {
+    internal class ExpectedSideEffect {
         let key: AnyHashable
         let file: StaticString
         let line: UInt
@@ -62,7 +62,7 @@ extension RenderTester {
         func apply<ContextType>(context: ContextType) where ContextType: RenderContextType, ContextType.WorkflowType == WorkflowType {}
     }
 
-    internal final class ExpectedSideEffectWithAction<WorkflowType, ActionType: WorkflowAction>: ExpectedSideEffect<WorkflowType> where ActionType.WorkflowType == WorkflowType {
+    internal final class ExpectedSideEffectWithAction<ActionType: WorkflowAction>: ExpectedSideEffect where ActionType.WorkflowType == WorkflowType {
         let action: ActionType
 
         internal init(key: AnyHashable, action: ActionType, file: StaticString, line: UInt) {

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -23,7 +23,7 @@ extension RenderTester {
     internal final class TestContext: RenderContextType {
         var state: WorkflowType.State
         var expectedWorkflows: [AnyExpectedWorkflow]
-        var expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>]
+        var expectedSideEffects: [AnyHashable: ExpectedSideEffect]
         var appliedAction: AppliedAction<WorkflowType>?
         var producedOutput: WorkflowType.Output?
         let file: StaticString
@@ -34,7 +34,7 @@ extension RenderTester {
         internal init(
             state: WorkflowType.State,
             expectedWorkflows: [AnyExpectedWorkflow],
-            expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>],
+            expectedSideEffects: [AnyHashable: ExpectedSideEffect],
             file: StaticString,
             line: UInt
         ) {

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -127,13 +127,13 @@ public struct RenderTester<WorkflowType: Workflow> {
     let state: WorkflowType.State
 
     private let expectedWorkflows: [AnyExpectedWorkflow]
-    private let expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>]
+    private let expectedSideEffects: [AnyHashable: ExpectedSideEffect]
 
     init(
         workflow: WorkflowType,
         state: WorkflowType.State,
         expectedWorkflows: [AnyExpectedWorkflow] = [],
-        expectedSideEffects: [AnyHashable: ExpectedSideEffect<WorkflowType>] = [:]
+        expectedSideEffects: [AnyHashable: ExpectedSideEffect] = [:]
     ) {
         self.workflow = workflow
         self.state = state


### PR DESCRIPTION
Nested type ExpectedSideEffect was using the same name for the workflow generic type as the outer type RenderTester.  This created a shadowed type name warning.
Removing the generic type got rid of the warning

## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
