### PR TITLE
fix: ensure custom dump version ≥ 1.3.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.5.0"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.2.1"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
We discovered downstream that we're using features from at least 1.3.1.

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
