### PR TITLE
test: run WorkflowSwiftUI tests in app host

### DIFF
--- a/Samples/Project.swift
+++ b/Samples/Project.swift
@@ -227,7 +227,10 @@ let project = Project(
         .unitTest(
             for: "WorkflowSwiftUI",
             sources: "../WorkflowSwiftUI/Tests/**",
-            dependencies: [.external(name: "WorkflowSwiftUI")]
+            dependencies: [
+                .external(name: "WorkflowSwiftUI"),
+                .target(name: "TestAppHost"),
+            ]
         ),
 
         // It's not currently possible to create a Tuist target that depends on a macro target. See

--- a/WorkflowSwiftUI/Tests/PreferredContentSizeTests.swift
+++ b/WorkflowSwiftUI/Tests/PreferredContentSizeTests.swift
@@ -7,17 +7,15 @@ import XCTest
 
 final class PreferredContentSizeTests: XCTestCase {
     func test_preferredContentSize() throws {
-        // FIXME: actually solve whatever the problem is here
-        try XCTSkipUnless(UIApplication.shared.delegate != nil)
-
         let maxWidth: CGFloat = 50
         let maxHeight: CGFloat = 50
+
+        // fudged offset to avoid safe area interference
+        let origin = CGPoint(x: 50, y: 50)
 
         func assertPreferredContentSize(in axes: Axis.Set) {
             let screen = TestScreen(model: .constant(state: State(axes: axes)))
             let viewController = screen.buildViewController(in: .empty)
-            viewController.view.frame = CGRect(x: 0, y: 0, width: maxWidth, height: maxHeight)
-            viewController.view.layoutIfNeeded()
 
             func assertContentSize(
                 _ contentSize: CGSize,
@@ -41,16 +39,24 @@ final class PreferredContentSizeTests: XCTestCase {
                 )
             }
 
-            assertContentSize(CGSize(width: 20, height: 20))
-            assertContentSize(CGSize(width: 40, height: 20))
-            assertContentSize(CGSize(width: 20, height: 40))
-            assertContentSize(
-                CGSize(width: 100, height: 100),
-                expected: CGSize(
-                    width: axes.contains(.horizontal) ? maxWidth : 100,
-                    height: axes.contains(.vertical) ? maxHeight : 100
+            show(viewController: viewController) { _ in
+                viewController.view.frame = CGRect(
+                    origin: origin,
+                    size: CGSize(width: maxWidth, height: maxHeight)
                 )
-            )
+                viewController.view.layoutIfNeeded()
+
+                assertContentSize(CGSize(width: 20, height: 20))
+                assertContentSize(CGSize(width: 40, height: 20))
+                assertContentSize(CGSize(width: 20, height: 40))
+                assertContentSize(
+                    CGSize(width: 100, height: 100),
+                    expected: CGSize(
+                        width: axes.contains(.horizontal) ? maxWidth : 100,
+                        height: axes.contains(.vertical) ? maxHeight : 100
+                    )
+                )
+            }
         }
 
         assertPreferredContentSize(in: [])
@@ -116,10 +122,12 @@ private struct TestView: View {
                 }
             }
         }
+        .ignoresSafeArea()
     }
 
     var box: some View {
         Color.red.frame(width: store.width, height: store.height)
+            .ignoresSafeArea()
     }
 }
 

--- a/WorkflowSwiftUI/Tests/XCTestCase+AppHost.swift
+++ b/WorkflowSwiftUI/Tests/XCTestCase+AppHost.swift
@@ -1,0 +1,41 @@
+#if canImport(UIKit)
+
+import UIKit
+import XCTest
+
+extension XCTestCase {
+    /// Call this method to show a view controller in the test host application during a unit test.
+    ///
+    /// After the test runs, the view controller will be removed from the view hierarchy.
+    ///
+    /// A test failure will occur if the host application does not exist, or does not have a root
+    /// view controller.
+    ///
+    func show<ViewController: UIViewController>(
+        viewController: ViewController,
+        test: (ViewController) throws -> Void
+    ) rethrows {
+        guard let rootVC = UIApplication.shared.delegate?.window??.rootViewController else {
+            #if SWIFT_PACKAGE
+            print("WARNING: Test cannot run directly from swift, it requires an app host. Please run from the Tuist project.")
+            #else
+            XCTFail("Cannot present a view controller in a test host that does not have a root window.")
+            #endif
+            return
+        }
+
+        rootVC.addChild(viewController)
+        rootVC.view.addSubview(viewController.view)
+        viewController.didMove(toParent: rootVC)
+
+        try autoreleasepool {
+            try test(viewController)
+        }
+
+        viewController.willMove(toParent: nil)
+        viewController.view.removeFromSuperview()
+        viewController.removeFromParent()
+    }
+}
+
+#endif


### PR DESCRIPTION
Adds an app host to to the WorkflowSwiftUI tests to restore the preferred content size test disabled in #343.

Fixes #346 

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
