### PR TITLE
[feat]: adopt swift-custom-dump in some testing utilities

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "3ce83179e5f0c83ad54c305779c6b438e82aaf1d",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "3ce83179e5f0c83ad54c305779c6b438e82aaf1d",
-        "version" : "1.2.1"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-identified-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.1.4"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
     ],
     targets: [
         // MARK: Workflow
@@ -80,7 +81,10 @@ let package = Package(
         ),
         .target(
             name: "WorkflowTesting",
-            dependencies: ["Workflow"],
+            dependencies: [
+                "Workflow",
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+            ],
             path: "WorkflowTesting/Sources",
             linkerSettings: [.linkedFramework("XCTest")]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.1.4"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.2.1"),
     ],
     targets: [
         // MARK: Workflow

--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -192,7 +192,10 @@ let project = Project(
         .unitTest(
             for: "WorkflowReactiveSwift",
             sources: "../WorkflowReactiveSwift/Tests/**",
-            dependencies: [.external(name: "WorkflowReactiveSwift")]
+            dependencies: [
+                .external(name: "WorkflowReactiveSwift"),
+                .external(name: "WorkflowReactiveSwiftTesting"),
+            ]
         ),
         .unitTest(
             for: "WorkflowReactiveSwiftTesting",
@@ -205,6 +208,7 @@ let project = Project(
             sources: "../WorkflowRxSwift/Tests/**",
             dependencies: [
                 .external(name: "WorkflowRxSwift"),
+                .external(name: "WorkflowRxSwiftTesting"),
                 .external(name: "WorkflowReactiveSwift"),
             ]
         ),

--- a/Samples/Tuist/Package.resolved
+++ b/Samples/Tuist/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-identified-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-identified-collections",

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -130,22 +130,18 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
     ///   and is expected to mutate it to match the new state.
     @discardableResult
     public func assertStateModifications(
-        _ modifications: (inout WorkflowType.State) throws -> Void,
-        fileID: StaticString = #fileID,
-        filePath: StaticString = #filePath,
+        file: StaticString = #file,
         line: UInt = #line,
-        column: UInt = #column
+        _ modifications: (inout WorkflowType.State) throws -> Void
     ) rethrows -> RenderTesterResult<WorkflowType> {
         var initialState = initialState
         try modifications(&initialState)
-        expectNoDifference(
+        XCTAssertNoDifference(
             initialState,
             state,
             "Expected state does not match",
-            fileID: fileID,
-            filePath: filePath,
-            line: line,
-            column: column
+            file: file,
+            line: line
         )
         return self
     }

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import CustomDump
 import Workflow
 import XCTest
 
@@ -129,13 +130,23 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
     ///   and is expected to mutate it to match the new state.
     @discardableResult
     public func assertStateModifications(
-        file: StaticString = #file,
+        _ modifications: (inout WorkflowType.State) throws -> Void,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
         line: UInt = #line,
-        _ modifications: (inout WorkflowType.State) throws -> Void
+        column: UInt = #column
     ) rethrows -> RenderTesterResult<WorkflowType> {
         var initialState = initialState
         try modifications(&initialState)
-        XCTAssertEqual(state, initialState, "Expected state does not match", file: file, line: line)
+        expectNoDifference(
+            initialState,
+            state,
+            "Expected state does not match",
+            fileID: fileID,
+            filePath: filePath,
+            line: line,
+            column: column
+        )
         return self
     }
 }

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -341,7 +341,7 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         }
     }
 
-    func test_assertState() {
+    func test_assertStateModifications() {
         let result = TestWorkflow()
             .renderTester(initialState: .idle)
             .render { _ in }


### PR DESCRIPTION
- Before: assertStateModifications was difficult to use because the diffs for failed assertions were difficult to read
- After: Incorporate CustomDump into assertStateModifications to make the assertions easy to read

### Demo
|Before|After|
|:-:|:-:|
|<img width="643" alt="Screenshot 2024-12-02 at 10 25 14 AM" src="https://github.com/user-attachments/assets/49340800-73f4-4016-9034-9017d39a5b92">|<img width="462" alt="Screenshot 2024-12-02 at 10 23 54 AM" src="https://github.com/user-attachments/assets/ce5fc790-b65b-4bc0-b113-cf4ddaad2ed2">|

### Complex Demo
|Before|After|
|:-:|:-:|
|<img width="774" alt="image" src="https://github.com/user-attachments/assets/d8ab25ae-5c89-413b-adec-30e81bb99218">|![image](https://github.com/user-attachments/assets/4d970a88-5e86-4307-810c-d748a37c57b0)|








## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
