### PR TITLE
[refactor]: improve diagnostics for escaped context instances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,14 +61,18 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", "1.5.0" ..< "3.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
+        // 'xctest-dynamic-overlay' is actually for "IssueReporting"
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
     ],
     targets: [
         // MARK: Workflow
 
         .target(
             name: "Workflow",
-            dependencies: ["ReactiveSwift"],
+            dependencies: [
+                .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+                .product(name: "ReactiveSwift", package: "ReactiveSwift"),
+            ],
             path: "Workflow/Sources"
         ),
         .target(
@@ -76,6 +80,7 @@ let package = Package(
             dependencies: [
                 "Workflow",
                 .product(name: "CustomDump", package: "swift-custom-dump"),
+                .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
             ],
             path: "WorkflowTesting/Sources",
             linkerSettings: [.linkedFramework("XCTest")]
@@ -125,7 +130,10 @@ let package = Package(
 
         .target(
             name: "WorkflowReactiveSwift",
-            dependencies: ["ReactiveSwift", "Workflow"],
+            dependencies: [
+                "Workflow",
+                .product(name: "ReactiveSwift", package: "ReactiveSwift"),
+            ],
             path: "WorkflowReactiveSwift/Sources"
         ),
         .target(
@@ -139,7 +147,10 @@ let package = Package(
 
         .target(
             name: "WorkflowRxSwift",
-            dependencies: ["RxSwift", "Workflow"],
+            dependencies: [
+                "Workflow",
+                .product(name: "RxSwift", package: "RxSwift"),
+            ],
             path: "WorkflowRxSwift/Sources"
         ),
         .target(

--- a/Workflow/Tests/ApplyContextTests.swift
+++ b/Workflow/Tests/ApplyContextTests.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import IssueReporting
 import Testing
 
 @testable import Workflow
@@ -38,7 +39,10 @@ struct ApplyContextTests {
         let emitEvent = node.render()
         node.enableEvents()
 
-        emitEvent()
+        // We're intentionally escaping the context
+        withExpectedIssue {
+            emitEvent()
+        }
 
         #expect(escapedContext != nil)
         #expect(escapedContext?.concreteStorage == nil)

--- a/Workflow/Tests/ApplyContextTests.swift
+++ b/Workflow/Tests/ApplyContextTests.swift
@@ -15,18 +15,17 @@
  */
 
 import IssueReporting
-import Testing
+import XCTest
 
 @testable import Workflow
 
 @MainActor
-struct ApplyContextTests {
-    @Test
-    func concreteApplyContextInvalidatedAfterUse() async throws {
+final class ApplyContextTests: XCTestCase {
+    func testConcreteApplyContextInvalidatedAfterUse() async throws {
         var escapedContext: ApplyContext<EscapingContextWorkflow>?
         let onApply = { (context: ApplyContext<EscapingContextWorkflow>) in
-            #expect(context[workflowValue: \.property] == 42)
-            #expect(context.concreteStorage != nil)
+            XCTAssert(context[workflowValue: \.property] == 42)
+            XCTAssert(context.concreteStorage != nil)
             escapedContext = context
         }
 
@@ -44,8 +43,8 @@ struct ApplyContextTests {
             emitEvent()
         }
 
-        #expect(escapedContext != nil)
-        #expect(escapedContext?.concreteStorage == nil)
+        XCTAssert(escapedContext != nil)
+        XCTAssert(escapedContext?.concreteStorage == nil)
     }
 }
 

--- a/Workflow/Tests/SubtreeManagerTests.swift
+++ b/Workflow/Tests/SubtreeManagerTests.swift
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import IssueReporting
 import ReactiveSwift
 import XCTest
+
 @testable import Workflow
 
 final class SubtreeManagerTests: XCTestCase {
@@ -126,14 +128,17 @@ final class SubtreeManagerTests: XCTestCase {
 
         var escapingContext: RenderContext<ParentWorkflow>!
 
-        _ = manager.render { context -> TestViewModel in
-            XCTAssertTrue(context.isValid)
-            escapingContext = context
-            return context.render(
-                workflow: TestWorkflow(),
-                key: "",
-                outputMap: { _ in AnyWorkflowAction.noAction }
-            )
+        // We expect the context escape check to detect this
+        withExpectedIssue {
+            _ = manager.render { context -> TestViewModel in
+                XCTAssertTrue(context.isValid)
+                escapingContext = context
+                return context.render(
+                    workflow: TestWorkflow(),
+                    key: "",
+                    outputMap: { _ in AnyWorkflowAction.noAction }
+                )
+            }
         }
         manager.enableEvents()
 


### PR DESCRIPTION
### Issue

the `{Render|Apply}Context` types should not escape from their respective methods, as this can allow library internals to 'leak out' and cause various issues[^1]. primarily this can result in lifetime discrepancies or surprising relationships in the object graph. historically we've enforced this invariant 'lazily' by setting a bit on the instances and checking that they are still 'valid' during access through their public API. however, it recently occurred to me that we could probably be a bit more proactive about this, and perform a unique reference check immediately after returning from the client callouts.

### Description

- adds logic to detect escaping context instances (debug mode only)
- adds the 'IssueReporting' dependency to Workflow so we can better test the logic in our unit tests
- minor incidental refactoring of the Package file
- updates unit tests appropriately

[^1]: this is really more of an issue for RenderContext, as it doesn't yet zero-out its internal storage when invalidated. since ApplyContext is newer, we didn't make that mistake twice.
