### PR TITLE
fix: explicit test dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -173,7 +173,7 @@ let package = Package(
         ),
         .testTarget(
             name: "WorkflowRxSwiftTests",
-            dependencies: ["WorkflowRxSwiftTesting"],
+            dependencies: ["WorkflowRxSwiftTesting", "WorkflowReactiveSwift"],
             path: "WorkflowRxSwift/Tests"
         ),
         .target(

--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -179,7 +179,10 @@ let project = Project(
         .unitTest(
             for: "WorkflowConcurrency",
             sources: "../WorkflowConcurrency/Tests/**",
-            dependencies: [.external(name: "WorkflowConcurrency")]
+            dependencies: [
+                .external(name: "WorkflowConcurrency"),
+                .external(name: "WorkflowTesting"),
+            ]
         ),
         .unitTest(
             for: "WorkflowConcurrencyTesting",
@@ -201,7 +204,10 @@ let project = Project(
         .unitTest(
             for: "WorkflowRxSwift",
             sources: "../WorkflowRxSwift/Tests/**",
-            dependencies: [.external(name: "WorkflowRxSwift")]
+            dependencies: [
+                .external(name: "WorkflowRxSwift"),
+                .external(name: "WorkflowReactiveSwift"),
+            ]
         ),
         .unitTest(
             for: "WorkflowRxSwiftTesting",

--- a/Samples/Tuist/Config.swift
+++ b/Samples/Tuist/Config.swift
@@ -1,0 +1,8 @@
+import ProjectDescription
+
+let config = Config(
+// This breaks snapshot tests, because iOSSnapshotTestCase depends on XCTest.
+// ENABLE_TESTING_SEARCH_PATHS should sufficient but doesn't seem to work with
+// enforceExplicitDependencies enabled.
+//    generationOptions: .options(enforceExplicitDependencies: true)
+)


### PR DESCRIPTION
These weren't being picked up on CI but could fail to build locally. The Tuist option to enforce dependencies should help detect similar stuff in the future.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
