### PR TITLE
feat: deprecate SwiftUIScreen

### DIFF
--- a/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
+++ b/WorkflowSwiftUIExperimental/Sources/SwiftUIScreen.swift
@@ -20,6 +20,7 @@ import SwiftUI
 import Workflow
 import WorkflowUI
 
+@available(*, deprecated, message: "Use the ObservableScreen protocol from WorkflowSwiftUI")
 public protocol SwiftUIScreen: Screen {
     associatedtype Content: View
 


### PR DESCRIPTION
To begin phasing out SwiftUIScreen & WorkflowSwiftUIExperimental in favor of ObservableScreen & WorkflowSwiftUI.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
