### PR TITLE
feat: Adding support for dynamic view controller types

### DIFF
--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -119,7 +119,6 @@ public struct ViewControllerDescription {
     ///   - build: Closure that produces a new instance of the view controller
     ///
     ///   - update: Closure that updates the given view controller
-    @_spi(DynamicControllerTypes)
     public init(
         performInitialUpdate: Bool = true,
         dynamicType: UIViewController.Type,

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -99,6 +99,50 @@ public struct ViewControllerDescription {
         }
     }
 
+    /// Constructs a view controller description by providing closures used to
+    /// build and update a specific view controller type. This initializer supports
+    /// implementations that cannot rely on static types.
+    ///
+    /// - Parameters:
+    ///   - performInitialUpdate: If an initial call to `update(viewController:)`
+    ///     will be performed when the view controller is created. Defaults to `true`.
+    ///
+    ///   - dynamicType: The type of view controller produced by this description.
+    ///     This type is used by `KindIdentifier` and its `checkViewControllerType`
+    ///     closure to inspect view controller types at runtime.
+    ///
+    ///   - environment: The `ViewEnvironment` that should be injected above the
+    ///     described view controller for ViewEnvironmentUI environment propagation.
+    ///     This is typically passed in from a `Screen` in its
+    ///     `viewControllerDescription(environment:)` method.
+    ///
+    ///   - build: Closure that produces a new instance of the view controller
+    ///
+    ///   - update: Closure that updates the given view controller
+    @_spi(DynamicControllerTypes)
+    public init(
+        performInitialUpdate: Bool = true,
+        dynamicType: UIViewController.Type,
+        environment: ViewEnvironment,
+        build: @escaping () -> UIViewController,
+        update: @escaping (UIViewController) -> Void
+    ) {
+        self.performInitialUpdate = performInitialUpdate
+
+        self.kind = .init(dynamicType: dynamicType)
+
+        self.environment = environment
+
+        self.build = build
+
+        self.update = { untypedViewController in
+            guard untypedViewController.isKind(of: dynamicType) else {
+                fatalError("Unable to update \(untypedViewController), expecting a \(dynamicType)")
+            }
+            update(untypedViewController)
+        }
+    }
+
     /// Construct and update a new view controller as described by this view controller description.
     /// The view controller will be updated before it is returned, so it is fully configured and prepared for display.
     public func buildViewController() -> UIViewController {
@@ -195,6 +239,12 @@ extension ViewControllerDescription {
             self.viewControllerType = VC.self
 
             self.checkViewControllerType = { $0 is VC }
+        }
+
+        /// This initializer uses dynamic type inspection in `checkViewControllerType`.
+        fileprivate init(dynamicType: UIViewController.Type) {
+            self.viewControllerType = dynamicType
+            self.checkViewControllerType = { $0.isKind(of: dynamicType) }
         }
 
         /// If the given view controller is of the correct type to be updated by this view controller description.

--- a/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -133,7 +133,13 @@ public struct ViewControllerDescription {
 
         self.environment = environment
 
-        self.build = build
+        self.build = {
+            let viewController = build()
+            guard viewController.isKind(of: dynamicType) else {
+                fatalError("Error creating \(viewController), expecting a \(dynamicType)")
+            }
+            return viewController
+        }
 
         self.update = { untypedViewController in
             guard untypedViewController.isKind(of: dynamicType) else {

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -255,6 +255,26 @@ class ViewControllerDescriptionTests: XCTestCase {
         XCTAssertFalse(descriptionWithStaticSubtype.canUpdate(viewController: SecondBlankViewController()))
         XCTAssertTrue(descriptionWithStaticSubtype.canUpdate(viewController: BlankViewControllerSubclass()))
     }
+
+    func test_buildingWithDynamicType() {
+        let descriptionWithSuperclassType = ViewControllerDescription(
+            dynamicType: BlankViewController.self,
+            environment: .empty,
+            build: { BlankViewControllerSubclass() },
+            update: { _ in }
+        )
+        XCTAssertTrue(descriptionWithSuperclassType.buildViewController().isKind(of: BlankViewController.self))
+        XCTAssertTrue(descriptionWithSuperclassType.buildViewController().isKind(of: BlankViewControllerSubclass.self))
+
+        let descriptionWithExactType = ViewControllerDescription(
+            dynamicType: BlankViewController.self,
+            environment: .empty,
+            build: { BlankViewController() },
+            update: { _ in }
+        )
+        XCTAssertTrue(descriptionWithExactType.buildViewController().isKind(of: BlankViewController.self))
+        XCTAssertFalse(descriptionWithExactType.buildViewController().isKind(of: BlankViewControllerSubclass.self))
+    }
 }
 
 class ViewControllerDescription_KindIdentifierTests: XCTestCase {

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -206,47 +206,50 @@ class ViewControllerDescriptionTests: XCTestCase {
         XCTAssertFalse(viewController === viewControllerAgain)
     }
 
-    func test_dynamicTypeInspection() {
-        func obfuscatedController() -> UIViewController { BlankViewController() }
-        let controller = obfuscatedController()
+    func test_viewControllerTypes() {
+        func polymorphicController() -> UIViewController { BlankViewController() }
+        let controller = polymorphicController()
 
+        // Case 1: Dynamic type inspection.
         // kind.viewControllerType == BlankViewController.self.
-        // canUpdate(viewController:) will evaluate to true for matching UIViewController types or subclasses.
         let descriptionWithDynamicType = ViewControllerDescription(
             dynamicType: type(of: controller),
             environment: .empty,
             build: { controller },
             update: { _ in }
         )
-        XCTAssertTrue(descriptionWithDynamicType.canUpdate(viewController: obfuscatedController()))
+        // canUpdate(viewController:) will evaluate to true for matching UIViewController types or subclasses.
+        XCTAssertTrue(descriptionWithDynamicType.canUpdate(viewController: polymorphicController()))
         XCTAssertTrue(descriptionWithDynamicType.canUpdate(viewController: BlankViewController()))
         XCTAssertFalse(descriptionWithDynamicType.canUpdate(viewController: UIViewController()))
         XCTAssertFalse(descriptionWithDynamicType.canUpdate(viewController: SecondBlankViewController()))
         XCTAssertTrue(descriptionWithDynamicType.canUpdate(viewController: BlankViewControllerSubclass()))
 
+        // Case 2: Example of static types losing granularity when supplying a superclass type.
         // kind.viewControllerType == UIViewController.self.
-        // canUpdate(viewController:) evaluates to true for any UIViewController type.
         let descriptionWithStaticSupertype = ViewControllerDescription(
             type: type(of: controller),
             environment: .empty,
             build: { controller },
             update: { _ in }
         )
-        XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: obfuscatedController()))
+        // canUpdate(viewController:) evaluates to true for any UIViewController type.
+        XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: polymorphicController()))
         XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: BlankViewController()))
         XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: UIViewController()))
         XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: SecondBlankViewController()))
         XCTAssertTrue(descriptionWithStaticSupertype.canUpdate(viewController: BlankViewControllerSubclass()))
 
