### PR TITLE
Use swift-custom-dump for all comparisons in RenderTesterResult

### DIFF
--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -80,7 +80,13 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> where ActionType.WorkflowType == WorkflowType, ActionType: Equatable {
         verifyAction(file: file, line: line) { appliedAction in
-            XCTAssertEqual(appliedAction, action, file: file, line: line)
+            XCTAssertNoDifference(
+                appliedAction,
+                action,
+                "Action (First) does not match the expected action (Second)",
+                file: file,
+                line: line
+            )
         }
     }
 
@@ -120,7 +126,13 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
         file: StaticString = #file,
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> {
-        XCTAssertEqual(state, expectedState, file: file, line: line)
+        XCTAssertNoDifference(
+            state,
+            expectedState,
+            "State (First) does not match the expected state (Second)",
+            file: file,
+            line: line
+        )
         return self
     }
 
@@ -137,9 +149,9 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
         var initialState = initialState
         try modifications(&initialState)
         XCTAssertNoDifference(
-            initialState,
             state,
-            "Expected state does not match",
+            initialState,
+            "State (First) does not match the expected state (Second)",
             file: file,
             line: line
         )
@@ -156,7 +168,13 @@ extension RenderTesterResult where WorkflowType.Output: Equatable {
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> {
         verifyOutput(file: file, line: line) { output in
-            XCTAssertEqual(output, expectedOutput, file: file, line: line)
+            XCTAssertNoDifference(
+                output,
+                expectedOutput,
+                "Output (First) does not match the expected output (Second)",
+                file: file,
+                line: line
+            )
         }
     }
 }

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -227,7 +227,14 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
                 rendering.doNoopAction(10)
             }
 
-        expectingFailure(#"("noop(10)") is not equal to ("noop(70)")"#) {
+        expectingFailure("""
+        failed - XCTAssertNoDifference failed: …
+
+          − TestAction.noop(10)
+          + TestAction.noop(70)
+
+        (First: −, Second: +) - Action (First) does not match the expected action (Second)
+        """) {
             result.assert(action: TestAction.noop(70))
         }
 
@@ -272,7 +279,14 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             }
         }
 
-        expectingFailure(#"("sendOutput("second")") is not equal to ("noop(0)")"#) {
+        expectingFailure("""
+        failed - XCTAssertNoDifference failed: …
+
+          − TestAction.sendOutput("second")
+          + TestAction.noop(0)
+
+        (First: −, Second: +) - Action (First) does not match the expected action (Second)
+        """) {
             result.assert(action: TestAction.noop(0))
         }
 
@@ -296,7 +310,14 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
                 rendering.doOutput("hello")
             }
 
-        expectingFailure(#"("string("hello")") is not equal to ("string("nope")")"#) {
+        expectingFailure("""
+        failed - XCTAssertNoDifference failed: …
+
+          − TestWorkflow.Output.string("hello")
+          + TestWorkflow.Output.string("nope")
+
+        (First: −, Second: +) - Output (First) does not match the expected output (Second)
+        """) {
             result.assert(output: .string("nope"))
         }
 
@@ -341,12 +362,36 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         }
     }
 
+    func test_assertState() {
+        let result = TestWorkflow()
+            .renderTester(initialState: .idle)
+            .render { _ in }
+
+        expectingFailure("""
+        failed - XCTAssertNoDifference failed: …
+
+          − TestWorkflow.State.idle
+          + TestWorkflow.State.sideEffect(key: "nah")
+
+        (First: −, Second: +) - State (First) does not match the expected state (Second)
+        """) {
+            result.assert(state: TestWorkflow.State.sideEffect(key: "nah"))
+        }
+    }
+
     func test_assertStateModifications() {
         let result = TestWorkflow()
             .renderTester(initialState: .idle)
             .render { _ in }
 
-        expectingFailure("Expected state does not match") {
+        expectingFailure("""
+        XCTAssertNoDifference failed: …
+
+          − TestWorkflow.State.idle
+          + TestWorkflow.State.sideEffect(key: "nah")
+
+        (First: −, Second: +) - State (First) does not match the expected state (Second)
+        """) {
             result.assertStateModifications { state in
                 state = .sideEffect(key: "nah")
             }


### PR DESCRIPTION
This expands the usage of swift-custom-dump to improve test failure readability


## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
