### PR TITLE
Resolve Bazel dylib issue due to aggressive code stripping

### DIFF
--- a/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -44,6 +44,7 @@ open class ScreenViewController<ScreenType: Screen>: WorkflowUIViewController {
         ScreenType.self
     }
 
+    @_alwaysEmitIntoClient
     private var previousEnvironment: ViewEnvironment
 
     public required init(screen: ScreenType, environment: ViewEnvironment) {


### PR DESCRIPTION
The dylib being generated internally is code stripping private vars incorrectly. This should resolve it.

## Checklist

N/A / validated by internal CI

- [X] Unit Tests
- [X] UI Tests
- [X] Snapshot Tests (iOS only)
- [X] I have made corresponding changes to the documentation
