### PR TITLE
Display a deprecation warning and fatal error when the top-level `@Environment(\.viewEnvironment)` is referenced

### DIFF
--- a/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
+++ b/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
@@ -29,4 +29,28 @@ extension EnvironmentValues {
     }
 }
 
+
+extension Environment where Value == ViewEnvironment {
+    
+    @available(
+        *,
+         deprecated,
+         message:
+            """
+            Please do not create an `@Environment` property that references the top-level `viewEnvironment`: \
+            it will break SwiftUI's automatic invalidation when any part of the `ViewEnvironment` changes. \
+            Instead, reference your relevant sub-property, eg `@Environment(\\.viewEnvironment.myProperty)`.
+            """
+    )
+    @inlinable public init(_ keyPath: KeyPath<EnvironmentValues, Value>) {
+        fatalError(
+            """
+            Please do not create an `@Environment` property that references the top-level `viewEnvironment`: \
+            it will break SwiftUI's automatic invalidation when any part of the `ViewEnvironment` changes. \
+            Instead, reference your relevant sub-property, eg `@Environment(\\.viewEnvironment.myProperty)`.
+            """
+        )
+    }
+}
+
 #endif


### PR DESCRIPTION
Display a deprecation warning and fatal error when the top-level `@Environment(\.viewEnvironment)` is referenced, to enforce people reference a sub-property. This ensures proper SwiftUI view invalidation.

<img width="872" alt="image" src="https://github.com/user-attachments/assets/9da9e08f-c65d-493b-b849-52d2ab91cddf" />

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
