### PR TITLE
Comment Updates to Improve Clarity

### DIFF
--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -22,16 +22,16 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowCombine
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect a `Publisher`-based Workflow.
     ///
     /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
     ///
     /// - Parameters:
     ///   - publisher: Type of the Publisher-based Workflow to expect
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expect<PublisherType: Publisher>(
+    func expect<PublisherType: Publisher>(
         publisher: PublisherType.Type,
         producingOutput output: PublisherType.Output? = nil,
         key: String = ""
@@ -46,7 +46,7 @@ extension RenderTester {
     }
 
     @available(*, deprecated, renamed: "expect(publisher:producingOutput:key:)")
-    public func expect<PublisherType: Publisher>(
+    func expect<PublisherType: Publisher>(
         publisher: PublisherType.Type,
         output: PublisherType.Output,
         key: String = ""

--- a/WorkflowCombine/Testing/WorkerTesting.swift
+++ b/WorkflowCombine/Testing/WorkerTesting.swift
@@ -20,14 +20,14 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowCombine
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
     ///
     /// - Parameters:
     ///   - worker: The worker to be expected
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expect<ExpectedWorkerType: Worker>(
+    func expect<ExpectedWorkerType: Worker>(
         worker: ExpectedWorkerType,
         producingOutput output: ExpectedWorkerType.Output? = nil,
         key: String = "",

--- a/WorkflowConcurrency/Testing/WorkerTesting.swift
+++ b/WorkflowConcurrency/Testing/WorkerTesting.swift
@@ -20,14 +20,14 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowConcurrency
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
     ///
     /// - Parameters:
     ///   - worker: The worker to be expected
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expect<ExpectedWorkerType: Worker>(
+    func expect<ExpectedWorkerType: Worker>(
         worker: ExpectedWorkerType,
         producingOutput output: ExpectedWorkerType.Output? = nil,
         key: String = "",

--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -20,7 +20,7 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowReactiveSwift
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect a `SignalProducer` with an optional output.
     ///
     /// `SignalProducerWorkflow` is used to subscribe to `SignalProducer`s and `Signal`s.
@@ -29,9 +29,9 @@ extension RenderTester {
     ///
     /// - Parameters:
     ///   - outputType: The `OutputType` of the expected `SignalProducerWorkflow`. Typically this will be correctly inferred by the type system, but may need to be explicitly specified if particular optionality is desired.
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expectSignalProducer<OutputType>(
+    func expectSignalProducer<OutputType>(
         outputType: OutputType.Type = OutputType.self,
         producingOutput: OutputType? = nil,
         key: String = "",

--- a/WorkflowReactiveSwift/Testing/WorkerTesting.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting.swift
@@ -20,14 +20,14 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowReactiveSwift
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
     ///
     /// - Parameters:
     ///   - worker: The worker to be expected
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expect<ExpectedWorkerType: Worker>(
+    func expect<ExpectedWorkerType: Worker>(
         worker: ExpectedWorkerType,
         producingOutput output: ExpectedWorkerType.Output? = nil,
         key: String = "",

--- a/WorkflowRxSwift/Testing/ObservableTesting.swift
+++ b/WorkflowRxSwift/Testing/ObservableTesting.swift
@@ -20,14 +20,14 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowRxSwift
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
 
     /// - Parameters:
     ///   - outputType: The `OutputType` of the expected `ObservableWorkflow`.
-    ///   - producingOutput: An output that should be returned when this worker is requested, if any.
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expectObservable<OutputType>(
+    func expectObservable<OutputType>(
         outputType: OutputType.Type = OutputType.self,
         producingOutput output: OutputType? = nil,
         key: String = "",

--- a/WorkflowRxSwift/Testing/WorkerTesting.swift
+++ b/WorkflowRxSwift/Testing/WorkerTesting.swift
@@ -20,13 +20,13 @@ import WorkflowTesting
 import XCTest
 @testable import WorkflowRxSwift
 
-extension RenderTester {
+public extension RenderTester {
     /// Expect the given worker. It will be checked for `isEquivalent(to:)` with the requested worker.
 
     /// - Parameters:
     ///   - worker: The worker to be expected
-    ///   - output: An output that should be returned when this worker is requested, if any.
-    public func expect<ExpectedWorkerType: Worker>(
+    ///   - output: An output that will be returned when this worker is requested, if any.
+    func expect<ExpectedWorkerType: Worker>(
         worker: ExpectedWorkerType,
         producingOutput output: ExpectedWorkerType.Output? = nil,
         key: String = "",

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -22,15 +22,15 @@
 import XCTest
 @testable import Workflow
 
-extension Workflow {
+public extension Workflow {
     /// Returns a `RenderTester` with a specified initial state.
-    public func renderTester(initialState: Self.State) -> RenderTester<Self> {
-        return RenderTester(workflow: self, state: initialState)
+    func renderTester(initialState: Self.State) -> RenderTester<Self> {
+        RenderTester(workflow: self, state: initialState)
     }
 
     /// Returns a `RenderTester` with an initial state provided by `self.makeInitialState()`
-    public func renderTester() -> RenderTester<Self> {
-        return renderTester(initialState: makeInitialState())
+    func renderTester() -> RenderTester<Self> {
+        renderTester(initialState: makeInitialState())
     }
 }
 
@@ -146,8 +146,8 @@ public struct RenderTester<WorkflowType: Workflow> {
     /// - Parameters:
     ///   - type: The type of the expected workflow.
     ///   - key: The key of the expected workflow (if specified).
-    ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
-    ///   - output: An output that should be returned after the workflow of this type is rendered, if any.
+    ///   - rendering: The rendering result that will be returned when the workflow of this type is rendered.
+    ///   - output: An output that will be returned after the workflow of this type is rendered, if any.
     ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
     public func expectWorkflow<ExpectedWorkflowType: Workflow>(
         type: ExpectedWorkflowType.Type,
@@ -157,7 +157,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         file: StaticString = #file, line: UInt = #line,
         assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
     ) -> RenderTester<WorkflowType> {
-        return RenderTester(
+        RenderTester(
             workflow: workflow,
             state: state,
             expectedWorkflows: expectedWorkflows.appending(
@@ -179,7 +179,7 @@ public struct RenderTester<WorkflowType: Workflow> {
     /// - Parameters:
     ///   - type: The type of the expected workflow.
     ///   - key: The key of the expected workflow (if specified).
-    ///   - rendering: The rendering result that should be returned when the workflow of this type is rendered.
+    ///   - rendering: The rendering result that will be returned when the workflow of this type is rendered.
     ///   - assertions: Additional assertions for the given workflow, if any. You may use this to assert the properties of the requested workflow are as expected.
     public func expectWorkflowIgnoringOutput<ExpectedWorkflowType: Workflow>(
         type: ExpectedWorkflowType.Type,
@@ -189,7 +189,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         line: UInt = #line,
         assertions: @escaping (ExpectedWorkflowType) -> Void = { _ in }
     ) -> RenderTester<WorkflowType> {
-        return expectWorkflow(
+        expectWorkflow(
             type: OutputBlockingWorkflow<ExpectedWorkflowType>.self,
             key: key,
             producingRendering: rendering,
@@ -206,7 +206,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         key: AnyHashable,
         file: StaticString = #file, line: UInt = #line
     ) -> RenderTester<WorkflowType> {
-        return RenderTester(
+        RenderTester(
             workflow: workflow,
             state: state,
             expectedWorkflows: expectedWorkflows,
@@ -231,7 +231,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         producingAction action: ActionType,
         file: StaticString = #file, line: UInt = #line
     ) -> RenderTester<WorkflowType> where ActionType: WorkflowAction, ActionType.WorkflowType == WorkflowType {
-        return RenderTester(
+        RenderTester(
             workflow: workflow,
             state: state,
             expectedWorkflows: expectedWorkflows,
@@ -283,14 +283,14 @@ public struct RenderTester<WorkflowType: Workflow> {
     }
 }
 
-extension Collection {
-    fileprivate func appending(_ element: Element) -> [Element] {
-        return self + [element]
+fileprivate extension Collection {
+    func appending(_ element: Element) -> [Element] {
+        self + [element]
     }
 }
 
-extension Dictionary {
-    fileprivate func setting(key: Key, value: Value) -> [Key: Value] {
+fileprivate extension Dictionary {
+    func setting(key: Key, value: Value) -> [Key: Value] {
         var newDictionary = self
         newDictionary[key] = value
         return newDictionary


### PR DESCRIPTION
This PR updates some comments on testing methods to improve clarity around the expected behavior. It replaces `should` with `will` to make it clearer that the provided renderings/outputs will not be validated against the rendering/output of the workflow/worker, but instead they will be stubbed as the rendering/output for the workflow/worker when called.

It also includes some other minor style changes that were picked up by the linter.

## Checklist

- [x] Unit Tests (N/A)
- [x] UI Tests (N/A)
- [x] Snapshot Tests (iOS only) (N/A)
- [x] I have made corresponding changes to the documentation
