### PR TITLE
Remove empty workflowDidChange from Xcode project templates

### DIFF
--- a/Samples/AsyncWorker/Sources/AsyncWorkerWorkflow.swift
+++ b/Samples/AsyncWorker/Sources/AsyncWorkerWorkflow.swift
@@ -24,8 +24,6 @@ extension AsyncWorkerWorkflow {
     func makeInitialState() -> AsyncWorkerWorkflow.State {
         State(model: Model(message: "Initial State"))
     }
-
-    func workflowDidChange(from previousWorkflow: AsyncWorkerWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/Default/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/Default/___FILEBASENAME___Workflow.swift
@@ -17,8 +17,6 @@ extension ___VARIABLE_productName___Workflow {
     func makeInitialState() -> ___VARIABLE_productName___Workflow.State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: ___VARIABLE_productName___Workflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerReactiveSwift/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerReactiveSwift/___FILEBASENAME___Workflow.swift
@@ -17,8 +17,6 @@ extension ___VARIABLE_productName___Workflow {
     func makeInitialState() -> ___VARIABLE_productName___Workflow.State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: ___VARIABLE_productName___Workflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerRxSwift/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerRxSwift/___FILEBASENAME___Workflow.swift
@@ -17,8 +17,6 @@ extension ___VARIABLE_productName___Workflow {
     func makeInitialState() -> ___VARIABLE_productName___Workflow.State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: ___VARIABLE_productName___Workflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/Workflow/Sources/Workflow.swift
+++ b/Workflow/Sources/Workflow.swift
@@ -91,8 +91,6 @@ extension Workflow where State == Void {
     public func makeInitialState() -> State {
         ()
     }
-
-    public func workflowDidChange(from previousWorkflow: Self, state: inout State) {}
 }
 
 extension Workflow {

--- a/Workflow/Tests/AnyWorkflowTests.swift
+++ b/Workflow/Tests/AnyWorkflowTests.swift
@@ -127,8 +127,6 @@ private struct OnOutputWorkflow: Workflow {
         false
     }
 
-    func workflowDidChange(from previousWorkflow: OnOutputWorkflow, state: inout Bool) {}
-
     func render(state: State, context: RenderContext<OnOutputWorkflow>) -> Bool {
         OnOutputChildWorkflow()
             .onOutput { state, output in

--- a/WorkflowCombine/TestingTests/TestingTests.swift
+++ b/WorkflowCombine/TestingTests/TestingTests.swift
@@ -149,8 +149,6 @@ private struct TestWorkflow: Workflow {
         .init(mode: .idle, output: "")
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<TestWorkflow>) {
         switch state.mode {
         case .idle:

--- a/WorkflowConcurrency/TestingTests/TestingTests.swift
+++ b/WorkflowConcurrency/TestingTests/TestingTests.swift
@@ -148,8 +148,6 @@ private struct TestWorkflow: Workflow {
         .init(mode: .idle, output: "")
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<TestWorkflow>) {
         switch state.mode {
         case .idle:

--- a/WorkflowReactiveSwift/TestingTests/TestingTests.swift
+++ b/WorkflowReactiveSwift/TestingTests/TestingTests.swift
@@ -149,8 +149,6 @@ private struct TestWorkflow: Workflow {
         .init(mode: .idle, output: "")
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<TestWorkflow>) {
         switch state.mode {
         case .idle:

--- a/WorkflowRxSwift/TestingTests/TestingTests.swift
+++ b/WorkflowRxSwift/TestingTests/TestingTests.swift
@@ -140,8 +140,6 @@ private struct TestWorkflow: Workflow {
         .init(mode: .idle, output: "")
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<TestWorkflow>) {
         switch state.mode {
         case .idle:


### PR DESCRIPTION
Remove the empty workflowDidChange(from previousWorkflow:state:) method from Xcode project templates and tests.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
