### PR TITLE
[chore]: improve Swift Testing support in test utilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.5.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.2.1"),
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
     ],
     targets: [
         // MARK: Workflow

--- a/WorkflowCombine/Testing/WorkerTesting.swift
+++ b/WorkflowCombine/Testing/WorkerTesting.swift
@@ -15,6 +15,7 @@
  */
 
 #if DEBUG
+import IssueReporting
 import Workflow
 import WorkflowTesting
 import XCTest
@@ -62,9 +63,9 @@ extension RenderTester {
                 guard !workflow.worker.isEquivalent(to: expectedWorker) else {
                     return
                 }
-                XCTFail(
+                reportIssue(
                     "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(expectedWorker). Got: \(workflow.worker)",
-                    file: file,
+                    filePath: file,
                     line: line
                 )
             }

--- a/WorkflowConcurrency/Testing/WorkerTesting.swift
+++ b/WorkflowConcurrency/Testing/WorkerTesting.swift
@@ -15,6 +15,7 @@
  */
 
 #if DEBUG
+import IssueReporting
 import Workflow
 import WorkflowTesting
 import XCTest
@@ -62,9 +63,9 @@ extension RenderTester {
                 guard !workflow.worker.isEquivalent(to: worker) else {
                     return
                 }
-                XCTFail(
+                reportIssue(
                     "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(worker). Got: \(workflow.worker)",
-                    file: file,
+                    filePath: file,
                     line: line
                 )
             }

--- a/WorkflowReactiveSwift/Testing/WorkerTesting.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting.swift
@@ -15,6 +15,7 @@
  */
 
 #if DEBUG
+import IssueReporting
 import Workflow
 import WorkflowTesting
 import XCTest
@@ -62,9 +63,9 @@ extension RenderTester {
                 guard !workflow.worker.isEquivalent(to: expectedWorker) else {
                     return
                 }
-                XCTFail(
+                reportIssue(
                     "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(expectedWorker). Got: \(workflow.worker)",
-                    file: file,
+                    filePath: file,
                     line: line
                 )
             }

--- a/WorkflowRxSwift/Testing/WorkerTesting.swift
+++ b/WorkflowRxSwift/Testing/WorkerTesting.swift
@@ -15,6 +15,7 @@
  */
 
 #if DEBUG
+import IssueReporting
 import Workflow
 import WorkflowTesting
 import XCTest
@@ -62,9 +63,9 @@ extension RenderTester {
                 guard !workflow.worker.isEquivalent(to: expectedWorker) else {
                     return
                 }
-                XCTFail(
+                reportIssue(
                     "Workers of type \(ExpectedWorkerType.self) not equivalent. Expected: \(expectedWorker). Got: \(workflow.worker)",
-                    file: file,
+                    filePath: file,
                     line: line
                 )
             }

--- a/WorkflowTesting/Sources/Internal/AppliedAction.swift
+++ b/WorkflowTesting/Sources/Internal/AppliedAction.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import IssueReporting
 import Workflow
 import XCTest
 
@@ -26,7 +27,7 @@ struct AppliedAction<WorkflowType: Workflow> {
 
     func assert<ActionType: WorkflowAction>(type: ActionType.Type = ActionType.self, file: StaticString, line: UInt, assertions: (ActionType) throws -> Void) rethrows where ActionType.WorkflowType == WorkflowType {
         guard let action = erasedAction as? ActionType else {
-            XCTFail("Expected action of type \(ActionType.self), got \(erasedAction)", file: file, line: line)
+            reportIssue("Expected action of type \(ActionType.self), got \(erasedAction)", filePath: file, line: line)
             return
         }
         try assertions(action)

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -15,6 +15,7 @@
  */
 
 import CustomDump
+import IssueReporting
 import Workflow
 import XCTest
 
@@ -56,7 +57,7 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> {
         if let appliedAction {
-            XCTFail("Expected no action, but got \(appliedAction.erasedAction).", file: file, line: line)
+            reportIssue("Expected no action, but got \(appliedAction.erasedAction).", filePath: file, line: line)
         }
         return self
     }
@@ -70,7 +71,7 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         assertions: (ActionType) throws -> Void
     ) rethrows -> RenderTesterResult<WorkflowType> where ActionType.WorkflowType == WorkflowType {
         guard let appliedAction else {
-            XCTFail("No action was produced", file: file, line: line)
+            reportIssue("No action was produced", filePath: file, line: line)
             return self
         }
         try appliedAction.assert(file: file, line: line, assertions: assertions)
@@ -106,7 +107,7 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         line: UInt = #line
     ) -> RenderTesterResult<WorkflowType> {
         if let output {
-            XCTFail("Expected no output, but got \(output).", file: file, line: line)
+            reportIssue("Expected no output, but got \(output).", filePath: file, line: line)
         }
         return self
     }
@@ -119,7 +120,7 @@ public struct RenderTesterResult<WorkflowType: Workflow> {
         assertions: (WorkflowType.Output) throws -> Void
     ) rethrows -> RenderTesterResult<WorkflowType> {
         guard let output else {
-            XCTFail("No output was produced", file: file, line: line)
+            reportIssue("No output was produced", filePath: file, line: line)
             return self
         }
         try assertions(output)

--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import CustomDump
+import IssueReporting
 import Workflow
 import XCTest
 
@@ -91,7 +93,7 @@ public struct WorkflowActionTester<WorkflowType, Action: WorkflowAction> where A
         line: UInt = #line
     ) -> WorkflowActionTester<WorkflowType, Action> {
         if let output {
-            XCTFail("Expected no output, but got \(output).", file: file, line: line)
+            reportIssue("Expected no output, but got \(output).", filePath: file, line: line)
         }
         return self
     }
@@ -109,7 +111,7 @@ public struct WorkflowActionTester<WorkflowType, Action: WorkflowAction> where A
         _ assertions: (WorkflowType.Output) throws -> Void
     ) rethrows -> WorkflowActionTester<WorkflowType, Action> {
         guard let output else {
-            XCTFail("No output was produced", file: file, line: line)
+            reportIssue("No output was produced", filePath: file, line: line)
             return self
         }
         try assertions(output)
@@ -143,7 +145,7 @@ extension WorkflowActionTester where WorkflowType.State: Equatable {
     @discardableResult
     public func assert(state expectedState: WorkflowType.State, file: StaticString = #file, line: UInt = #line) -> WorkflowActionTester<WorkflowType, Action> {
         verifyState { actualState in
-            XCTAssertEqual(actualState, expectedState, file: file, line: line)
+            expectNoDifference(actualState, expectedState, filePath: file, line: line)
         }
     }
 }
@@ -157,7 +159,7 @@ extension WorkflowActionTester where WorkflowType.Output: Equatable {
     @discardableResult
     public func assert(output expectedOutput: WorkflowType.Output, file: StaticString = #file, line: UInt = #line) -> WorkflowActionTester<WorkflowType, Action> {
         verifyOutput { actualOutput in
-            XCTAssertEqual(actualOutput, expectedOutput, file: file, line: line)
+            expectNoDifference(actualOutput, expectedOutput, filePath: file, line: line)
         }
     }
 }

--- a/WorkflowTesting/Tests/TestingFrameworkCompatibilityTests.swift
+++ b/WorkflowTesting/Tests/TestingFrameworkCompatibilityTests.swift
@@ -1,0 +1,65 @@
+/*
+ * Copyright Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+import Workflow
+import XCTest
+
+@testable import WorkflowTesting
+
+struct SwiftTestingCompatibilityTests {
+    @Test
+    func testInternalFailureRecordsExpectationFailure_swiftTesting() {
+        withKnownIssue {
+            TestAction
+                .tester(withState: false)
+                .send(action: .change(true))
+                .assertNoOutput() // should fail the test
+        }
+    }
+}
+
+final class XCTestCompatibilityTests: XCTestCase {
+    func testInternalFailureRecordsExpectationFailure_xctest() {
+        XCTExpectFailure {
+            _ = TestAction
+                .tester(withState: false)
+                .send(action: .change(true))
+                .assertNoOutput() // should fail the test
+        }
+    }
+}
+
+private enum TestAction: WorkflowAction {
+    typealias WorkflowType = TestWorkflow
+
+    case change(Bool)
+
+    func apply(toState state: inout Bool) -> TestWorkflow.Output? {
+        if case .change(let newState) = self {
+            state = newState
+        }
+        return 42
+    }
+}
+
+private struct TestWorkflow: Workflow {
+    typealias Rendering = Void
+    typealias Output = Int
+
+    func makeInitialState() -> Bool { true }
+    func render(state: Bool, context: RenderContext<TestWorkflow>) {}
+}


### PR DESCRIPTION
migrates test utilities from `XCTest` assertions to analogs provided by the `CustomDump` and `IssueReporting` libraries. this should fix the issue where assertion failures would be invisible to client code written using Swift Testing rather than XCTest.

ideally we should probably add a lint check in the relevant places to enforce use of the appropriate API, but that will be a separate task.

resolves: https://github.com/square/workflow-swift/issues/330