### PR TITLE
Add a read only subscript to `ObservableModel`

### DIFF
--- a/WorkflowSwiftUI/Sources/ObservableModel.swift
+++ b/WorkflowSwiftUI/Sources/ObservableModel.swift
@@ -147,4 +147,9 @@ extension ObservableModel {
             accessor.sendValue { $0[keyPath: keyPath] = newValue }
         }
     }
+
+    /// Allows dynamic member lookup to read state through the accessor.
+    public subscript<T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
+        accessor.state[keyPath: keyPath]
+    }
 }


### PR DESCRIPTION
https://square.slack.com/archives/CBZJ5V163/p1751313246347059

When you have a screen with a model type of `ActionModel<MyWorkflow.State, MyWorkflow.Action>`, you were unable to use a `let` or computed `var` property on that screen. If you did you would get a compiler error of `Cannot assign to property: 'enableDoneButton' is a 'let' constant`, even if you were only trying to read the property.


## Checklist

- [ ] Unit Tests - There aren't any tests of `ObservableModel` in the codebase currently. As I'm not very familiar with this codebase, I don't know how to really make a useful test here.
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
