### PR TITLE
AsyncSequenceWorker’s should not throw errors

### DIFF
--- a/WorkflowConcurrency/Sources/AsyncSequenceWorker.swift
+++ b/WorkflowConcurrency/Sources/AsyncSequenceWorker.swift
@@ -51,8 +51,12 @@ struct AsyncSequenceWorkerWorkflow<WorkerType: AsyncSequenceWorker>: Workflow {
         context.runSideEffect(key: state) { lifetime in
             let sequence = worker.run()
             let task = Task { @MainActor in
-                for try await output in sequence {
-                    sink.send(AnyWorkflowAction(sendingOutput: output))
+                do {
+                    for try await output in sequence {
+                        sink.send(AnyWorkflowAction(sendingOutput: output))
+                    }
+                } catch {
+                    fatalError("AsyncSequenceWorker implementations should not throw errors on iteration: \(error)")
                 }
             }
 


### PR DESCRIPTION
Added catch for errors in AsyncSequenceWorker.


## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