+        // Case 3: Common/standard Workflow use case with static types.
         // kind.viewControllerType == BlankViewController.self.
-        // canUpdate(viewController:) will evaluate to true for matching UIViewController types or subclasses.
         let descriptionWithStaticSubtype = ViewControllerDescription(
             type: BlankViewController.self,
             environment: .empty,
             build: { BlankViewController() },
             update: { _ in }
         )
-        XCTAssertTrue(descriptionWithStaticSubtype.canUpdate(viewController: obfuscatedController()))
+        // canUpdate(viewController:) will evaluate to true for matching UIViewController types or subclasses.
+        XCTAssertTrue(descriptionWithStaticSubtype.canUpdate(viewController: polymorphicController()))
         XCTAssertTrue(descriptionWithStaticSubtype.canUpdate(viewController: BlankViewController()))
         XCTAssertFalse(descriptionWithStaticSubtype.canUpdate(viewController: UIViewController()))
         XCTAssertFalse(descriptionWithStaticSubtype.canUpdate(viewController: SecondBlankViewController()))

--- a/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
+++ b/WorkflowUI/Tests/ViewControllerDescriptionTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 import ReactiveSwift
 import Workflow
-@_spi(DynamicControllerTypes) @testable import WorkflowUI
+@testable import WorkflowUI
 
 fileprivate class BlankViewController: UIViewController {}
 fileprivate class BlankViewControllerSubclass: BlankViewController {}


### PR DESCRIPTION
This PR adds support to `ViewControllerDescription` for dynamic view controller types. This is used in cases where the static type of the description's view controller is not granular enough, like implementations that supply a `UIViewController.self` type to `ViewControllerDescription` instead of the subclass type.

This is behind a `DynamicControllerTypes` SPI to encourage use of the existing initializer that uses generics.

## Checklist

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
