### PR TITLE
[perf]: don't instantiate debugger info if not needed

### DIFF
--- a/Workflow/Sources/Debugging.swift
+++ b/Workflow/Sources/Debugging.swift
@@ -161,7 +161,7 @@ extension WorkflowUpdateDebugInfo? {
 
 extension WorkflowUpdateDebugInfo {
     fileprivate static let unexpectedlyMissing = {
-        assertionFailure("Creation of actual WorkflowUpdateDebugInfo failed unexectedly")
+        assertionFailure("Creation of actual WorkflowUpdateDebugInfo failed unexpectedly")
         return WorkflowUpdateDebugInfo(
             workflowType: "BUG IN WORKFLOW",
             kind: .didUpdate(source: .external)

--- a/Workflow/Sources/Debugging.swift
+++ b/Workflow/Sources/Debugging.swift
@@ -148,3 +148,23 @@ extension WorkflowHierarchyDebugSnapshot {
         }
     }
 }
+
+// MARK: - Compatibility
+
+/// These extensions are utilities to support conditionally emitting debug info only when a
+/// `debugger` is set.
+extension WorkflowUpdateDebugInfo? {
+    var unwrappedOrErrorDefault: WorkflowUpdateDebugInfo {
+        self ?? .unexpectedlyMissing
+    }
+}
+
+extension WorkflowUpdateDebugInfo {
+    fileprivate static let unexpectedlyMissing = {
+        assertionFailure("Creation of actual WorkflowUpdateDebugInfo failed unexectedly")
+        return WorkflowUpdateDebugInfo(
+            workflowType: "BUG IN WORKFLOW",
+            kind: .didUpdate(source: .external)
+        )
+    }()
+}

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -131,10 +131,29 @@ extension WorkflowNode {
     }
 }
 
+/// Carries information about the provenance of an event handled by the runtime.
+enum EventSource: Equatable {
+    /// An event received from an external source.
+    case external
+
+    /// An event that from a descendent in the subtree.
+    /// Will contain associated debug info iff the `debugger` property of the `WorkflowHost`
+    /// is set.
+    case subtree(WorkflowUpdateDebugInfo?)
+
+    /// Compatibility method to convert to the public representation of this data
+    func toDebugInfoSource() -> WorkflowUpdateDebugInfo.Source {
+        switch self {
+        case .external: .external
+        case .subtree(let maybeInfo): .subtree(maybeInfo.unwrappedOrErrorDefault)
+        }
+    }
+}
+
 extension WorkflowNode.SubtreeManager {
     enum Output {
-        case update(any WorkflowAction<WorkflowType>, source: WorkflowUpdateDebugInfo.Source)
-        case childDidUpdate(WorkflowUpdateDebugInfo)
+        case update(any WorkflowAction<WorkflowType>, source: EventSource)
+        case childDidUpdate(WorkflowUpdateDebugInfo?)
     }
 }
 

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -136,7 +136,7 @@ enum EventSource: Equatable {
     /// An event received from an external source.
     case external
 
-    /// An event that from a descendent in the subtree.
+    /// An event that comes from a descendent in the subtree.
     /// Will contain associated debug info iff the `debugger` property of the `WorkflowHost`
     /// is set.
     case subtree(WorkflowUpdateDebugInfo?)

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -96,19 +96,23 @@ final class WorkflowNode<WorkflowType: Workflow> {
             /// Finally, we tell the outside world that our state has changed (including an output event if it exists).
             output = Output(
                 outputEvent: outputEvent,
-                debugInfo: WorkflowUpdateDebugInfo(
-                    workflowType: "\(WorkflowType.self)",
-                    kind: .didUpdate(source: source)
-                )
+                debugInfo: hostContext.ifDebuggerEnabled {
+                    WorkflowUpdateDebugInfo(
+                        workflowType: "\(WorkflowType.self)",
+                        kind: .didUpdate(source: source.toDebugInfoSource())
+                    )
+                }
             )
 
         case .childDidUpdate(let debugInfo):
             output = Output(
                 outputEvent: nil,
-                debugInfo: WorkflowUpdateDebugInfo(
-                    workflowType: "\(WorkflowType.self)",
-                    kind: .childDidUpdate(debugInfo)
-                )
+                debugInfo: hostContext.ifDebuggerEnabled {
+                    WorkflowUpdateDebugInfo(
+                        workflowType: "\(WorkflowType.self)",
+                        kind: .childDidUpdate(debugInfo.unwrappedOrErrorDefault)
+                    )
+                }
             )
         }
 
@@ -179,7 +183,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
 extension WorkflowNode {
     struct Output {
         var outputEvent: WorkflowType.Output?
-        var debugInfo: WorkflowUpdateDebugInfo
+        var debugInfo: WorkflowUpdateDebugInfo?
     }
 }
 

--- a/Workflow/Tests/HostContextTests.swift
+++ b/Workflow/Tests/HostContextTests.swift
@@ -12,12 +12,12 @@ final class HostContextTests: XCTestCase {
 
     func test_conditional_debug_info_with_debugger() {
         let subject = HostContext.testing(debugger: TestDebugger())
-        let expectaiton = expectation(description: "debugger block invoked")
+        let expectation = expectation(description: "debugger block invoked")
 
         subject.ifDebuggerEnabled {
-            expectaiton.fulfill()
+            expectation.fulfill()
         }
 
-        wait(for: [expectaiton], timeout: 0.001)
+        wait(for: [expectation], timeout: 0.001)
     }
 }

--- a/Workflow/Tests/HostContextTests.swift
+++ b/Workflow/Tests/HostContextTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+@testable import Workflow
+
+final class HostContextTests: XCTestCase {
+    func test_conditional_debug_info_no_debugger() {
+        let subject = HostContext.testing(debugger: nil)
+        subject.ifDebuggerEnabled {
+            XCTFail("should not be called")
+        }
+    }
+
+    func test_conditional_debug_info_with_debugger() {
+        let subject = HostContext.testing(debugger: TestDebugger())
+        let expectaiton = expectation(description: "debugger block invoked")
+
+        subject.ifDebuggerEnabled {
+            expectaiton.fulfill()
+        }
+
+        wait(for: [expectaiton], timeout: 0.001)
+    }
+}

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -57,7 +57,7 @@ struct StateTransitioningWorkflow: Workflow {
     }
 }
 
-// MARK: -
+// MARK: - HostContext
 
 extension HostContext {
     static func testing(
@@ -69,4 +69,17 @@ extension HostContext {
             debugger: debugger
         )
     }
+}
+
+// MARK: - WorkflowDebugger
+
+struct TestDebugger: WorkflowDebugger {
+    func didEnterInitialState(
+        snapshot: WorkflowHierarchyDebugSnapshot
+    ) {}
+
+    func didUpdate(
+        snapshot: WorkflowHierarchyDebugSnapshot,
+        updateInfo: WorkflowUpdateDebugInfo
+    ) {}
 }

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -61,11 +61,12 @@ struct StateTransitioningWorkflow: Workflow {
 
 extension HostContext {
     static func testing(
-        observer: WorkflowObserver? = nil
+        observer: WorkflowObserver? = nil,
+        debugger: WorkflowDebugger? = nil
     ) -> HostContext {
         HostContext(
             observer: observer,
-            debugger: nil
+            debugger: debugger
         )
     }
 }

--- a/Workflow/Tests/WorkflowNodeTests.swift
+++ b/Workflow/Tests/WorkflowNodeTests.swift
@@ -160,6 +160,38 @@ final class WorkflowNodeTests: XCTestCase {
         }
     }
 
+    func test_noDebugUpdateInfoIfNoDebugger() {
+        typealias WorkflowType = CompositeWorkflow<EventEmittingWorkflow, SimpleWorkflow>
+
+        let workflow = CompositeWorkflow(
+            a: EventEmittingWorkflow(string: "Hello"),
+            b: SimpleWorkflow(string: "World")
+        )
+
+        let context = HostContext.testing(debugger: nil)
+        let node = WorkflowNode(workflow: workflow, hostContext: context)
+
+        let rendering = node.render()
+        node.enableEvents()
+
+        var emittedDebugInfo: [WorkflowUpdateDebugInfo?] = []
+
+        let expectation = XCTestExpectation(description: "Output")
+        node.onOutput = { value in
+            emittedDebugInfo.append(value.debugInfo)
+            expectation.fulfill()
+        }
+
+        rendering.aRendering.someoneTappedTheButton()
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(emittedDebugInfo.count, 1)
+
+        let debugInfo = emittedDebugInfo[0]
+        XCTAssertNil(debugInfo)
+    }
+
     func test_debugTreeSnapshots() {
         typealias WorkflowType = CompositeWorkflow<EventEmittingWorkflow, SimpleWorkflow>
 
@@ -419,17 +451,4 @@ extension WorkflowNode {
             parentSession: parentSession
         )
     }
-}
-
-// MARK: -
-
-private struct TestDebugger: WorkflowDebugger {
-    func didEnterInitialState(
-        snapshot: WorkflowHierarchyDebugSnapshot
-    ) {}
-
-    func didUpdate(
-        snapshot: WorkflowHierarchyDebugSnapshot,
-        updateInfo: WorkflowUpdateDebugInfo
-    ) {}
 }


### PR DESCRIPTION
refactors action propagation to no longer instantiate any `WorkflowDebugInfo` types unless there is a `WorkflowDebugger` set on the host. this should avoid some unnecessary string allocations and reflection metadata lookups.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
