### PR TITLE
build: rename generated project

### DIFF
--- a/.buildscript/build_swift_docs.sh
+++ b/.buildscript/build_swift_docs.sh
@@ -41,5 +41,5 @@ for scheme in $WORKFLOW_SCHEMES; do
         --output-folder "$SOURCEDOCS_OUTPUT_DIR/$scheme" \
         -- \
         -scheme $scheme \
-        -workspace Samples/Development.xcworkspace
+        -workspace Samples/WorkflowDevelopment.xcworkspace
 done

--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -37,7 +37,7 @@ let snapshotEnvironment: [String: EnvironmentVariable] = {
 }()
 
 let project = Project(
-    name: "Development",
+    name: "WorkflowDevelopment",
     settings: .settings(base: ["ENABLE_MODULE_VERIFIER": "YES"]),
     targets: [
         // MARK: - Samples

--- a/Samples/Tuist/Package.swift
+++ b/Samples/Tuist/Package.swift
@@ -42,7 +42,7 @@ let packageSettings = PackageSettings(
 #endif
 
 let package = Package(
-    name: "Development",
+    name: "WorkflowDevelopment",
     dependencies: [
         .package(path: "../../"),
         .package(url: "https://github.com/uber/ios-snapshot-test-case.git", from: "8.0.0"),

--- a/Samples/Tutorial/README.md
+++ b/Samples/Tutorial/README.md
@@ -35,7 +35,7 @@ Generating workspace Tutorial.xcworkspace
 Generating project Workflow
 Generating project Tutorial
 Generating project swift-case-paths
-Generating project Development
+Generating project WorkflowDevelopment
 Generating project xctest-dynamic-overlay
 Generating project swift-identified-collections
 Generating project ReactiveSwift

--- a/Samples/Workspace.swift
+++ b/Samples/Workspace.swift
@@ -2,7 +2,7 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 let workspace = Workspace(
-    name: "Development",
+    name: "WorkflowDevelopment",
     projects: [".", "Tutorial"],
     schemes: [
         // Generate a scheme for each target in Package.swift for convenience


### PR DESCRIPTION
Gardening PR. I bounce between several Tuist-generated projects and I regret giving them all generic names. This makes it easier to pick out from Xcode's recent projects list.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
