### PR TITLE
[gardening]: remove unneeded 'isRootNode' param

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -476,7 +476,7 @@ extension WorkflowNode.SubtreeManager {
         }
 
         func render() -> W.Rendering {
-            node.render(isRootNode: false)
+            node.render()
         }
 
         func update(

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -69,7 +69,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
             observer: observer
         )
 
-        self.mutableRendering = MutableProperty(rootNode.render(isRootNode: true))
+        self.mutableRendering = MutableProperty(rootNode.render())
         self.rendering = Property(mutableRendering)
         rootNode.enableEvents()
 
@@ -96,7 +96,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
     }
 
     private func handle(output: WorkflowNode<WorkflowType>.Output) {
-        mutableRendering.value = rootNode.render(isRootNode: true)
+        mutableRendering.value = rootNode.render()
 
         if let outputEvent = output.outputEvent {
             outputEventObserver.send(value: outputEvent)

--- a/Workflow/Sources/WorkflowLogger.swift
+++ b/Workflow/Sources/WorkflowLogger.swift
@@ -161,11 +161,10 @@ enum WorkflowLogger {
     // MARK: Rendering
 
     static func logWorkflowStartedRendering<WorkflowType>(
-        ref: WorkflowNode<WorkflowType>,
-        isRootNode: Bool
+        ref: WorkflowNode<WorkflowType>
     ) {
         guard shouldLogRenderTimings(
-            isRootNode: isRootNode
+            isRootNode: ref.isRootNode
         ) else { return }
 
         let signpostID = OSSignpostID(log: .active, object: ref)
@@ -180,11 +179,10 @@ enum WorkflowLogger {
     }
 
     static func logWorkflowFinishedRendering(
-        ref: WorkflowNode<some Any>,
-        isRootNode: Bool
+        ref: WorkflowNode<some Any>
     ) {
         guard shouldLogRenderTimings(
-            isRootNode: isRootNode
+            isRootNode: ref.isRootNode
         ) else { return }
 
         let signpostID = OSSignpostID(log: .active, object: ref)
@@ -194,7 +192,7 @@ enum WorkflowLogger {
     // MARK: - Utilities
 
     private static func shouldLogRenderTimings(
-        isRootNode: Bool
+        isRootNode: @autoclosure () -> Bool
     ) -> Bool {
         guard WorkflowLogging.isOSLoggingAllowed else {
             return false
@@ -203,7 +201,7 @@ enum WorkflowLogger {
         case .none:
             return false
         case .rootsOnly:
-            return isRootNode
+            return isRootNode()
         case .allNodes:
             return true
         }

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -114,8 +114,8 @@ final class WorkflowNode<WorkflowType: Workflow> {
     /// - Parameter isRootNode: whether or not this is the root node of the tree. Note, this
     /// is currently only used as a hint for the logging infrastructure, and is up to callers to correctly specify.
     /// - Returns: A `Rendering` of appropriate type
-    func render(isRootNode: Bool = false) -> WorkflowType.Rendering {
-        WorkflowLogger.logWorkflowStartedRendering(ref: self, isRootNode: isRootNode)
+    func render() -> WorkflowType.Rendering {
+        WorkflowLogger.logWorkflowStartedRendering(ref: self)
 
         let renderObserverCompletion = observer?.workflowWillRender(
             workflow,
@@ -128,7 +128,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
         defer {
             renderObserverCompletion?(rendering)
 
-            WorkflowLogger.logWorkflowFinishedRendering(ref: self, isRootNode: isRootNode)
+            WorkflowLogger.logWorkflowFinishedRendering(ref: self)
         }
 
         rendering = subtreeManager.render { context in
@@ -211,5 +211,13 @@ extension WorkflowNode {
         output = action.apply(toState: &state)
 
         return output
+    }
+}
+
+// MARK: - Utility
+
+extension WorkflowNode {
+    var isRootNode: Bool {
+        session.parent == nil
     }
 }

--- a/Workflow/Tests/PerformanceTests.swift
+++ b/Workflow/Tests/PerformanceTests.swift
@@ -37,7 +37,7 @@ class PerformanceTests: XCTestCase {
     func test_render_wideShallowTree() throws {
         measure {
             let node = WorkflowNode(workflow: WideShallowParentWorkflow())
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
@@ -47,14 +47,14 @@ class PerformanceTests: XCTestCase {
                 workflow: WideShallowParentWorkflow(),
                 observer: noOpObserver
             )
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
     func test_render_narrowDeepTree() throws {
         measure {
             let node = WorkflowNode(workflow: NarrowDeepParentWorkflow())
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
@@ -64,7 +64,7 @@ class PerformanceTests: XCTestCase {
                 workflow: NarrowDeepParentWorkflow(),
                 observer: noOpObserver
             )
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
@@ -74,7 +74,7 @@ class PerformanceTests: XCTestCase {
 
         measure {
             let node = WorkflowNode(workflow: WideShallowParentWorkflow())
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
@@ -84,7 +84,7 @@ class PerformanceTests: XCTestCase {
 
         measure {
             let node = WorkflowNode(workflow: WideShallowParentWorkflow())
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 
@@ -94,7 +94,7 @@ class PerformanceTests: XCTestCase {
 
         measure {
             let node = WorkflowNode(workflow: NarrowDeepParentWorkflow())
-            _ = node.render(isRootNode: true)
+            _ = node.render()
         }
     }
 }

--- a/Workflow/Tests/WorkflowNodeTests.swift
+++ b/Workflow/Tests/WorkflowNodeTests.swift
@@ -236,6 +236,26 @@ final class WorkflowNodeTests: XCTestCase {
         XCTAssertTrue(sessions[2].workflowType is EventEmittingWorkflow.Type)
         XCTAssertEqual(sessions[0].sessionID, sessions[1].parent?.sessionID)
     }
+
+    func test_isRootNode() {
+        do {
+            let root = WorkflowNode(workflow: SimpleWorkflow(string: "root"))
+            XCTAssert(root.isRootNode)
+        }
+
+        do {
+            let parentSession = WorkflowSession(
+                workflow: SimpleWorkflow(string: "parent"),
+                renderKey: "",
+                parent: nil
+            )
+            let root = WorkflowNode(
+                workflow: SimpleWorkflow(string: "root"),
+                parentSession: parentSession
+            )
+            XCTAssertFalse(root.isRootNode)
+        }
+    }
 }
 
 /// Renders two child state machines of types `A` and `B`.


### PR DESCRIPTION
minor cleanup of a now-superfluous parameter used for logging determinations
