### PR TITLE
[perf]: a couple more micro optimizations

### DIFF
--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -82,15 +82,19 @@ extension WorkflowNode {
             childWorkflows = context.usedChildWorkflows
             sideEffectLifetimes = context.usedSideEffectLifetimes
 
-            /// Captured the reusable sinks from this render pass.
+            /// Capture the reusable sinks from this render pass.
             previousSinks = context.sinkStore.usedSinks
 
             /// Capture all the pipes to be enabled after render completes.
             eventPipes = context.eventPipes
-            eventPipes.append(contentsOf: context.sinkStore.eventPipes)
+            for (_, sink) in context.sinkStore.usedSinks {
+                eventPipes.append(sink.eventPipe)
+            }
 
             /// Set all event pipes to `pending`.
-            eventPipes.forEach { $0.setPending() }
+            for eventPipe in eventPipes {
+                eventPipe.setPending()
+            }
 
             /// Return the rendered result
             return rendering
@@ -288,12 +292,6 @@ extension WorkflowNode.SubtreeManager {
 
 extension WorkflowNode.SubtreeManager {
     fileprivate struct SinkStore {
-        var eventPipes: [EventPipe] {
-            usedSinks.values.map { reusableSink -> EventPipe in
-                reusableSink.eventPipe
-            }
-        }
-
         private var previousSinks: [ObjectIdentifier: AnyReusableSink]
         private(set) var usedSinks: [ObjectIdentifier: AnyReusableSink]
 

--- a/Workflow/Sources/WorkflowObserver.swift
+++ b/Workflow/Sources/WorkflowObserver.swift
@@ -107,7 +107,7 @@ public struct WorkflowSession {
         private static var _nextRawID: UInt64 = 0
         private static func _makeNextSessionID() -> UInt64 {
             let nextID = _nextRawID
-            _nextRawID += 1
+            _nextRawID &+= 1
             return nextID
         }
 


### PR DESCRIPTION
small changes to:

1. avoid an unnecessary buffer copy during render() when updating event pipes
2. allow our 'session' id generation to wrap so it doesn't need to perform bounds checks (it functionally cannot overflow so they are unneeded)