### PR TITLE
Make Worker.Output Sendable

### DIFF
--- a/WorkflowCombine/Sources/Worker.swift
+++ b/WorkflowCombine/Sources/Worker.swift
@@ -28,7 +28,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void, Output: Sendable {
     /// The type of output events returned by this worker.
     associatedtype Output
     associatedtype WorkerPublisher: Publisher where

--- a/WorkflowConcurrency/Sources/Worker.swift
+++ b/WorkflowConcurrency/Sources/Worker.swift
@@ -25,7 +25,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void, Output: Sendable {
     /// The type of output events returned by this worker.
     associatedtype Output
 
@@ -63,7 +63,7 @@ struct WorkerWorkflow<WorkerType: Worker>: Workflow {
         let logger = WorkerLogger<WorkerType>()
         let sink = context.makeOutputSink()
         context.runSideEffect(key: state) { lifetime in
-            let send: @MainActor(Output) -> Void = sink.send
+            let send: @MainActor (Output) -> Void = sink.send
             let task = Task(priority: .high) {
                 logger.logStarted()
                 let output = await worker.run()

--- a/WorkflowReactiveSwift/Sources/Worker.swift
+++ b/WorkflowReactiveSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void, Output: Sendable {
     /// The type of output events returned by this worker.
     associatedtype Output
 

--- a/WorkflowRxSwift/Sources/Worker.swift
+++ b/WorkflowRxSwift/Sources/Worker.swift
@@ -26,7 +26,7 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void {
+public protocol Worker<Output>: AnyWorkflowConvertible where Rendering == Void, Output: Sendable {
     /// The type of output events returned by this worker.
     associatedtype Output
 


### PR DESCRIPTION
Adds `Sendable` conformance as a constraint on `Workflow.Output`.

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
