### PR TITLE
feat: allow SwiftUI ViewEnvironment access via SPI

### DIFF
--- a/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
+++ b/ViewEnvironment/Sources/EnvironmentValues+ViewEnvironment.swift
@@ -29,6 +29,23 @@ extension EnvironmentValues {
     }
 }
 
+@_spi(ViewEnvironmentWiring)
+public struct ViewEnvironmentWrapper {
+    public var viewEnvironment: ViewEnvironment
+
+    public init(_ viewEnvironment: ViewEnvironment) {
+        self.viewEnvironment = viewEnvironment
+    }
+}
+
+extension EnvironmentValues {
+    @_spi(ViewEnvironmentWiring)
+    public var viewEnvironmentWrapper: ViewEnvironmentWrapper {
+        get { ViewEnvironmentWrapper(self[ViewEnvironmentKey.self]) }
+        set { self[ViewEnvironmentKey.self] = newValue.viewEnvironment }
+    }
+}
+
 extension Environment where Value == ViewEnvironment {
     @available(
         *,


### PR DESCRIPTION
Restores the ability to bridge ViewEnvironment back out, which was removed in #319.

This PR does it with SPI currently, but tbh I think we could safely revert the deprecation and be OK.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
