### PR TITLE
[gardening]: swap some preconditions with fatalError for better debugging

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -230,7 +230,9 @@ extension WorkflowNode.SubtreeManager {
 
             /// If the key was already in `used`, then a workflow of the same type was rendered multiple times
             /// during this render pass with the same key. This is not allowed.
-            precondition(keyWasUnused, "Child workflows of the same type must be given unique keys. Duplicate workflows of type \(Child.self) were encountered with the key \"\(key)\" in \(WorkflowType.self)")
+            guard keyWasUnused else {
+                fatalError("Child workflows of the same type must be given unique keys. Duplicate workflows of type \(Child.self) were encountered with the key \"\(key)\" in \(WorkflowType.self)")
+            }
 
             return child.render()
         }

--- a/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/UIViewController+Extensions.swift
@@ -62,13 +62,14 @@ extension UpdateChildScreenViewController where Self: UIViewController {
             // We should only add the view controller if the old one was already within the parent.
 
             if let parent = old.parent {
-                precondition(
-                    parent == self,
-                    """
-                    The parent of the child view controller must be \(self). Instead, it was \(parent). \
-                    Please call `update(child:)` on the correct parent view controller.
-                    """
-                )
+                guard parent == self else {
+                    fatalError(
+                        """
+                        The parent of the child view controller must be \(self). Instead, it was \(parent). \
+                        Please call `update(child:)` on the correct parent view controller.
+                        """
+                    )
+                }
 
                 // Begin the transition: Signal the new vc will begin moving in, and the old one, out.
 

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -131,14 +131,15 @@ public struct ViewControllerDescription {
     /// You must pass a view controller previously created by a compatible `ViewControllerDescription`
     /// that passes `canUpdate(viewController:)`. Failure to do so will result in a fatal precondition.
     public func update(viewController: UIViewController) {
-        precondition(
-            canUpdate(viewController: viewController),
-            """
-            `ViewControllerDescription` was provided a view controller it cannot update: (\(viewController).
+        guard canUpdate(viewController: viewController) else {
+            fatalError(
+                """
+                `ViewControllerDescription` was provided a view controller it cannot update: (\(viewController).
 
-            The view controller type (\(type(of: viewController)) is a compatible type to the expected type \(kind.viewControllerType)).
-            """
-        )
+                The view controller type (\(type(of: viewController)) is a compatible type to the expected type \(kind.viewControllerType)).
+                """
+            )
+        }
 
         configureAncestor(of: viewController)
 


### PR DESCRIPTION
it was pointed out that `precondition` failure messages are generally not displayed in crash reports, so `fatalError` may be a better tool to handle terminating conditions. this change swaps out usage of `precondition` with `fatalError` for this reason.
