### PR TITLE
[feat]: add support for sizingOptions to SwiftUIScreen

### DIFF
--- a/Development.podspec
+++ b/Development.podspec
@@ -109,6 +109,12 @@ Pod::Spec.new do |s|
     test_spec.framework = 'XCTest'
   end
 
+  s.test_spec 'WorkflowSwiftUIExperimentalTests' do |test_spec|
+    test_spec.requires_app_host = true
+    test_spec.source_files = 'WorkflowSwiftUIExperimental/Tests/**/*.swift'
+    test_spec.framework = 'XCTest'
+  end
+
   s.test_spec 'WorkflowTests' do |test_spec|
     test_spec.requires_app_host = true
     test_spec.source_files = 'Workflow/Tests/**/*.swift'

--- a/WorkflowSwiftUIExperimental.podspec
+++ b/WorkflowSwiftUIExperimental.podspec
@@ -22,4 +22,16 @@ Pod::Spec.new do |s|
     s.dependency 'WorkflowUI', "~> #{WORKFLOW_MAJOR_VERSION}.0"
 
     s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+
+    s.test_spec 'Tests' do |test_spec|
+      test_spec.source_files = 'WorkflowSwiftUIExperimental/Tests/**/*.swift'
+      test_spec.framework = 'XCTest'
+      test_spec.library = 'swiftos'
+
+      # Create an app host so that we can host
+      # view or view controller based tests in a real environment.
+      test_spec.requires_app_host = true
+
+      test_spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'NO' }
+    end
   end

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -30,7 +30,7 @@ public protocol SwiftUIScreen: Screen {
 }
 
 public extension SwiftUIScreen {
-    static var isEquivalent: ((Self, Self) -> Bool)? { return nil }
+    static var isEquivalent: ((Self, Self) -> Bool)? { nil }
 }
 
 public extension SwiftUIScreen where Self: Equatable {
@@ -87,6 +87,16 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("not implemented")
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let size = view.sizeThatFits(view.frame.size)
+
+        if preferredContentSize != size {
+            preferredContentSize = size
+        }
     }
 }
 

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -150,13 +150,11 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
                     preferredContentSize = size
                 }
             }
-        } else if !swiftUIScreenSizingOptions.isEmpty {
-            if swiftUIScreenSizingOptions.contains(.preferredContentSize) {
-                let size = view.sizeThatFits(view.frame.size)
+        } else if swiftUIScreenSizingOptions.contains(.preferredContentSize) {
+            let size = view.sizeThatFits(view.frame.size)
 
-                if preferredContentSize != size {
-                    preferredContentSize = size
-                }
+            if preferredContentSize != size {
+                preferredContentSize = size
             }
         }
     }
@@ -173,12 +171,10 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
     }
 
     private func setNeedsLayoutBeforeFirstLayoutIfNeeded() {
-        if #available(iOS 16.0, *),
-            swiftUIScreenSizingOptions.contains(.preferredContentSize) {
+        if swiftUIScreenSizingOptions.contains(.preferredContentSize) {
             // Without manually calling setNeedsLayout here it was observed that a call to
             // layoutIfNeeded() immediately after loading the view would not perform a layout, and
-            // therefore would not update the preferredContentSize on the first layout in
-            // viewDidLayoutSubviews() below.
+            // therefore would not update the preferredContentSize in viewDidLayoutSubviews().
             view.setNeedsLayout()
         }
     }

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -123,6 +123,15 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
         super.viewDidLoad()
 
         view.backgroundColor = .clear
+
+        if #available(iOS 16.0, *),
+            swiftUIScreenSizingOptions.contains(.preferredContentSize) {
+            // Without manually calling setNeedsLayout here it was observed that a call to
+            // layoutIfNeeded() immediately after loading the view would not perform a layout, and
+            // therefore would not update the preferredContentSize on the first layout in
+            // viewDidLayoutSubviews() below.
+            view.setNeedsLayout()
+        }
     }
 
     private var hasLaidOutOnce = false

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -142,6 +142,7 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
         if #available(iOS 16.0, *) {
             // Handled in initializer, but set it on first layout to resolve a bug where the PCS is
             // not updated appropriately after the first layout.
+            // UI-5797
             if !hasLaidOutOnce,
                 swiftUIScreenSizingOptions.contains(.preferredContentSize) {
                 let size = view.sizeThatFits(view.frame.size)
@@ -175,6 +176,7 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
             // Without manually calling setNeedsLayout here it was observed that a call to
             // layoutIfNeeded() immediately after loading the view would not perform a layout, and
             // therefore would not update the preferredContentSize in viewDidLayoutSubviews().
+            // UI-5797
             view.setNeedsLayout()
         }
     }

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -78,8 +78,7 @@ public struct SwiftUIScreenSizingOptions: OptionSet {
         self.rawValue = rawValue
     }
 
-    public static let intrinsicContentSize: SwiftUIScreenSizingOptions = .init(rawValue: 1 << 0)
-    public static let preferredContentSize: SwiftUIScreenSizingOptions = .init(rawValue: 1 << 1)
+    public static let preferredContentSize: SwiftUIScreenSizingOptions = .init(rawValue: 1 << 0)
 }
 
 private struct EnvironmentInjectingView<Content: View>: View {
@@ -159,10 +158,6 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
                     preferredContentSize = size
                 }
             }
-
-            if swiftUIScreenSizingOptions.contains(.intrinsicContentSize) {
-                view.invalidateIntrinsicContentSize()
-            }
         }
     }
 }
