### PR TITLE
[BREAKING CHANGE]: update WorkflowAction API to expose access to Workflow instance values

### DIFF
--- a/Samples/AsyncWorker/Sources/AsyncWorkerWorkflow.swift
+++ b/Samples/AsyncWorker/Sources/AsyncWorkerWorkflow.swift
@@ -34,7 +34,7 @@ extension AsyncWorkerWorkflow {
 
         typealias WorkflowType = AsyncWorkerWorkflow
 
-        func apply(toState state: inout AsyncWorkerWorkflow.State) -> AsyncWorkerWorkflow.Output? {
+        func apply(toState state: inout AsyncWorkerWorkflow.State, context: ApplyContext<WorkflowType>) -> AsyncWorkerWorkflow.Output? {
             switch self {
             // Update state and produce an optional output based on which action was received.
             case .fakeNetworkRequestLoaded(let result):

--- a/Samples/ObservableComposition/Sources/CounterWorkflow.swift
+++ b/Samples/ObservableComposition/Sources/CounterWorkflow.swift
@@ -49,7 +49,7 @@ struct CounterWorkflow: Workflow {
         case increment
         case decrement
 
-        func apply(toState state: inout CounterWorkflow.State) -> CounterWorkflow.Output? {
+        func apply(toState state: inout CounterWorkflow.State, context: ApplyContext<WorkflowType>) -> CounterWorkflow.Output? {
             switch self {
             case .increment:
                 state.count += state.info.stepSize

--- a/Samples/ObservableComposition/Sources/MultiCounterWorkflow.swift
+++ b/Samples/ObservableComposition/Sources/MultiCounterWorkflow.swift
@@ -31,7 +31,7 @@ struct MultiCounterWorkflow: Workflow {
     struct ResetAction: WorkflowAction {
         typealias WorkflowType = MultiCounterWorkflow
 
-        func apply(toState state: inout MultiCounterWorkflow.State) -> Never? {
+        func apply(toState state: inout MultiCounterWorkflow.State, context: ApplyContext<WorkflowType>) -> Never? {
             state.resetToken = .init()
             return nil
         }
@@ -43,7 +43,7 @@ struct MultiCounterWorkflow: Workflow {
 
         case showSum(Bool)
 
-        func apply(toState state: inout MultiCounterWorkflow.State) -> Never? {
+        func apply(toState state: inout MultiCounterWorkflow.State, context: ApplyContext<WorkflowType>) -> Never? {
             switch self {
             case .showSum(let showSum):
                 state.showSum = showSum
@@ -58,7 +58,7 @@ struct MultiCounterWorkflow: Workflow {
         case addCounter
         case removeCounter(UUID)
 
-        func apply(toState state: inout MultiCounterWorkflow.State) -> Never? {
+        func apply(toState state: inout MultiCounterWorkflow.State, context: ApplyContext<WorkflowType>) -> Never? {
             switch self {
             case .addCounter:
                 state.addCounter()

--- a/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -76,7 +76,7 @@ extension DemoWorkflow {
         case refreshComplete(String)
         case refreshError(Error)
 
-        func apply(toState state: inout DemoWorkflow.State) -> DemoWorkflow.Output? {
+        func apply(toState state: inout DemoWorkflow.State, context: ApplyContext<WorkflowType>) -> DemoWorkflow.Output? {
             switch self {
             case .titleButtonTapped:
                 switch state.colorState {

--- a/Samples/SampleApp/Sources/RootWorkflow.swift
+++ b/Samples/SampleApp/Sources/RootWorkflow.swift
@@ -45,7 +45,7 @@ extension RootWorkflow {
 
         case login(name: String)
 
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+        func apply(toState state: inout RootWorkflow.State, context: ApplyContext<WorkflowType>) -> RootWorkflow.Output? {
             switch self {
             case .login(name: let name):
                 state = .demo(name: name)

--- a/Samples/SampleApp/Sources/WelcomeWorkflow.swift
+++ b/Samples/SampleApp/Sources/WelcomeWorkflow.swift
@@ -46,7 +46,7 @@ extension WelcomeWorkflow {
         case nameChanged(String)
         case login
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(let updatedName):
                 state.name = updatedName

--- a/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
+++ b/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
@@ -43,7 +43,7 @@ extension DemoWorkflow {
 
         case viewTapped
 
-        func apply(toState state: inout DemoWorkflow.State) -> Never? {
+        func apply(toState state: inout DemoWorkflow.State, context: ApplyContext<WorkflowType>) -> Never? {
             switch self {
             case .viewTapped:
                 state += 1

--- a/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -61,7 +61,7 @@ extension AuthenticationWorkflow {
         case authenticationError(AuthenticationService.AuthenticationError)
         case dismissAuthenticationAlert
 
-        func apply(toState state: inout AuthenticationWorkflow.State) -> AuthenticationWorkflow.Output? {
+        func apply(toState state: inout AuthenticationWorkflow.State, context: ApplyContext<WorkflowType>) -> AuthenticationWorkflow.Output? {
             switch self {
             case .back:
                 switch state {

--- a/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -49,7 +49,7 @@ extension LoginWorkflow {
         case passwordUpdated(String)
         case login
 
-        func apply(toState state: inout LoginWorkflow.State) -> LoginWorkflow.Output? {
+        func apply(toState state: inout LoginWorkflow.State, context: ApplyContext<WorkflowType>) -> LoginWorkflow.Output? {
             switch self {
             case .emailUpdated(let email):
                 state.email = email

--- a/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
@@ -56,7 +56,7 @@ extension ConfirmQuitWorkflow {
 
         typealias WorkflowType = ConfirmQuitWorkflow
 
-        func apply(toState state: inout ConfirmQuitWorkflow.State) -> ConfirmQuitWorkflow.Output? {
+        func apply(toState state: inout ConfirmQuitWorkflow.State, context: ApplyContext<WorkflowType>) -> ConfirmQuitWorkflow.Output? {
             switch self {
             case .cancel:
                 return .cancel

--- a/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -58,7 +58,7 @@ extension RunGameWorkflow {
         case back
         case confirmQuit
 
-        func apply(toState state: inout RunGameWorkflow.State) -> RunGameWorkflow.Output? {
+        func apply(toState state: inout RunGameWorkflow.State, context: ApplyContext<WorkflowType>) -> RunGameWorkflow.Output? {
             switch self {
             case .updatePlayerX(let name):
                 state.playerX = name

--- a/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
@@ -47,7 +47,7 @@ extension TakeTurnsWorkflow {
 
         case selected(row: Int, col: Int)
 
-        func apply(toState state: inout TakeTurnsWorkflow.State) -> TakeTurnsWorkflow.Output? {
+        func apply(toState state: inout TakeTurnsWorkflow.State, context: ApplyContext<WorkflowType>) -> TakeTurnsWorkflow.Output? {
             switch state.gameState {
             case .ongoing(turn: let turn):
                 switch self {

--- a/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -48,7 +48,7 @@ extension MainWorkflow {
         case authenticated(sessionToken: String)
         case logout
 
-        func apply(toState state: inout MainWorkflow.State) -> MainWorkflow.Output? {
+        func apply(toState state: inout MainWorkflow.State, context: ApplyContext<WorkflowType>) -> MainWorkflow.Output? {
             switch self {
             case .authenticated(sessionToken: let sessionToken):
                 state = .runningGame(sessionToken: sessionToken)

--- a/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -47,7 +47,7 @@ extension WelcomeWorkflow {
 
         case nameChanged(name: String)
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(name: let name):
                 // Update our state with the updated name.

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
@@ -54,7 +54,7 @@ extension RootWorkflow {
         case logIn(name: String)
         case logOut
 
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+        func apply(toState state: inout RootWorkflow.State, context: ApplyContext<WorkflowType>) -> RootWorkflow.Output? {
             switch self {
             case .logIn(name: let name):
                 // When the `login` action is received, change the state to `todo`.

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -45,7 +45,7 @@ extension TodoListWorkflow {
     enum Action: WorkflowAction {
         typealias WorkflowType = TodoListWorkflow
 
-        func apply(toState state: inout TodoListWorkflow.State) -> TodoListWorkflow.Output? {
+        func apply(toState state: inout TodoListWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoListWorkflow.Output? {
             switch self {
                 // Update state and produce an optional output based on which action was received.
             }

--- a/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -50,7 +50,7 @@ extension WelcomeWorkflow {
         case nameChanged(name: String)
         case didLogIn
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(name: let name):
                 // Update our state with the updated name.

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
@@ -54,7 +54,7 @@ extension RootWorkflow {
         case logIn(name: String)
         case logOut
 
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+        func apply(toState state: inout RootWorkflow.State, context: ApplyContext<WorkflowType>) -> RootWorkflow.Output? {
             switch self {
             case .logIn(name: let name):
                 state = .todo(name: name)

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -66,7 +66,7 @@ extension TodoEditWorkflow {
         case discardChanges
         case saveChanges
 
-        func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
+        func apply(toState state: inout TodoEditWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoEditWorkflow.Output? {
             switch self {
             case .titleChanged(let title):
                 state.todo.title = title

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -73,7 +73,7 @@ extension TodoListWorkflow {
         case discardChanges
         case saveChanges(todo: TodoModel, index: Int)
 
-        func apply(toState state: inout TodoListWorkflow.State) -> TodoListWorkflow.Output? {
+        func apply(toState state: inout TodoListWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoListWorkflow.Output? {
             switch self {
             case .onBack:
                 // When a `.onBack` action is received, emit a `.back` output

--- a/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -50,7 +50,7 @@ extension WelcomeWorkflow {
         case nameChanged(name: String)
         case didLogIn
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(name: let name):
                 // Update our state with the updated name.

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
@@ -54,7 +54,7 @@ extension RootWorkflow {
         case logIn(name: String)
         case logOut
 
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+        func apply(toState state: inout RootWorkflow.State, context: ApplyContext<WorkflowType>) -> RootWorkflow.Output? {
             switch self {
             case .logIn(name: let name):
                 // When the `login` action is received, change the state to `todo`.

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -66,7 +66,7 @@ extension TodoEditWorkflow {
         case discardChanges
         case saveChanges
 
-        func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
+        func apply(toState state: inout TodoEditWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoEditWorkflow.Output? {
             switch self {
             case .titleChanged(let title):
                 state.todo.title = title

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -58,7 +58,7 @@ extension TodoListWorkflow {
         case selectTodo(index: Int)
         case new
 
-        func apply(toState state: inout TodoListWorkflow.State) -> TodoListWorkflow.Output? {
+        func apply(toState state: inout TodoListWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoListWorkflow.Output? {
             switch self {
             case .onBack:
                 // When a `.onBack` action is received, emit a `.back` output

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
@@ -71,7 +71,7 @@ extension TodoWorkflow {
         case editTodo(index: Int)
         case newTodo
 
-        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+        func apply(toState state: inout TodoWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoWorkflow.Output? {
             switch self {
             case .back:
                 return .back
@@ -97,7 +97,7 @@ extension TodoWorkflow {
         case discardChanges
         case saveChanges(todo: TodoModel, index: Int)
 
-        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+        func apply(toState state: inout TodoWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoWorkflow.Output? {
             guard case .edit = state.step else {
                 fatalError("Received edit action when state was not `.edit`.")
             }

--- a/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -50,7 +50,7 @@ extension WelcomeWorkflow {
         case nameChanged(name: String)
         case didLogIn
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(name: let name):
                 // Update our state with the updated name.

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -54,7 +54,7 @@ extension RootWorkflow {
         case logIn(name: String)
         case logOut
 
-        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+        func apply(toState state: inout RootWorkflow.State, context: ApplyContext<WorkflowType>) -> RootWorkflow.Output? {
             switch self {
             case .logIn(name: let name):
                 state = .todo(name: name)

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -66,7 +66,7 @@ extension TodoEditWorkflow {
         case discardChanges
         case saveChanges
 
-        func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
+        func apply(toState state: inout TodoEditWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoEditWorkflow.Output? {
             switch self {
             case .titleChanged(let title):
                 state.todo.title = title

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -58,7 +58,7 @@ extension TodoListWorkflow {
         case selectTodo(index: Int)
         case new
 
-        func apply(toState state: inout TodoListWorkflow.State) -> TodoListWorkflow.Output? {
+        func apply(toState state: inout TodoListWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoListWorkflow.Output? {
             switch self {
             case .onBack:
                 // When a `.onBack` action is received, emit a `.back` output

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
@@ -71,7 +71,7 @@ extension TodoWorkflow {
         case editTodo(index: Int)
         case newTodo
 
-        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+        func apply(toState state: inout TodoWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoWorkflow.Output? {
             switch self {
             case .back:
                 return .back
@@ -97,7 +97,7 @@ extension TodoWorkflow {
         case discardChanges
         case saveChanges(todo: TodoModel, index: Int)
 
-        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+        func apply(toState state: inout TodoWorkflow.State, context: ApplyContext<WorkflowType>) -> TodoWorkflow.Output? {
             guard case .edit = state.step else {
                 fatalError("Received edit action when state was not `.edit`.")
             }

--- a/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -50,7 +50,7 @@ extension WelcomeWorkflow {
         case nameChanged(name: String)
         case didLogIn
 
-        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+        func apply(toState state: inout WelcomeWorkflow.State, context: ApplyContext<WorkflowType>) -> WelcomeWorkflow.Output? {
             switch self {
             case .nameChanged(name: let name):
                 // Update our state with the updated name.

--- a/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorkflow.swift
+++ b/Samples/WorkflowCombineSampleApp/WorkflowCombineSampleApp/DemoWorkflow.swift
@@ -37,7 +37,7 @@ extension DemoWorkflow {
 
         let publishedDate: Date
 
-        func apply(toState state: inout DemoWorkflow.State) -> DemoWorkflow.Output? {
+        func apply(toState state: inout DemoWorkflow.State, context: ApplyContext<WorkflowType>) -> DemoWorkflow.Output? {
             state.date = publishedDate
             return nil
         }

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/Default/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/Default/___FILEBASENAME___Workflow.swift
@@ -25,7 +25,7 @@ extension ___VARIABLE_productName___Workflow {
     enum Action: WorkflowAction {
         typealias WorkflowType = ___VARIABLE_productName___Workflow
 
-        func apply(toState state: inout ___VARIABLE_productName___Workflow.State) -> ___VARIABLE_productName___Workflow.Output? {
+        func applytoState state: inout ___VARIABLE_productName___Workflow.State, context: ApplyContext<WorkflowType> -> ___VARIABLE_productName___Workflow.Output? {
             switch self {
                 // Update state and produce an optional output based on which action was received.
             }

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerReactiveSwift/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerReactiveSwift/___FILEBASENAME___Workflow.swift
@@ -25,7 +25,7 @@ extension ___VARIABLE_productName___Workflow {
     enum Action: WorkflowAction {
         typealias WorkflowType = ___VARIABLE_productName___Workflow
 
-        func apply(toState state: inout ___VARIABLE_productName___Workflow.State) -> ___VARIABLE_productName___Workflow.Output? {
+        func apply(toState state: inout ___VARIABLE_productName___Workflow.State, context: ApplyContext<WorkflowType>) -> ___VARIABLE_productName___Workflow.Output? {
             switch self {
                 // Update state and produce an optional output based on which action was received.
             }

--- a/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerRxSwift/___FILEBASENAME___Workflow.swift
+++ b/Tooling/Templates/Workflow (Verbose).xctemplate/generateWorkerRxSwift/___FILEBASENAME___Workflow.swift
@@ -25,7 +25,7 @@ extension ___VARIABLE_productName___Workflow {
     enum Action: WorkflowAction {
         typealias WorkflowType = ___VARIABLE_productName___Workflow
 
-        func apply(toState state: inout ___VARIABLE_productName___Workflow.State) -> ___VARIABLE_productName___Workflow.Output? {
+        func apply(toState state: inout ___VARIABLE_productName___Workflow.State, context: ApplyContext<WorkflowType>) -> ___VARIABLE_productName___Workflow.Output? {
             switch self {
                 // Update state and produce an optional output based on which action was received.
             }

--- a/Workflow/Sources/AnyWorkflowConvertible.swift
+++ b/Workflow/Sources/AnyWorkflowConvertible.swift
@@ -115,10 +115,12 @@ extension AnyWorkflowConvertible {
     /// Process an `Output`
     ///
     /// - Parameter apply: On `Output`, mutate `State` as necessary and return new `Output` (or `nil`).
-    public func onOutput<Parent>(_ apply: @escaping ((inout Parent.State, Output) -> Parent.Output?)) -> AnyWorkflow<Rendering, AnyWorkflowAction<Parent>> {
+    public func onOutput<Parent>(
+        _ apply: @escaping (inout Parent.State, Output) -> Parent.Output?
+    ) -> AnyWorkflow<Rendering, AnyWorkflowAction<Parent>> {
         asAnyWorkflow()
             .mapOutput { output in
-                AnyWorkflowAction { state -> Parent.Output? in
+                AnyWorkflowAction { state, _ -> Parent.Output? in
                     apply(&state, output)
                 }
             }

--- a/Workflow/Sources/ApplyContext.swift
+++ b/Workflow/Sources/ApplyContext.swift
@@ -24,8 +24,39 @@ protocol ApplyContextType<WorkflowType> {
 }
 
 /// Runtime context passed as a parameter to `WorkflowAction`'s `apply()` method
-/// that provides an integration point with the runtime that can be used to read property values
-/// off of the current `Workflow` instance.
+/// that provides an integration point with the runtime that can be used to read values from
+/// the current `Workflow` instance.
+///
+/// Read-only access to `Workflow` values is exposed via the `subscript[workflowValue:]` API,
+/// which accepts a read-only `KeyPath` to a `Workflow`'s value.
+///
+/// Usage example:
+///
+/// ```swift
+///     struct MyWorkflow: Workflow {
+///         let shouldSuppressOutput: Bool
+///
+///         // ... implementation ...
+///     }
+///
+///     enum MyAction: WorkflowAction {
+///         typealias WorkflowType = MyWorkflow
+///
+///         case one
+///         case two
+///
+///         func apply(toState state: inout WorkflowType.State, context: ApplyContext<WorkflowType>) -> WorkflowType.Output? {
+///             // Make conditional choices based on the `Workflow`'s instance values
+///             let shouldSuppressOutput = context[workflowValue: \.shouldSuppressOutput]
+///             if shouldSuppressOutput { return nil }
+///
+///             // ... implementation ...
+///         }
+///     }
+/// ```
+///
+/// > Warning: The instance of this type passed to the `apply()` method should not escape from that method.
+/// Attempting to access the instance after the `apply()` method has returned is a client error and will crash.
 public struct ApplyContext<WorkflowType: Workflow> {
     let wrappedContext: any ApplyContextType<WorkflowType>
 

--- a/Workflow/Sources/ApplyContext.swift
+++ b/Workflow/Sources/ApplyContext.swift
@@ -1,0 +1,87 @@
+/*
+ * Copyright Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Internal utility protocol so that `WorkflowTesting` can provide an alternate implementation
+protocol ApplyContextType<WorkflowType> {
+    associatedtype WorkflowType: Workflow
+
+    subscript<Value>(
+        workflowValue keyPath: KeyPath<WorkflowType, Value>
+    ) -> Value { get }
+}
+
+/// Runtime context passed as a parameter to `WorkflowAction`'s `apply()` method
+/// that provides an integration point with the runtime that can be used to read property values
+/// off of the current `Workflow` instance.
+public struct ApplyContext<WorkflowType: Workflow> {
+    let wrappedContext: any ApplyContextType<WorkflowType>
+
+    init<Impl: ApplyContextType>(_ context: Impl)
+        where Impl.WorkflowType == WorkflowType
+    {
+        self.wrappedContext = context
+    }
+
+    public subscript<Value>(
+        workflowValue keyPath: KeyPath<WorkflowType, Value>
+    ) -> Value {
+        wrappedContext[workflowValue: keyPath]
+    }
+}
+
+extension ApplyContext {
+    static func make<Wrapped: ApplyContextType>(
+        implementation: Wrapped
+    ) -> ApplyContext<Wrapped.WorkflowType>
+        where Wrapped.WorkflowType == WorkflowType
+    {
+        ApplyContext(implementation)
+    }
+}
+
+// FIXME: this is currently a class so that we can zero out the storage
+// when it's invalidated. it'd be nice to eventually make the `ApplyContext`
+// type itself `~Escapable` since that's really the behavior that we want
+// to enforce.
+
+/// The `ApplyContext` used by the Workflow runtime when applying actions.
+final class ConcreteApplyContext<WorkflowType: Workflow>: ApplyContextType {
+    private(set) var storage: WorkflowType?
+
+    private var validatedStorage: WorkflowType {
+        guard let storage else {
+            fatalError("Attempt to use an ApplyContext for Workflow of type '\(WorkflowType.self)' after it was invalidated. The context is only valid during a call to an apply(...) method.")
+        }
+
+        return storage
+    }
+
+    init(storage: WorkflowType) {
+        self.storage = storage
+    }
+
+    subscript<Value>(
+        workflowValue keyPath: KeyPath<WorkflowType, Value>
+    ) -> Value {
+        validatedStorage[keyPath: keyPath]
+    }
+
+    // MARK: -
+
+    func invalidate() {
+        storage = nil
+    }
+}

--- a/Workflow/Sources/RenderContext.swift
+++ b/Workflow/Sources/RenderContext.swift
@@ -184,7 +184,7 @@ extension RenderContext {
     ) -> Sink<Event> {
         makeSink(of: AnyWorkflowAction.self)
             .contraMap { event in
-                AnyWorkflowAction<WorkflowType> { state in
+                AnyWorkflowAction<WorkflowType> { state, _ in
                     onEvent(event, &state)
                 }
             }

--- a/Workflow/Sources/StateMutationSink.swift
+++ b/Workflow/Sources/StateMutationSink.swift
@@ -44,7 +44,7 @@ public struct StateMutationSink<WorkflowType: Workflow> {
     ///   - update: The `State` mutation to perform.
     public func send(_ update: @escaping (inout WorkflowType.State) -> Void) {
         sink.send(
-            AnyWorkflowAction<WorkflowType> { state in
+            AnyWorkflowAction<WorkflowType> { state, _ in
                 update(&state)
                 return nil
             }

--- a/Workflow/Sources/WorkflowAction.swift
+++ b/Workflow/Sources/WorkflowAction.swift
@@ -24,9 +24,12 @@ public protocol WorkflowAction<WorkflowType> {
     ///
     /// - Parameter state: The current state of the workflow. The state is passed as an `inout` param, allowing actions
     ///                    to modify state during application.
+    /// - Parameter context: A context object provided by the runtime that enables reading values of the underlying `Workflow` instance.
     ///
     /// - Returns: An optional output event for the workflow. If an output event is returned, it will be passed up
     ///            the workflow hierarchy to this workflow's parent.
+    /// > Warning: The `context` parameter should not escape from implementations of this requirement.
+    /// Attempting to access the instance after `apply()` has returned is a client error and will crash.
     func apply(
         toState state: inout WorkflowType.State,
         context: ApplyContext<WorkflowType>

--- a/Workflow/Sources/WorkflowAction.swift
+++ b/Workflow/Sources/WorkflowAction.swift
@@ -27,14 +27,22 @@ public protocol WorkflowAction<WorkflowType> {
     ///
     /// - Returns: An optional output event for the workflow. If an output event is returned, it will be passed up
     ///            the workflow hierarchy to this workflow's parent.
-    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output?
+    func apply(
+        toState state: inout WorkflowType.State,
+        context: ApplyContext<WorkflowType>
+    ) -> WorkflowType.Output?
+}
+
+extension WorkflowAction {
+    /// Closure type signature matching `WorkflowAction`'s `apply()` method.
+    public typealias ActionApplyClosure = (inout WorkflowType.State, ApplyContext<WorkflowType>) -> WorkflowType.Output?
 }
 
 /// A type-erased workflow action.
 ///
 /// The `AnyWorkflowAction` type forwards `apply` to an underlying workflow action, hiding its specific underlying type.
 public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
-    private let _apply: (inout WorkflowType.State) -> WorkflowType.Output?
+    private let _apply: ActionApplyClosure
 
     /// The underlying type-erased `WorkflowAction`
     public let base: Any
@@ -50,7 +58,9 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
             self = anyEvent
             return
         }
-        self._apply = { base.apply(toState: &$0) }
+        self._apply = {
+            base.apply(toState: &$0, context: $1)
+        }
         self.base = base
         self.isClosureBased = false
     }
@@ -59,7 +69,7 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
     ///
     /// - Parameter apply: the apply function for the resulting action.
     public init(
-        _ apply: @escaping (inout WorkflowType.State) -> WorkflowType.Output?,
+        _ apply: @escaping ActionApplyClosure,
         fileID: StaticString = #fileID,
         line: UInt = #line
     ) {
@@ -71,16 +81,35 @@ public struct AnyWorkflowAction<WorkflowType: Workflow>: WorkflowAction {
         self.init(closureAction: closureAction)
     }
 
+    /// Creates a type-erased workflow action with the given `apply` implementation.
+    ///
+    /// - Parameter apply: the apply function for the resulting action.
+    @_disfavoredOverload
+    public init(
+        _ apply: @escaping (inout WorkflowType.State) -> WorkflowType.Output?,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        self.init(
+            { state, _ in apply(&state) },
+            fileID: fileID,
+            line: line
+        )
+    }
+
     /// Private initializer forwarded to via `init(_ apply:...)`
     /// - Parameter closureAction: The `ClosureAction` wrapping the underlying `apply` closure.
     fileprivate init(closureAction: ClosureAction<WorkflowType>) {
-        self._apply = closureAction.apply(toState:)
+        self._apply = closureAction.apply(toState:context:)
         self.base = closureAction
         self.isClosureBased = true
     }
 
-    public func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
-        _apply(&state)
+    public func apply(
+        toState state: inout WorkflowType.State,
+        context: ApplyContext<WorkflowType>
+    ) -> WorkflowType.Output? {
+        _apply(&state, context)
     }
 }
 
@@ -89,7 +118,7 @@ extension AnyWorkflowAction {
     ///
     /// - Parameter output: The output event to send when this action is applied.
     public init(sendingOutput output: WorkflowType.Output) {
-        self = AnyWorkflowAction { state in
+        self = AnyWorkflowAction { _, _ in
             output
         }
     }
@@ -97,7 +126,7 @@ extension AnyWorkflowAction {
     /// Creates a type-erased workflow action that does nothing (it leaves state unchanged and does not emit an output
     /// event).
     public static var noAction: AnyWorkflowAction<WorkflowType> {
-        AnyWorkflowAction { state in
+        AnyWorkflowAction { _, _ in
             nil
         }
     }
@@ -109,12 +138,12 @@ extension AnyWorkflowAction {
 /// Mainly used to provide more useful debugging/telemetry information for `AnyWorkflow` instances
 /// defined via a closure.
 struct ClosureAction<WorkflowType: Workflow>: WorkflowAction {
-    private let _apply: (inout WorkflowType.State) -> WorkflowType.Output?
+    private let _apply: ActionApplyClosure
     let fileID: StaticString
     let line: UInt
 
     init(
-        _apply: @escaping (inout WorkflowType.State) -> WorkflowType.Output?,
+        _apply: @escaping ActionApplyClosure,
         fileID: StaticString,
         line: UInt
     ) {
@@ -123,8 +152,11 @@ struct ClosureAction<WorkflowType: Workflow>: WorkflowAction {
         self.line = line
     }
 
-    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
-        _apply(&state)
+    func apply(
+        toState state: inout WorkflowType.State,
+        context: ApplyContext<WorkflowType>
+    ) -> WorkflowType.Output? {
+        _apply(&state, context)
     }
 }
 

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -218,7 +218,14 @@ extension WorkflowNode {
         defer { observerCompletion?(state, output) }
 
         /// Apply the action to the current state
-        output = action.apply(toState: &state)
+        do {
+            // TODO: can we avoid instantiating a class here somehow?
+            let context = ConcreteApplyContext(storage: workflow)
+            defer { context.invalidate() }
+
+            let wrappedContext = ApplyContext.make(implementation: context)
+            output = action.apply(toState: &state, context: wrappedContext)
+        }
 
         return output
     }

--- a/Workflow/Sources/WorkflowNode.swift
+++ b/Workflow/Sources/WorkflowNode.swift
@@ -219,7 +219,7 @@ extension WorkflowNode {
 
         /// Apply the action to the current state
         do {
-            // TODO: can we avoid instantiating a class here somehow?
+            // FIXME: can we avoid instantiating a class here somehow?
             let context = ConcreteApplyContext(storage: workflow)
             defer { context.invalidate() }
 

--- a/Workflow/Tests/AnyWorkflowActionTests.swift
+++ b/Workflow/Tests/AnyWorkflowActionTests.swift
@@ -83,7 +83,8 @@ final class AnyWorkflowActionTests: XCTestCase {
         XCTAssertEqual(log, [])
 
         var state: Void = ()
-        _ = erased.apply(toState: &state)
+        let ctx = ApplyContext(ConcreteApplyContext(storage: ExampleWorkflow()))
+        _ = erased.apply(toState: &state, context: ctx)
 
         XCTAssertEqual(log, ["action invoked"])
     }

--- a/Workflow/Tests/AnyWorkflowActionTests.swift
+++ b/Workflow/Tests/AnyWorkflowActionTests.swift
@@ -108,7 +108,7 @@ private struct ExampleWorkflow: Workflow {
 private struct ExampleAction: WorkflowAction, Equatable {
     typealias WorkflowType = ExampleWorkflow
 
-    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
+    func apply(toState state: inout WorkflowType.State, context: ApplyContext<WorkflowType>) -> WorkflowType.Output? {
         nil
     }
 }
@@ -118,7 +118,7 @@ private struct ObservableExampleAction: WorkflowAction {
 
     var block: () -> Void = {}
 
-    func apply(toState state: inout WorkflowType.State) -> WorkflowType.Output? {
+    func apply(toState state: inout WorkflowType.State, context: ApplyContext<WorkflowType>) -> WorkflowType.Output? {
         block()
         return nil
     }

--- a/Workflow/Tests/ApplyContextTests.swift
+++ b/Workflow/Tests/ApplyContextTests.swift
@@ -1,0 +1,79 @@
+/*
+ * Copyright Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+
+@testable import Workflow
+
+@MainActor
+struct ApplyContextTests {
+    @Test
+    func concreteApplyContextInvalidatedAfterUse() async throws {
+        var escapedContext: ApplyContext<EscapingContextWorkflow>?
+        let onApply = { (context: ApplyContext<EscapingContextWorkflow>) in
+            #expect(context[workflowValue: \.property] == 42)
+            #expect(context.concreteStorage != nil)
+            escapedContext = context
+        }
+
+        let workflow = EscapingContextWorkflow(
+            property: 42,
+            onApply: onApply
+        )
+        let node = WorkflowNode(workflow: workflow)
+
+        let emitEvent = node.render()
+        node.enableEvents()
+
+        emitEvent()
+
+        #expect(escapedContext != nil)
+        #expect(escapedContext?.concreteStorage == nil)
+    }
+}
+
+// MARK: -
+
+private struct EscapingContextWorkflow: Workflow {
+    typealias Rendering = () -> Void
+    typealias State = Void
+
+    var property: Int
+    var onApply: ((ApplyContext<Self>) -> Void)?
+
+    func render(
+        state: State,
+        context: RenderContext<EscapingContextWorkflow>
+    ) -> Rendering {
+        let sink = context.makeSink(of: EscapingAction.self)
+        let action = EscapingAction(onApply: onApply)
+        return { sink.send(action) }
+    }
+
+    struct EscapingAction: WorkflowAction {
+        typealias WorkflowType = EscapingContextWorkflow
+
+        var onApply: ((ApplyContext<WorkflowType>) -> Void)?
+
+        func apply(
+            toState state: inout WorkflowType.State,
+            context: ApplyContext<WorkflowType>
+        ) -> WorkflowType.Output? {
+            onApply?(context)
+            return nil
+        }
+    }
+}

--- a/Workflow/Tests/ConcurrencyTests.swift
+++ b/Workflow/Tests/ConcurrencyTests.swift
@@ -186,7 +186,7 @@ final class ConcurrencyTests: XCTestCase {
 
                 case updated
 
-                func apply(toState state: inout State) -> Never? {
+                func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Never? {
                     switch self {
                     case .updated:
                         state.count += 1
@@ -279,7 +279,7 @@ final class ConcurrencyTests: XCTestCase {
 
                 case update
 
-                func apply(toState state: inout State) -> Output? {
+                func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output? {
                     switch self {
                     case .update:
                         state.count += 10
@@ -378,7 +378,7 @@ final class ConcurrencyTests: XCTestCase {
                 typealias WorkflowType = AnyActionWorkflow
                 case update
 
-                func apply(toState state: inout State) -> Output? {
+                func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output? {
                     switch self {
                     case .update:
                         state.count += 1
@@ -391,7 +391,7 @@ final class ConcurrencyTests: XCTestCase {
                 typealias WorkflowType = AnyActionWorkflow
                 case update
 
-                func apply(toState state: inout State) -> Output? {
+                func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output? {
                     switch self {
                     case .update:
                         state.count += 10
@@ -494,7 +494,7 @@ final class ConcurrencyTests: XCTestCase {
             case update
             case secondUpdate
 
-            func apply(toState state: inout State) -> Output? {
+            func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output? {
                 switch self {
                 case .update:
                     state.count += 1

--- a/Workflow/Tests/SubtreeManagerTests.swift
+++ b/Workflow/Tests/SubtreeManagerTests.swift
@@ -296,7 +296,7 @@ private struct TestWorkflow: Workflow {
         case changeState
         case sendOutput
 
-        func apply(toState state: inout TestWorkflow.State) -> TestWorkflow.Output? {
+        func apply(toState state: inout TestWorkflow.State, context: ApplyContext<WorkflowType>) -> TestWorkflow.Output? {
             switch self {
             case .changeState:
                 switch state {

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -83,3 +83,15 @@ struct TestDebugger: WorkflowDebugger {
         updateInfo: WorkflowUpdateDebugInfo
     ) {}
 }
+
+// MARK: - ApplyContext
+
+extension ApplyContext {
+    var wrappedConcreteContext: ConcreteApplyContext<WorkflowType>? {
+        wrappedContext as? ConcreteApplyContext<WorkflowType>
+    }
+
+    var concreteStorage: WorkflowType? {
+        wrappedConcreteContext?.storage
+    }
+}

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -47,7 +47,7 @@ struct StateTransitioningWorkflow: Workflow {
 
         typealias WorkflowType = StateTransitioningWorkflow
 
-        func apply(toState state: inout Bool) -> Never? {
+        func apply(toState state: inout Bool, context: ApplyContext<WorkflowType>) -> Never? {
             switch self {
             case .toggle:
                 state.toggle()

--- a/Workflow/Tests/WorkflowHostTests.swift
+++ b/Workflow/Tests/WorkflowHostTests.swift
@@ -125,7 +125,7 @@ extension WorkflowHost_EventEmissionTests {
 
             case childChanged
 
-            func apply(toState state: inout Parent.State) -> Never? {
+            func apply(toState state: inout Parent.State, context: ApplyContext<WorkflowType>) -> Never? {
                 state.eventCount += 1
                 state.renderFirst.toggle()
                 return nil
@@ -150,7 +150,7 @@ extension WorkflowHost_EventEmissionTests {
 
             case eventOccurred
 
-            func apply(toState state: inout Void) -> Child.Output? {
+            func apply(toState state: inout Void, context: ApplyContext<WorkflowType>) -> Child.Output? {
                 .eventOccurred
             }
         }

--- a/Workflow/Tests/WorkflowNodeTests.swift
+++ b/Workflow/Tests/WorkflowNodeTests.swift
@@ -320,7 +320,7 @@ extension CompositeWorkflow {
 
         typealias WorkflowType = CompositeWorkflow<A, B>
 
-        func apply(toState state: inout CompositeWorkflow<A, B>.State) -> CompositeWorkflow<A, B>.Output? {
+        func apply(toState state: inout CompositeWorkflow<A, B>.State, context: ApplyContext<WorkflowType>) -> CompositeWorkflow<A, B>.Output? {
             switch self {
             case .a(let childOutput):
                 .childADidSomething(childOutput)
@@ -402,7 +402,7 @@ extension EventEmittingWorkflow {
 
         typealias WorkflowType = EventEmittingWorkflow
 
-        func apply(toState state: inout EventEmittingWorkflow.State) -> EventEmittingWorkflow.Output? {
+        func apply(toState state: inout EventEmittingWorkflow.State, context: ApplyContext<WorkflowType>) -> EventEmittingWorkflow.Output? {
             switch self {
             case .tapped:
                 .helloWorld

--- a/Workflow/Tests/WorkflowObserverTests.swift
+++ b/Workflow/Tests/WorkflowObserverTests.swift
@@ -685,7 +685,7 @@ private struct InjectableWorkflow: Workflow {
 
         case forwardedOutput
 
-        func apply(toState state: inout ()) -> InjectableWorkflow.Output? {
+        func apply(toState state: inout (), context: ApplyContext<WorkflowType>) -> InjectableWorkflow.Output? {
             .forwardedOutput
         }
     }
@@ -729,7 +729,7 @@ private struct VoidStateWorkflow: Workflow {
 
         case actionValue
 
-        func apply(toState state: inout VoidStateWorkflow.State) -> VoidStateWorkflow.Output? {
+        func apply(toState state: inout VoidStateWorkflow.State, context: ApplyContext<WorkflowType>) -> VoidStateWorkflow.Output? {
             nil
         }
     }

--- a/WorkflowReactiveSwift/Sources/SignalProducerWorkflow.swift
+++ b/WorkflowReactiveSwift/Sources/SignalProducerWorkflow.swift
@@ -51,7 +51,7 @@ struct SignalProducerWorkflow<Value>: Workflow {
         typealias WorkflowType = SignalProducerWorkflow
         let output: Value
 
-        func apply(toState state: inout Void) -> Value? {
+        func apply(toState state: inout Void, context: ApplyContext<WorkflowType>) -> Value? {
             output
         }
     }

--- a/WorkflowRxSwift/Tests/Rx+ReactiveWorkers.swift
+++ b/WorkflowRxSwift/Tests/Rx+ReactiveWorkers.swift
@@ -45,7 +45,7 @@ class Rx_ReactiveWorkersTests: XCTestCase {
                 typealias WorkflowType = TestWorkflow
                 case complete
 
-                func apply(toState state: inout State) -> Output? {
+                func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output? {
                     switch self {
                     case .complete:
                         .finished
@@ -103,7 +103,7 @@ struct CombinedWorkflow: Workflow {
         case rxSwift
         case reactiveSwift
 
-        func apply(toState state: inout CombinedWorkflow.State) -> CombinedWorkflow.State? {
+        func apply(toState state: inout CombinedWorkflow.State, context: ApplyContext<WorkflowType>) -> CombinedWorkflow.State? {
             switch self {
             case .rxSwift:
                 state.rxOutputReceived = true

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -27,6 +27,7 @@ extension RenderTester {
         var expectedWorkflows: [AnyExpectedWorkflow]
         var expectedSideEffects: [AnyHashable: ExpectedSideEffect]
         var appliedAction: AppliedAction<WorkflowType>?
+        var applyContext: TestApplyContext<WorkflowType>
         var producedOutput: WorkflowType.Output?
         let file: StaticString
         let line: UInt
@@ -37,6 +38,7 @@ extension RenderTester {
             state: WorkflowType.State,
             expectedWorkflows: [AnyExpectedWorkflow],
             expectedSideEffects: [AnyHashable: ExpectedSideEffect],
+            applyContext: TestApplyContext<WorkflowType>,
             file: StaticString,
             line: UInt
         ) {
@@ -45,6 +47,7 @@ extension RenderTester {
             self.expectedSideEffects = expectedSideEffects
             self.file = file
             self.line = line
+            self.applyContext = applyContext
         }
 
         func render<Child: Workflow, Action: WorkflowAction>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Action.WorkflowType == WorkflowType {
@@ -121,7 +124,8 @@ extension RenderTester {
                 reportIssue("Received multiple actions in a single render test", filePath: file, line: line)
             }
             appliedAction = AppliedAction(action)
-            let output = action.apply(toState: &state)
+            let wrappedContext = ApplyContext.make(implementation: applyContext)
+            let output = action.apply(toState: &state, context: wrappedContext)
 
             if let output {
                 if producedOutput != nil {

--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -16,13 +16,22 @@
 
 import CustomDump
 import IssueReporting
-import Workflow
 import XCTest
+
+@testable import Workflow
 
 extension WorkflowAction {
     /// Returns a state tester containing `self`.
-    public static func tester(withState state: WorkflowType.State) -> WorkflowActionTester<WorkflowType, Self> {
-        WorkflowActionTester(state: state)
+    public static func tester(
+        withState state: WorkflowType.State,
+        workflow: WorkflowType? = nil
+    ) -> WorkflowActionTester<WorkflowType, Self> {
+        WorkflowActionTester(
+            state: state,
+            context: TestApplyContext(
+                kind: workflow.map { .workflow($0) } ?? .expectations([:])
+            )
+        )
     }
 }
 
@@ -65,10 +74,16 @@ public struct WorkflowActionTester<WorkflowType, Action: WorkflowAction> where A
     /// The current state
     let state: WorkflowType.State
     let output: WorkflowType.Output?
+    let context: TestApplyContext<WorkflowType>
 
     /// Initializes a new state tester
-    fileprivate init(state: WorkflowType.State, output: WorkflowType.Output? = nil) {
+    fileprivate init(
+        state: WorkflowType.State,
+        context: TestApplyContext<WorkflowType>,
+        output: WorkflowType.Output? = nil
+    ) {
         self.state = state
+        self.context = context
         self.output = output
     }
 
@@ -78,10 +93,14 @@ public struct WorkflowActionTester<WorkflowType, Action: WorkflowAction> where A
     ///
     /// - returns: A new state tester containing the state and output (if any) after the update.
     @discardableResult
-    public func send(action: Action) -> WorkflowActionTester<WorkflowType, Action> {
+    public func send(action: Action) -> WorkflowActionTester<WorkflowType, Action>
+        where Action.WorkflowType == WorkflowType
+    {
         var newState = state
-        let output = action.apply(toState: &newState)
-        return WorkflowActionTester(state: newState, output: output)
+        let wrappedContext = ApplyContext.make(implementation: context)
+        let output = action.apply(toState: &newState, context: wrappedContext)
+
+        return WorkflowActionTester(state: newState, context: context, output: output)
     }
 
     /// Asserts that the action produced no output
@@ -124,7 +143,9 @@ public struct WorkflowActionTester<WorkflowType, Action: WorkflowAction> where A
     ///
     /// - returns: A tester containing the current state and output.
     @discardableResult
-    public func verifyState(_ assertions: (WorkflowType.State) throws -> Void) rethrows -> WorkflowActionTester<WorkflowType, Action> {
+    public func verifyState(
+        _ assertions: (WorkflowType.State) throws -> Void
+    ) rethrows -> WorkflowActionTester<WorkflowType, Action> {
         try assertions(state)
         return self
     }
@@ -160,6 +181,37 @@ extension WorkflowActionTester where WorkflowType.Output: Equatable {
     public func assert(output expectedOutput: WorkflowType.Output, file: StaticString = #file, line: UInt = #line) -> WorkflowActionTester<WorkflowType, Action> {
         verifyOutput { actualOutput in
             expectNoDifference(actualOutput, expectedOutput, filePath: file, line: line)
+        }
+    }
+}
+
+// MARK: - ApplyContext
+
+struct TestApplyContext<Wrapped: Workflow>: ApplyContextType {
+    enum TestContextKind {
+        case workflow(Wrapped)
+        // TODO: flesh this out to support 'just in time' values
+        // rather than requiring a full Workflow instance to be provided
+        case expectations([AnyKeyPath: Any])
+    }
+
+    var storage: TestContextKind
+
+    init(kind: TestContextKind) {
+        self.storage = kind
+    }
+
+    subscript<Value>(
+        workflowValue keyPath: KeyPath<Wrapped, Value>
+    ) -> Value {
+        switch storage {
+        case .workflow(let workflow):
+            return workflow[keyPath: keyPath]
+        case .expectations(var expectedValues):
+            guard let value = expectedValues.removeValue(forKey: keyPath) as? Value else {
+                fatalError("Attempted to read value \(keyPath as AnyKeyPath), when applying an action, but no value was present. Pass an instance of the Workflow to the ActionTester to enable this functionality.")
+            }
+            return value
         }
     }
 }

--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -190,8 +190,9 @@ extension WorkflowActionTester where WorkflowType.Output: Equatable {
 struct TestApplyContext<Wrapped: Workflow>: ApplyContextType {
     enum TestContextKind {
         case workflow(Wrapped)
-        // TODO: flesh this out to support 'just in time' values
+        // FIXME: flesh this out to support 'just in time' values
         // rather than requiring a full Workflow instance to be provided
+        // https://github.com/square/workflow-swift/issues/351
         case expectations([AnyKeyPath: Any])
     }
 

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -128,6 +128,7 @@ public struct RenderTester<WorkflowType: Workflow> {
 
     private let expectedWorkflows: [AnyExpectedWorkflow]
     private let expectedSideEffects: [AnyHashable: ExpectedSideEffect]
+    private let applyContext: TestApplyContext<WorkflowType>
 
     init(
         workflow: WorkflowType,
@@ -139,6 +140,7 @@ public struct RenderTester<WorkflowType: Workflow> {
         self.state = state
         self.expectedWorkflows = expectedWorkflows
         self.expectedSideEffects = expectedSideEffects
+        self.applyContext = .init(kind: .workflow(workflow))
     }
 
     /// Expect the given workflow type in the next rendering.
@@ -264,6 +266,7 @@ public struct RenderTester<WorkflowType: Workflow> {
             state: state,
             expectedWorkflows: expectedWorkflows,
             expectedSideEffects: expectedSideEffects,
+            applyContext: applyContext,
             file: file,
             line: line
         )

--- a/WorkflowTesting/Tests/TestingFrameworkCompatibilityTests.swift
+++ b/WorkflowTesting/Tests/TestingFrameworkCompatibilityTests.swift
@@ -48,7 +48,7 @@ private enum TestAction: WorkflowAction {
 
     case change(Bool)
 
-    func apply(toState state: inout Bool) -> TestWorkflow.Output? {
+    func apply(toState state: inout Bool, context: ApplyContext<WorkflowType>) -> TestWorkflow.Output? {
         if case .change(let newState) = self {
             state = newState
         }

--- a/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
@@ -117,7 +117,7 @@ extension WorkflowActionTesterTests {
             .assert(output: .value("read props: 42"))
     }
 
-    // TODO: ideally an 'exit/death test' would be used for this...
+    // FIXME: ideally an 'exit/death test' would somehow be used for this...
     /*
      func test_old_api_explodes_if_you_use_props() {
          XCTExpectFailure("This test should fail")

--- a/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterFailureTests.swift
@@ -449,7 +449,7 @@ private enum TestAction: WorkflowAction, Equatable {
 
     typealias WorkflowType = TestWorkflow
 
-    func apply(toState state: inout TestWorkflow.State) -> TestWorkflow.Output? {
+    func apply(toState state: inout TestWorkflow.State, context: ApplyContext<TestWorkflow>) -> TestWorkflow.Output? {
         switch self {
         case .noop:
             nil


### PR DESCRIPTION
this BREAKING change updates the WorkflowAction API to pass through a new parameter in the `apply()` method that allows reading values off the corresponding node's current Workflow instance. the new method signature is:

```swift
func apply(toState state: inout State, context: ApplyContext<WorkflowType>) -> Output?
```

which mirrors the `render()` API, but uses a new `ApplyContext` parameter to expose access to the runtime-managed data. the public API for `ApplyContext` exposes a read-only subscript for accessing Workflow values via keypath:

```swift
public struct ApplyContext<WorkflowType: Workflow> {
    public subscript<Value>(
        workflowValue keyPath: KeyPath<WorkflowType, Value>
    ) -> Value 
}
```
---

for reviewing purposes, i'd suggest using the 'commit filter' function to exclude the commit labeled 'AUTOMATED' as that one is essentially just noise where a bunch of new parameters were added.

also, there's definitely some more documentation to be written here, but i've currently punted on that somewhat. do feel free to point out places you'd like to see anything specific though.