### PR TITLE
[gardening]: fix some deprecation warnings

### DIFF
--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -156,10 +156,10 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
     @discardableResult
     public func assertStateModifications(
         file: StaticString = #file,
-        line: UInt = #line,
-        _ modifications: (inout WorkflowType.State) throws -> Void,
         fileID: StaticString = #fileID,
-        column: UInt = #column
+        line: UInt = #line,
+        column: UInt = #column,
+        _ modifications: (inout WorkflowType.State) throws -> Void
     ) rethrows -> RenderTesterResult<WorkflowType> {
         var initialState = initialState
         try modifications(&initialState)

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -26,7 +26,12 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
     let appliedAction: AppliedAction<WorkflowType>?
     let output: WorkflowType.Output?
 
-    init(initialState: WorkflowType.State, state: WorkflowType.State, appliedAction: AppliedAction<WorkflowType>?, output: WorkflowType.Output?) {
+    init(
+        initialState: WorkflowType.State,
+        state: WorkflowType.State,
+        appliedAction: AppliedAction<WorkflowType>?,
+        output: WorkflowType.Output?
+    ) {
         self.initialState = initialState
         self.state = state
         self.appliedAction = appliedAction
@@ -77,15 +82,19 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
     public func assert<ActionType: WorkflowAction>(
         action: ActionType,
         file: StaticString = #file,
-        line: UInt = #line
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        column: UInt = #column
     ) -> RenderTesterResult<WorkflowType> where ActionType.WorkflowType == WorkflowType, ActionType: Equatable {
         verifyAction(file: file, line: line) { appliedAction in
-            XCTAssertNoDifference(
+            expectNoDifference(
                 appliedAction,
                 action,
                 "Action (First) does not match the expected action (Second)",
-                file: file,
-                line: line
+                fileID: fileID,
+                filePath: file,
+                line: line,
+                column: column
             )
         }
     }
@@ -124,14 +133,18 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
     public func assert(
         state expectedState: WorkflowType.State,
         file: StaticString = #file,
-        line: UInt = #line
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        column: UInt = #column
     ) -> RenderTesterResult<WorkflowType> {
-        XCTAssertNoDifference(
+        expectNoDifference(
             state,
             expectedState,
             "State (First) does not match the expected state (Second)",
-            file: file,
-            line: line
+            fileID: fileID,
+            filePath: file,
+            line: line,
+            column: column
         )
         return self
     }
@@ -144,16 +157,20 @@ extension RenderTesterResult where WorkflowType.State: Equatable {
     public func assertStateModifications(
         file: StaticString = #file,
         line: UInt = #line,
-        _ modifications: (inout WorkflowType.State) throws -> Void
+        _ modifications: (inout WorkflowType.State) throws -> Void,
+        fileID: StaticString = #fileID,
+        column: UInt = #column
     ) rethrows -> RenderTesterResult<WorkflowType> {
         var initialState = initialState
         try modifications(&initialState)
-        XCTAssertNoDifference(
+        expectNoDifference(
             state,
             initialState,
             "State (First) does not match the expected state (Second)",
-            file: file,
-            line: line
+            fileID: fileID,
+            filePath: file,
+            line: line,
+            column: column
         )
         return self
     }
@@ -165,15 +182,19 @@ extension RenderTesterResult where WorkflowType.Output: Equatable {
     public func assert(
         output expectedOutput: WorkflowType.Output,
         file: StaticString = #file,
-        line: UInt = #line
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        column: UInt = #column
     ) -> RenderTesterResult<WorkflowType> {
         verifyOutput(file: file, line: line) { output in
-            XCTAssertNoDifference(
+            expectNoDifference(
                 output,
                 expectedOutput,
                 "Output (First) does not match the expected output (Second)",
-                file: file,
-                line: line
+                fileID: fileID,
+                filePath: file,
+                line: line,
+                column: column
             )
         }
     }

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -228,12 +228,12 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             }
 
         expectingFailure("""
-        failed - XCTAssertNoDifference failed: …
+        failed - Action (First) does not match the expected action (Second) - Difference: …
 
           − TestAction.noop(10)
           + TestAction.noop(70)
 
-        (First: −, Second: +) - Action (First) does not match the expected action (Second)
+        (First: −, Second: +)
         """) {
             result.assert(action: TestAction.noop(70))
         }
@@ -280,12 +280,12 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
         }
 
         expectingFailure("""
-        failed - XCTAssertNoDifference failed: …
+        failed - Action (First) does not match the expected action (Second) - Difference: …
 
           − TestAction.sendOutput("second")
           + TestAction.noop(0)
 
-        (First: −, Second: +) - Action (First) does not match the expected action (Second)
+        (First: −, Second: +)
         """) {
             result.assert(action: TestAction.noop(0))
         }
@@ -311,12 +311,12 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             }
 
         expectingFailure("""
-        failed - XCTAssertNoDifference failed: …
+        failed - Output (First) does not match the expected output (Second) - Difference: …
 
           − TestWorkflow.Output.string("hello")
           + TestWorkflow.Output.string("nope")
 
-        (First: −, Second: +) - Output (First) does not match the expected output (Second)
+        (First: −, Second: +)
         """) {
             result.assert(output: .string("nope"))
         }
@@ -368,12 +368,12 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             .render { _ in }
 
         expectingFailure("""
-        failed - XCTAssertNoDifference failed: …
+        failed - State (First) does not match the expected state (Second) - Difference: …
 
           − TestWorkflow.State.idle
           + TestWorkflow.State.sideEffect(key: "nah")
 
-        (First: −, Second: +) - State (First) does not match the expected state (Second)
+        (First: −, Second: +)
         """) {
             result.assert(state: TestWorkflow.State.sideEffect(key: "nah"))
         }
@@ -385,12 +385,12 @@ final class WorkflowRenderTesterFailureTests: XCTestCase {
             .render { _ in }
 
         expectingFailure("""
-        XCTAssertNoDifference failed: …
+        failed - State (First) does not match the expected state (Second) - Difference: …
 
           − TestWorkflow.State.idle
           + TestWorkflow.State.sideEffect(key: "nah")
 
-        (First: −, Second: +) - State (First) does not match the expected state (Second)
+        (First: −, Second: +)
         """) {
             result.assertStateModifications { state in
                 state = .sideEffect(key: "nah")


### PR DESCRIPTION
updates some testing API to use more defaulted parameters and pass them through to the `expectNoDifference` method from `CustomDump`, as the existing `XCTAssertNoDifference` has been deprecated.