### PR TITLE
Move AnyAsyncSequenceWorker into WorkflowConcurrency as AsyncSequenceWorker

### DIFF
--- a/WorkflowConcurrency/Sources/AsyncSequenceWorker.swift
+++ b/WorkflowConcurrency/Sources/AsyncSequenceWorker.swift
@@ -9,16 +9,16 @@ import Workflow
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public protocol AsyncSequenceWorker<Output>: AnyWorkflowConvertible where Rendering == Void {
+public protocol AsyncSequenceWorker<Output>: AnyWorkflowConvertible where Rendering == Void, Output: Sendable {
     /// The type of output events returned by this worker.
-    associatedtype Output
+    associatedtype Sequence: AsyncSequence where Sequence.Element == Output
 
     // In iOS 18+ we can do:
     // func run() -> any AsyncSequence<Output, Never>
-    // And then remove the casting in the side effect
 
     /// Returns an `AsyncSequence` to execute the work represented by this worker.
-    func run() -> any AsyncSequence
+    func run() -> Sequence
+
     /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
     /// account whatever data is meaningful to the task. For example, a worker that loads a user account from a server
     /// would not be equivalent to another worker with a different user ID.
@@ -49,15 +49,10 @@ struct AsyncSequenceWorkerWorkflow<WorkerType: AsyncSequenceWorker>: Workflow {
     func render(state: State, context: RenderContext<AsyncSequenceWorkerWorkflow>) -> Rendering {
         let sink = context.makeSink(of: AnyWorkflowAction.self)
         context.runSideEffect(key: state) { lifetime in
-            let task = Task {
-                for try await output in worker.run() {
-                    // Not necessary in iOS 18+ once we can use AsyncSequence<Output, Never>
-                    guard let output = output as? Output else {
-                        fatalError("Unexpected output type \(type(of: output)) from worker \(worker)")
-                    }
-                    await MainActor.run {
-                        sink.send(AnyWorkflowAction(sendingOutput: output))
-                    }
+            let sequence = worker.run()
+            let task = Task { @MainActor in
+                for try await output in sequence {
+                    sink.send(AnyWorkflowAction(sendingOutput: output))
                 }
             }
 

--- a/WorkflowConcurrency/Tests/AsyncSequenceWorkerTests.swift
+++ b/WorkflowConcurrency/Tests/AsyncSequenceWorkerTests.swift
@@ -289,12 +289,14 @@ class AsyncSequenceWorkerTests: XCTestCase {
             }
 
             struct ExpectingWorker: AsyncSequenceWorker {
+                typealias Sequence = AsyncStream<Void>
+
                 typealias Output = Void
 
                 let startExpectation: XCTestExpectation
                 let endExpectation: XCTestExpectation
 
-                func run() -> any AsyncSequence {
+                func run() -> Sequence {
                     startExpectation.fulfill()
                     return AsyncStream<Output> {
                         if Task.isCancelled {
@@ -376,9 +378,11 @@ class AsyncSequenceWorkerTests: XCTestCase {
     }
 
     private struct IntWorker: AsyncSequenceWorker {
+        typealias Sequence = AsyncStream<Int>
+
         let isEquivalent: Bool
 
-        func run() -> any AsyncSequence {
+        func run() -> Sequence {
             AsyncStream<Int>(Int.self) { continuation in
                 continuation.yield(1)
                 continuation.finish()
@@ -415,7 +419,9 @@ class AsyncSequenceWorkerTests: XCTestCase {
     }
 
     private struct ContinuousIntWorker: AsyncSequenceWorker {
-        func run() -> any AsyncSequence {
+        typealias Sequence = AsyncStream<Int>
+
+        func run() -> Sequence {
             var i = 0
             return AsyncStream<Int> {
                 i += 1


### PR DESCRIPTION
This moves `AnyAsyncSequenceWorker` from `WorkflowExperimental` in register into `WorkflowConcurrency` as `AsyncSequenceWorker`.

** Update **
After pairing with @jamieQ I've pushed out an update that includes his change that adds a `Sequence` associated type that can be used to require `Element` from `AsyncSequence` to match `Output`.
This allows the worker workflow to be able to get typed output from the `for await`.

## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
