### PR TITLE
Adds a convenience for mapping Never outputs to other types

### DIFF
--- a/Workflow/Sources/AnyWorkflow.swift
+++ b/Workflow/Sources/AnyWorkflow.swift
@@ -195,3 +195,14 @@ extension AnyWorkflowConvertible {
         asAnyWorkflow().mapRendering(transform)
     }
 }
+
+// MARK: -
+
+extension AnyWorkflowConvertible where Output == Never {
+    /// A convenience for workflows that don't produce output but want to change the declared output type.
+    public func mapOutput<NewOutput>(to: NewOutput.Type) -> AnyWorkflow<Rendering, NewOutput> {
+        mapOutput(mapNever(_:))
+    }
+}
+
+private func mapNever<T>(_ input: Never) -> T {}

--- a/Workflow/Tests/AnyWorkflowTests.swift
+++ b/Workflow/Tests/AnyWorkflowTests.swift
@@ -82,6 +82,13 @@ public class AnyWorkflowTests: XCTestCase {
 
         XCTAssertNotNil(erased.base as? OnOutputWorkflow)
     }
+
+    func testMapNeverToOtherType() {
+        // test that this `Output = Bool` workflow compiles when mapped from an `Output = Never` workflow
+        let boolOutputWorkflow: AnyWorkflow<String, Bool> = NeverOutputWorkflow().mapOutput(to: Bool.self)
+
+        XCTAssertNotNil(boolOutputWorkflow)
+    }
 }
 
 /// Has no state or output, simply renders a reversed string
@@ -148,5 +155,15 @@ private struct OnOutputChildWorkflow: Workflow {
         DispatchQueue.main.async {
             sink.send(true)
         }
+    }
+}
+
+private struct NeverOutputWorkflow: Workflow {
+    typealias Output = Never
+    typealias Rendering = String
+    typealias State = Void
+
+    func render(state: State, context: RenderContext<NeverOutputWorkflow>) -> String {
+        "Never"
     }
 }


### PR DESCRIPTION
Adds a way to map a workflow's `Never` output type to a different type without generating compiler warnings.  Fixes https://github.com/square/workflow-swift/issues/339

I like this solution because the natural inclination is to simply delete the block containing unreachable code and that just works:

```diff
-            .mapOutput { switch $0 {} }
+            .mapOutput()
```

I'm happy to add a test using this but the true validation is to successfully build without warnings.