@@ -171,10 +166,6 @@ extension SwiftUIScreenSizingOptions {
     @available(iOS 16.0, *)
     fileprivate var uiHostingControllerSizingOptions: UIHostingControllerSizingOptions {
         var options = UIHostingControllerSizingOptions()
-
-        if contains(.intrinsicContentSize) {
-            options.insert(.intrinsicContentSize)
-        }
 
         if contains(.preferredContentSize) {
             options.insert(.preferredContentSize)

--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -89,6 +89,12 @@ private final class ModeledHostingController<Model, Content: View>: UIHostingCon
         fatalError("not implemented")
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 

--- a/WorkflowSwiftUIExperimental/Tests/SwiftUIScreenTests.swift
+++ b/WorkflowSwiftUIExperimental/Tests/SwiftUIScreenTests.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import UIKit
+import WorkflowSwiftUIExperimental
+import XCTest
+
+final class SwiftUIScreenTests: XCTestCase {
+    override func setUp() {
+        contentScreenSizingOptions = []
+    }
+
+    func test_preferredContentSize_noSizingOptions() {
+        contentScreenSizingOptions = []
+
+        let viewController = ContentScreen()
+            .buildViewController(in: .empty)
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(viewController.preferredContentSize, .zero)
+    }
+
+    func test_preferredContentSize() {
+        contentScreenSizingOptions = .preferredContentSize
+
+        let viewController = ContentScreen()
+            .buildViewController(in: .empty)
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(
+            viewController.preferredContentSize,
+            .init(width: 42, height: 42)
+        )
+    }
+}
+
+private var contentScreenSizingOptions: SwiftUIScreenSizingOptions = []
+
+private struct ContentScreen: SwiftUIScreen {
+    static func makeView(model: ObservableValue<ContentScreen>) -> some View {
+        Color.clear
+            .frame(width: 42, height: 42)
+    }
+
+    static var sizingOptions: SwiftUIScreenSizingOptions { contentScreenSizingOptions }
+}

--- a/WorkflowSwiftUIExperimental/Tests/SwiftUIScreenTests.swift
+++ b/WorkflowSwiftUIExperimental/Tests/SwiftUIScreenTests.swift
@@ -4,14 +4,8 @@ import WorkflowSwiftUIExperimental
 import XCTest
 
 final class SwiftUIScreenTests: XCTestCase {
-    override func setUp() {
-        contentScreenSizingOptions = []
-    }
-
-    func test_preferredContentSize_noSizingOptions() {
-        contentScreenSizingOptions = []
-
-        let viewController = ContentScreen()
+    func test_noSizingOptions() {
+        let viewController = ContentScreen(sizingOptions: [])
             .buildViewController(in: .empty)
 
         viewController.view.layoutIfNeeded()
@@ -20,9 +14,7 @@ final class SwiftUIScreenTests: XCTestCase {
     }
 
     func test_preferredContentSize() {
-        contentScreenSizingOptions = .preferredContentSize
-
-        let viewController = ContentScreen()
+        let viewController = ContentScreen(sizingOptions: .preferredContentSize)
             .buildViewController(in: .empty)
 
         viewController.view.layoutIfNeeded()
@@ -32,15 +24,41 @@ final class SwiftUIScreenTests: XCTestCase {
             .init(width: 42, height: 42)
         )
     }
+
+    func test_preferredContentSize_sizingOptionsChanges() {
+        let viewController = ContentScreen(sizingOptions: [])
+            .buildViewController(in: .empty)
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(viewController.preferredContentSize, .zero)
+
+        ContentScreen(sizingOptions: .preferredContentSize)
+            .viewControllerDescription(environment: .empty)
+            .update(viewController: viewController)
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(
+            viewController.preferredContentSize,
+            .init(width: 42, height: 42)
+        )
+
+        ContentScreen(sizingOptions: [])
+            .viewControllerDescription(environment: .empty)
+            .update(viewController: viewController)
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(viewController.preferredContentSize, .zero)
+    }
 }
 
-private var contentScreenSizingOptions: SwiftUIScreenSizingOptions = []
-
 private struct ContentScreen: SwiftUIScreen {
+    let sizingOptions: SwiftUIScreenSizingOptions
+
     static func makeView(model: ObservableValue<ContentScreen>) -> some View {
         Color.clear
             .frame(width: 42, height: 42)
     }
-
-    static var sizingOptions: SwiftUIScreenSizingOptions { contentScreenSizingOptions }
 }


### PR DESCRIPTION
Market's Modal framework relies on `preferredContentSize` to size modals during presentation.

Without any changes, view controllers that back `SwiftUIScreen`s never had their `preferredContentSize` updated. 

`SwiftUIScreen` is backed by a `UIHostingController` subclass. In iOS 16 and above, a new `sizingOption` parameter was added that allows a consumer to specify the `.preferredContentSize` option which will cause the view controller to update the `preferredContentSize` as it changes over time. Before iOS 16, you have to do this manually.

One thing that's surprising is that with the `sizingOption` support for `preferredContentSize`, the `preferredContentSize` does not appear to be updated after the first layout. Also, the `UIHostingController`'s `view` is does not appear to have `setNeedsLayout` set, which has generally been expected in Market's infrastructure so far. I've opened [UI-5797](https://block.atlassian.net/browse/UI-5797) to investigate this to see whether Market's Modal framework is holding this wrong, or if the workarounds found in this PR are in fact needed.

Market also supports having the `preferredContentSize` automatically calculated if it's requested by a consumer via an associated value on `UIViewController`—we'll likely want to figure out a way to support this with `SwiftUIScreen`s, and that may involve moving some of that infra into the Workflow repo ([UI-5801](https://block.atlassian.net/browse/UI-5801)).

I've also introduced a test target for `WorkflowSwiftUIExperimental` so that I could add some tests related to `preferredContentSize` calculations.

An integration experiment was added to Market in [here](https://github.com/squareup/market/pull/8106).

These changes resolve [UI-5766](https://block.atlassian.net/browse/UI-5766).

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
