### PR TITLE
[fix] View environment customizations on hosting VCs now propagate to SwiftUI environment

### DIFF
--- a/WorkflowSwiftUI/Sources/StateAccessor.swift
+++ b/WorkflowSwiftUI/Sources/StateAccessor.swift
@@ -12,6 +12,14 @@
 public struct StateAccessor<State: ObservableState> {
     let state: State
     let sendValue: (@escaping (inout State) -> Void) -> Void
+
+    public init(
+        state: State,
+        sendValue: @escaping (@escaping (inout State) -> Void) -> Void
+    ) {
+        self.state = state
+        self.sendValue = sendValue
+    }
 }
 
 extension StateAccessor: ObservableModel {

--- a/WorkflowSwiftUI/Tests/ObservableScreenTests.swift
+++ b/WorkflowSwiftUI/Tests/ObservableScreenTests.swift
@@ -1,0 +1,80 @@
+#if canImport(UIKit)
+
+import SwiftUI
+import ViewEnvironment
+@_spi(ViewEnvironmentWiring) import ViewEnvironmentUI
+import XCTest
+@testable import WorkflowSwiftUI
+
+final class ObservableScreenTests: XCTestCase {
+    func test_viewEnvironmentObservation() {
+        // Ensure that environment customizations made on the view controller
+        // are propagated to the SwiftUI view environment.
+
+        var state = MyState()
+
+        let viewController = TestKeyEmittingScreen(
+            model: MyModel(
+                accessor: StateAccessor(
+                    state: state,
+                    sendValue: { $0(&state) }
+                )
+            )
+        )
+        .buildViewController(in: .empty)
+
+        let lifetime = viewController.addEnvironmentCustomization { environment in
+            environment[TestKey.self] = 1
+        }
+
+        viewController.view.layoutIfNeeded()
+
+        XCTAssertEqual(state.emittedValue, 1)
+
+        withExtendedLifetime(lifetime) {}
+    }
+}
+
+private struct TestKey: ViewEnvironmentKey {
+    static var defaultValue: Int = 0
+}
+
+@ObservableState
+private struct MyState {
+    var emittedValue: TestKey.Value?
+}
+
+private struct MyModel: ObservableModel {
+    typealias State = MyState
+
+    let accessor: StateAccessor<State>
+}
+
+private struct TestKeyEmittingScreen: ObservableScreen {
+    typealias Model = MyModel
+
+    var model: Model
+
+    let sizingOptions: WorkflowSwiftUI.SwiftUIScreenSizingOptions = [.preferredContentSize]
+
+    static func makeView(store: Store<Model>) -> some View {
+        ContentView(store: store)
+    }
+
+    struct ContentView: View {
+        @Environment(\.viewEnvironment)
+        var viewEnvironment: ViewEnvironment
+
+        var store: Store<Model>
+
+        var body: some View {
+            WithPerceptionTracking {
+                let _ = { store.emittedValue = viewEnvironment[TestKey.self] }()
+                Color.clear
+                    .frame(width: 1, height: 1)
+            }
+        }
+    }
+}
+
+#endif

--- a/WorkflowSwiftUI/Tests/ObservableScreenTests.swift
+++ b/WorkflowSwiftUI/Tests/ObservableScreenTests.swift
@@ -3,8 +3,8 @@
 import SwiftUI
 import ViewEnvironment
 @_spi(ViewEnvironmentWiring) import ViewEnvironmentUI
+import WorkflowSwiftUI
 import XCTest
-@testable import WorkflowSwiftUI
 
 final class ObservableScreenTests: XCTestCase {
     func test_viewEnvironmentObservation() {


### PR DESCRIPTION
- View environment customizations on hosting VCs now propagate to SwiftUI environment
- ModeledHostingController implementations now conform to ViewEnvironmentObserving
- Added tests

These changes ensure that any view environment customizations made to a Swift UI screen's backing VC are propagated to the SwiftUI environment. We hit this issue in Market when attempting to propagate the VC's navigation item to SwiftUI and there may be other uses for this behaviour too.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
