### PR TITLE
chore: Bump Perception to 2.0.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.5"),
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
-        .package(url: "https://github.com/pointfreeco/swift-perception", from: "2.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-perception", "1.5.0"..<"3.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.5"),
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
-        .package(url: "https://github.com/pointfreeco/swift-perception", "1.5.0"..<"3.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-perception", "1.5.0" ..< "3.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.5"),
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
-        .package(url: "https://github.com/pointfreeco/swift-perception", from: "1.5.0"),
+        .package(url: "https://github.com/pointfreeco/swift-perception", from: "2.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
     ],

--- a/Samples/Tuist/Package.resolved
+++ b/Samples/Tuist/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "21811d6230a625fa0f2e6ffa85be857075cc02c4",
-        "version" : "1.5.0"
+        "revision" : "59b00dfa5548b5b91ebbda6d94d6328d82ca00fe",
+        "version" : "2.0.6"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "96beb108a57f24c8476ae1f309239270772b2940",
-        "version" : "1.2.5"
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
       }
     }
   ],


### PR DESCRIPTION
## Checklist

**Bump perception to 2.0.6**
**`tuist install --path Samples` to update Sample resolved dependencies**

The Perception version specified in Package.swift is now `1.5.0"..<"3.0.0`. This allows easier upgrade and downgrades by consumers.

I've opened this in favor of https://github.com/square/workflow-swift/pull/376 because Perception has been [updated](https://github.com/pointfreeco/swift-perception/pull/156) following Apple's reversion of https://github.com/swiftlang/swift/pull/83436 and it avoids test updates on our end for now.

I didn't run the `tuist install` with the `--update` flag this time either. There doesn't seem to be a way to scope the updates to only Perception and it's sub-dependencies and I didn't want all the other clutter associated with this change.

- [x] Unit Tests
- [x] UI Tests
- [x] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation
- [x] Resolve new Perception warning in ios-register: https://github.com/squareup/ios-register/pull/131811
- [x] Resolve new instances of Perception warnings in Market: https://github.com/squareup/market/pull/11042
