### PR TITLE
[fix]: bump catalyst to fix build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .iOS(.v16),
         .macOS(.v12),
         .watchOS(.v8),
-        .macCatalyst(.v15),
+        .macCatalyst(.v16),
         .tvOS(.v12),
     ],
     products: [


### PR DESCRIPTION
- bumped mac catalyst min version to 16 to fix downstream build issues
- going to treat this as a 'hotfix' followup to the 4.0.0 tag