### PR TITLE
[gardening]: swiftformat – prefer acl's on declarations

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -36,6 +36,7 @@
 --empty void
 --exponentcase lowercase
 --exponentgrouping disabled
+--extensionacl on-declarations
 --fractiongrouping disabled
 --fragment false
 --hexgrouping none


### PR DESCRIPTION
changing the lint preference for this repo from having ACLs on extensions to declarations. this just changes the config – i did not run it against the repo yet.