### PR TITLE
[fix]: short circuit worker logging & require explicit opt-in

### DIFF
--- a/WorkflowCombine/Sources/Logger.swift
+++ b/WorkflowCombine/Sources/Logger.swift
@@ -15,6 +15,7 @@
  */
 
 import os.signpost
+@_spi(Logging) import Workflow
 
 private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowCombine", category: "Worker")
@@ -29,6 +30,8 @@ final class WorkerLogger<WorkerType: Worker> {
     // MARK: - Workers
 
     func logStarted() {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .begin,
             log: .worker,
@@ -40,6 +43,8 @@ final class WorkerLogger<WorkerType: Worker> {
     }
 
     func logFinished(status: StaticString) {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .end,
             log: .worker,
@@ -50,6 +55,8 @@ final class WorkerLogger<WorkerType: Worker> {
     }
 
     func logOutput() {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .event,
             log: .worker,

--- a/WorkflowConcurrency/Sources/Logger.swift
+++ b/WorkflowConcurrency/Sources/Logger.swift
@@ -15,6 +15,7 @@
  */
 
 import os.signpost
+@_spi(Logging) import Workflow
 
 private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowConcurrency", category: "Worker")
@@ -29,6 +30,8 @@ final class WorkerLogger<WorkerType: Worker> {
     // MARK: - Workers
 
     func logStarted() {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .begin,
             log: .worker,
@@ -40,6 +43,8 @@ final class WorkerLogger<WorkerType: Worker> {
     }
 
     func logFinished(status: StaticString) {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .end,
             log: .worker,
@@ -50,6 +55,8 @@ final class WorkerLogger<WorkerType: Worker> {
     }
 
     func logOutput() {
+        guard WorkflowLogging.isOSLoggingAllowed else { return }
+
         os_signpost(
             .event,
             log: .worker,

--- a/WorkflowReactiveSwift/Sources/Logger.swift
+++ b/WorkflowReactiveSwift/Sources/Logger.swift
@@ -15,6 +15,7 @@
  */
 
 import os.signpost
+@_spi(Logging) import Workflow
 
 // Namespace for Worker logging
 public enum WorkerLogging {}
@@ -22,14 +23,19 @@ public enum WorkerLogging {}
 extension WorkerLogging {
     public static var enabled: Bool {
         get { OSLog.active === OSLog.worker }
-        set { OSLog.active = newValue ? .worker : .disabled }
+        set {
+            guard WorkflowLogging.isOSLoggingAllowed else { return }
+            OSLog.active = newValue ? .worker : .disabled
+        }
     }
 }
 
 private extension OSLog {
     static let worker = OSLog(subsystem: "com.squareup.WorkflowReactiveSwift", category: "Worker")
 
-    static var active: OSLog = .disabled
+    static var active: OSLog = {
+        WorkflowLogging.isOSLoggingAllowed ? .worker : .disabled
+    }()
 }
 
 // MARK: -
@@ -43,6 +49,8 @@ final class WorkerLogger<WorkerType: Worker> {
     // MARK: - Workers
 
     func logStarted() {
+        guard WorkerLogging.enabled else { return }
+
         os_signpost(
             .begin,
             log: .active,
@@ -54,10 +62,14 @@ final class WorkerLogger<WorkerType: Worker> {
     }
 
     func logFinished(status: StaticString) {
+        guard WorkerLogging.enabled else { return }
+
         os_signpost(.end, log: .active, name: "Running", signpostID: signpostID, status)
     }
 
     func logOutput() {
+        guard WorkerLogging.enabled else { return }
+
         os_signpost(
             .event,
             log: .active,


### PR DESCRIPTION
### Issue

the existing os logging implementations log various type descriptions as part of the log message. these strings are apparently calculated even if the logging has been disabled, which introduces unneeded/undesirable work in release builds. these logs shouldn't be made in release builds, and should be opt-in in other contexts.

### Description

this change adds short circuiting logic for all the os logging methods in addition to a new environment variable check that can be used to enable the logging when debugging.

- [x] TODO: WorkflowLogger should probably get the same treatment

## Checklist

- [x] Unit Tests – didn't add unit tests, but manually ran existing ones using the new env variable to confirm expected behavior (os_log calls aren't made when the env var isn't set)
~- [x] UI Tests~ n/a
~- [x] Snapshot Tests (iOS only)~ n/a
~- [x] I have made corresponding changes to the documentation~ n/a
