### PR TITLE
[fix]: add host-level logic for reentrant event handling

### DIFF
--- a/Workflow/Sources/RuntimeConfiguration.swift
+++ b/Workflow/Sources/RuntimeConfiguration.swift
@@ -88,6 +88,10 @@ extension Runtime {
 
         /// Note: this doesn't control anything yet, but is here as a placeholder
         public var renderOnlyIfStateChanged: Bool = false
+
+        /// Whether action handling should be delegated to the `SinkEventHandler` type.
+        /// This is expected to eventually be removed and become the default behavior.
+        public var useSinkEventHandler: Bool = false
     }
 
     struct BootstrappableConfiguration {

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -325,7 +325,7 @@ extension WorkflowNode.SubtreeManager {
 
         mutating func findOrCreate<Action: WorkflowAction>(
             actionType: Action.Type,
-            onSinkEvent: @escaping OnSinkEvent
+            onSinkEvent: OnSinkEvent?
         ) -> ReusableSink<Action> {
             let key = ObjectIdentifier(actionType)
 
@@ -352,10 +352,10 @@ extension WorkflowNode.SubtreeManager {
     /// Type-erased base class for reusable sinks.
     fileprivate class AnyReusableSink {
         /// The callback to invoke when an event is to be handled.
-        let onSinkEvent: OnSinkEvent
+        let onSinkEvent: OnSinkEvent?
         var eventPipe: EventPipe
 
-        init(onSinkEvent: @escaping OnSinkEvent) {
+        init(onSinkEvent: OnSinkEvent?) {
             self.onSinkEvent = onSinkEvent
             self.eventPipe = EventPipe()
         }
@@ -363,6 +363,36 @@ extension WorkflowNode.SubtreeManager {
 
     fileprivate final class ReusableSink<Action: WorkflowAction>: AnyReusableSink where Action.WorkflowType == WorkflowType {
         func handle(action: Action) {
+            if let onSinkEvent {
+                handleWithSinkEventHandler(action: action, onSinkEvent: onSinkEvent)
+                return
+            }
+
+            // Prior logic
+            let output = Output.update(
+                action,
+                source: .external,
+                subtreeInvalidated: false // initial state
+            )
+
+            if case .pending = eventPipe.validationState {
+                // Workflow is currently processing an `event`.
+                // Scheduling it to be processed after.
+                DispatchQueue.workflowExecution.async { [weak self] in
+                    self?.eventPipe.handle(event: output)
+                }
+                return
+            }
+            eventPipe.handle(event: output)
+        }
+
+        private func handleWithSinkEventHandler(
+            action: Action,
+            onSinkEvent: OnSinkEvent
+        ) {
+            // new `SinkEventHandler` logic
+            dispatchPrecondition(condition: .onQueue(DispatchQueue.workflowExecution))
+
             // If we can process now, forward through the `EventPipe`
             let immediatePerform: () -> Void = {
                 let output = Output.update(

--- a/Workflow/Sources/SubtreeManager.swift
+++ b/Workflow/Sources/SubtreeManager.swift
@@ -363,7 +363,8 @@ extension WorkflowNode.SubtreeManager {
 
     fileprivate final class ReusableSink<Action: WorkflowAction>: AnyReusableSink where Action.WorkflowType == WorkflowType {
         func handle(action: Action) {
-            let perform: () -> Void = {
+            // If we can process now, forward through the `EventPipe`
+            let immediatePerform: () -> Void = {
                 let output = Output.update(
                     action,
                     source: .external,
@@ -373,11 +374,12 @@ extension WorkflowNode.SubtreeManager {
                 self.eventPipe.handle(event: output)
             }
 
-            let enqueue: () -> Void = { [weak self] in
+            // Otherwise, try to recurse again in the future
+            let deferredPerform: () -> Void = { [weak self] in
                 self?.handle(action: action)
             }
 
-            onSinkEvent(perform, enqueue)
+            onSinkEvent(immediatePerform, deferredPerform)
         }
     }
 }

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -51,7 +51,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
         context.debugger
     }
 
-    let eventHandler: SinkEventHandler
+    let sinkEventHandler: SinkEventHandler
 
     /// Initializes a new host with the given workflow at the root.
     ///
@@ -64,12 +64,8 @@ public final class WorkflowHost<WorkflowType: Workflow> {
         observers: [WorkflowObserver] = [],
         debugger: WorkflowDebugger? = nil
     ) {
-        self.eventHandler = SinkEventHandler()
-        assert(
-            eventHandler.state == .initializing,
-            "EventHandler must begin in the `.initializing` state"
-        )
-        defer { eventHandler.state = .ready }
+        self.sinkEventHandler = SinkEventHandler()
+        defer { sinkEventHandler.state = .ready }
 
         let observer = WorkflowObservation
             .sharedObserversInterceptor
@@ -80,7 +76,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
             observer: observer,
             debugger: debugger,
             runtimeConfig: Runtime.configuration,
-            onSinkEvent: eventHandler.makeOnSinkEventCallback()
+            onSinkEvent: sinkEventHandler.makeOnSinkEventCallback()
         )
 
         self.rootNode = WorkflowNode(
@@ -102,6 +98,12 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
     /// Update the input for the workflow. Will cause a render pass.
     public func update(workflow: WorkflowType) {
+        sinkEventHandler.withEventHandlingSuspended {
+            _update(workflow: workflow)
+        }
+    }
+
+    private func _update(workflow: WorkflowType) {
         rootNode.update(workflow: workflow)
 
         // Treat the update as an "output" from the workflow originating from an external event to force a render pass.
@@ -193,69 +195,85 @@ extension HostContext {
     }
 }
 
-// MARK: - EventHandler
+// MARK: - SinkEventHandler
 
 /// Callback signature for the internal `ReusableSink` types to invoke when
 /// they receive an event from the 'outside world'.
-/// - Parameter perform: The event handler to invoke if the event can be processed immediately.
-/// - Parameter enqueue: The event handler to invoke in the future if the event cannot currently be processed.
+/// - Parameter immediatePerform: The event handler to invoke if the event can be processed immediately.
+/// - Parameter deferredPerform: The event handler to invoke in the future if the event cannot currently be processed.
 typealias OnSinkEvent = (
-    _ perform: () -> Void,
-    _ enqueue: @escaping () -> Void
+    _ immediatePerform: () -> Void,
+    _ deferredPerform: @escaping () -> Void
 ) -> Void
 
 /// Handles events from 'Sinks' such that runtime-level event handling state is appropriately
 /// managed, and attempts to perform reentrant action handling can be detected and dealt with.
 final class SinkEventHandler {
     enum State {
-        /// The handler (and related components) are being
-        /// initialized, and are not yet ready to process events.
-        /// Attempts to do so in this state will fail with a fatal error.
-        case initializing
-
-        /// An event is currently being processed.
-        case processingEvent
-
         /// Ready to handle an event.
         case ready
+
+        /// The event handler is busy. Usually this indicates another event is being
+        /// processed, but it may also be set when some other condition prevents
+        /// event handling (e.g. a `WorkflowHost` was told to update its root node).
+        case busy
     }
 
-    fileprivate(set) var state: State = .initializing
+    fileprivate(set) var state: State
+
+    init(state: State = .busy) {
+        self.state = state
+    }
 
     /// Synchronously performs or enqueues the specified event handlers based on the current
     /// event handler state.
     /// - Parameters:
-    ///   - perform: The event handling action to perform immediately if possible.
-    ///   - enqueue: The event handling action to enqueue if the event handler is already processing an event.
+    ///   - immediate: The event handling action to perform immediately if possible.
+    ///   - deferred: The event handling action to enqueue if the event handler is already processing an event.
     func performOrEnqueueEvent(
-        perform: () -> Void,
-        enqueue: @escaping () -> Void
+        immediate: () -> Void,
+        deferred: @escaping () -> Void
     ) {
         switch state {
-        case .initializing:
-            fatalError("Tried to handle event before finishing initialization.")
-
-        case .processingEvent:
-            DispatchQueue.workflowExecution.async(execute: enqueue)
-
         case .ready:
-            state = .processingEvent
+            withEventHandlingSuspended(immediate)
+
+        case .busy:
+            DispatchQueue.workflowExecution.async(execute: deferred)
+        }
+    }
+
+    /// Invokes the given closure with event handling explicitly set to the `busy` state, so
+    /// any incoming events produced while executing the closure's body will be enqueued.
+    /// - Parameter body: The closure to invoke.
+    func withEventHandlingSuspended(_ body: () -> Void) {
+        switch state {
+        case .ready:
+            state = .busy
             defer { state = .ready }
-            perform()
+            body()
+
+        case .busy:
+            body()
         }
     }
 
     /// Creates the callback that should be invoked by Sinks to handle their event appropriately
-    /// given the `EventHandler`'s current state.
+    /// given the `SinkEventHandler`'s current state.
     /// - Returns: The callback that should be invoked.
     func makeOnSinkEventCallback() -> OnSinkEvent {
-        // TODO: do we need the weak ref?
-        let onSinkEvent: OnSinkEvent = { [weak self] perform, enqueue in
+        // We may not actually need the weak ref, but it's more defensive to keep it.
+        let onSinkEvent: OnSinkEvent = { [weak self] immediate, deferred in
             guard let self else {
-                return // TODO: what's the appropriate handling?
+                // We just drop the events here. Should we signal this somehow?
+                // Maybe as a debug-only thing? Or is it just noise?
+                return
             }
 
-            performOrEnqueueEvent(perform: perform, enqueue: enqueue)
+            performOrEnqueueEvent(
+                immediate: immediate,
+                deferred: deferred
+            )
         }
 
         return onSinkEvent

--- a/Workflow/Sources/WorkflowHost.swift
+++ b/Workflow/Sources/WorkflowHost.swift
@@ -72,11 +72,14 @@ public final class WorkflowHost<WorkflowType: Workflow> {
             .workflowObservers(for: observers)
             .chained()
 
+        let config = Runtime.configuration
+        let sinkEventCallback = config.useSinkEventHandler ? sinkEventHandler.makeOnSinkEventCallback() : nil
+
         self.context = HostContext(
             observer: observer,
             debugger: debugger,
-            runtimeConfig: Runtime.configuration,
-            onSinkEvent: sinkEventHandler.makeOnSinkEventCallback()
+            runtimeConfig: config,
+            onSinkEvent: sinkEventCallback
         )
 
         self.rootNode = WorkflowNode(
@@ -98,12 +101,16 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
     /// Update the input for the workflow. Will cause a render pass.
     public func update(workflow: WorkflowType) {
-        sinkEventHandler.withEventHandlingSuspended {
-            _update(workflow: workflow)
+        if context.runtimeConfig.useSinkEventHandler {
+            sinkEventHandler.withEventHandlingSuspended {
+                updateRootNode(workflow: workflow)
+            }
+        } else {
+            updateRootNode(workflow: workflow)
         }
     }
 
-    private func _update(workflow: WorkflowType) {
+    private func updateRootNode(workflow: WorkflowType) {
         rootNode.update(workflow: workflow)
 
         // Treat the update as an "output" from the workflow originating from an external event to force a render pass.
@@ -171,14 +178,14 @@ struct HostContext {
     let debugger: WorkflowDebugger?
     let runtimeConfig: Runtime.Configuration
 
-    /// Event handler to be plumbed through the runtime down to the Sinks
-    let onSinkEvent: OnSinkEvent
+    /// Event handler to be plumbed through the runtime down to the (reusable) Sinks.
+    let onSinkEvent: OnSinkEvent?
 
     init(
         observer: WorkflowObserver?,
         debugger: WorkflowDebugger?,
         runtimeConfig: Runtime.Configuration,
-        onSinkEvent: @escaping OnSinkEvent
+        onSinkEvent: OnSinkEvent?
     ) {
         self.observer = observer
         self.debugger = debugger

--- a/Workflow/Tests/SinkEventHandlerTests.swift
+++ b/Workflow/Tests/SinkEventHandlerTests.swift
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+
+@testable import Workflow
+
+struct SinkEventHandlerTests {
+    @Test
+    func initialState() async throws {
+        let subject = SinkEventHandler()
+        #expect(subject.state == .busy)
+    }
+
+    @Test
+    func stateTransitions() async throws {
+        let subject = SinkEventHandler(state: .ready)
+
+        #expect(subject.state == .ready)
+
+        var stateDuringPerform: SinkEventHandler.State?
+        var stateDuringEnqueue: SinkEventHandler.State?
+        subject.performOrEnqueueEvent {
+            stateDuringPerform = subject.state
+        } deferred: {
+            stateDuringEnqueue = subject.state
+        }
+
+        #expect(stateDuringPerform == .busy)
+        #expect(stateDuringEnqueue == nil)
+        #expect(subject.state == .ready)
+    }
+
+    // we are asserting things & depending on the main dispatch queue
+    @MainActor
+    @Test
+    func reentrancyHandling() async throws {
+        let subject = SinkEventHandler(state: .ready)
+
+        var performCount = 0
+        var enqueueCount = 0
+        let incrementPerform = { performCount += 1 }
+        let incrementEnqueue = { enqueueCount += 1 }
+
+        subject.performOrEnqueueEvent {
+            incrementPerform()
+            subject.performOrEnqueueEvent {
+                Issue.record("should not perform")
+            } deferred: {
+                incrementEnqueue()
+            }
+        } deferred: {
+            Issue.record("should not enqueue")
+        }
+
+        // should have synchronously performed once and not yet enqueued
+        #expect(performCount == 1)
+        #expect(enqueueCount == 0)
+
+        await drainMainQueue()
+
+        // should have invoked the enqueued event
+        #expect(performCount == 1)
+        #expect(enqueueCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func callbackReentrancyHandling() async throws {
+        let subject = SinkEventHandler(state: .ready)
+
+        var performCount = 0
+        var enqueueCount = 0
+        let incrementPerform = { performCount += 1 }
+        let incrementEnqueue = { enqueueCount += 1 }
+
+        let callback = subject.makeOnSinkEventCallback()
+
+        callback( /* immediatePerform */ {
+            incrementPerform()
+            callback( /* immediatePerform */ {
+                Issue.record("should not perform")
+            }, /* deferredPerform */ {
+                incrementEnqueue()
+            })
+        }, /* deferredPerform */ {
+            Issue.record("should not enqueue")
+        })
+
+        // should have synchronously performed once and not yet enqueued
+        #expect(performCount == 1)
+        #expect(enqueueCount == 0)
+
+        await drainMainQueue()
+
+        // should have invoked the enqueued event
+        #expect(performCount == 1)
+        #expect(enqueueCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func callbackIgnoresEventAfterDeinit() async throws {
+        weak var weakRef: SinkEventHandler?
+        let callback: OnSinkEvent
+        let subject = SinkEventHandler(state: .ready)
+        weakRef = subject
+        callback = consume subject.makeOnSinkEventCallback()
+
+        // should not invoke anything because event handler deinited
+        callback( /* immediatePerform */ {
+            Issue.record("should not perform")
+        }, /* deferredPerform */ {
+            Issue.record("should not enqueue")
+        })
+
+        #expect(weakRef == nil)
+    }
+
+    @Test
+    func explicitEventHandlingDisabled() async throws {
+        let subject = SinkEventHandler(state: .ready)
+
+        #expect(subject.state == .ready)
+
+        subject.withEventHandlingSuspended {
+            #expect(subject.state == .busy)
+
+            subject.withEventHandlingSuspended {
+                #expect(subject.state == .busy)
+            }
+        }
+
+        #expect(subject.state == .ready)
+    }
+}

--- a/Workflow/Tests/SinkEventHandlerTests.swift
+++ b/Workflow/Tests/SinkEventHandlerTests.swift
@@ -118,7 +118,8 @@ struct SinkEventHandlerTests {
         let callback: OnSinkEvent
         let subject = SinkEventHandler(state: .ready)
         weakRef = subject
-        callback = consume subject.makeOnSinkEventCallback()
+        callback = subject.makeOnSinkEventCallback()
+        _ = consume subject
 
         // should not invoke anything because event handler deinited
         callback( /* immediatePerform */ {

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -68,7 +68,8 @@ extension HostContext {
         HostContext(
             observer: observer,
             debugger: debugger,
-            runtimeConfig: runtimeConfig
+            runtimeConfig: runtimeConfig,
+            onSinkEvent: { perform, _ in perform() }
         )
     }
 }

--- a/Workflow/Tests/TestUtilities.swift
+++ b/Workflow/Tests/TestUtilities.swift
@@ -106,3 +106,71 @@ extension Runtime {
         Runtime._bootstrapConfiguration = .init()
     }
 }
+
+// MARK: - WorkflowObserver
+
+final class TestObserver: WorkflowObserver {
+    var onSessionBegan: ((WorkflowSession) -> Void)?
+    var onSessionEnded: ((WorkflowSession) -> Void)?
+    /// (Workflow, State, Session) -> Void
+    var onDidMakeInitialState: ((Any, Any, WorkflowSession) -> Void)?
+    /// (Workflow, State, Session) -> ((Rendering) -> Void)?
+    var onWillRender: ((Any, Any, WorkflowSession) -> ((Any) -> Void)?)?
+    /// (Workflow [old], Workflow [new], State, Session) -> Void
+    var onDidChange: ((Any, Any, Any, WorkflowSession) -> Void)?
+    /// (Action, Workflow, Session) -> Void
+    var onDidReceiveAction: ((Any, Any, WorkflowSession) -> Void)?
+    /// (Action, Workflow, State, Session) -> ((State, Output?) -> Void)?
+    var onApplyAction: ((Any, Any, Any, WorkflowSession) -> ((Any, Any) -> Void)?)?
+
+    func sessionDidBegin(_ session: WorkflowSession) {
+        onSessionBegan?(session)
+    }
+
+    func sessionDidEnd(_ session: WorkflowSession) {
+        onSessionEnded?(session)
+    }
+
+    func workflowDidMakeInitialState<WorkflowType>(
+        _ workflow: WorkflowType,
+        initialState: WorkflowType.State,
+        session: WorkflowSession
+    ) where WorkflowType: Workflow {
+        onDidMakeInitialState?(workflow, initialState, session)
+    }
+
+    func workflowWillRender<WorkflowType>(_ workflow: WorkflowType, state: WorkflowType.State, session: WorkflowSession) -> ((WorkflowType.Rendering) -> Void)? where WorkflowType: Workflow {
+        onWillRender?(workflow, state, session)
+    }
+
+    func workflowDidChange<WorkflowType>(from oldWorkflow: WorkflowType, to newWorkflow: WorkflowType, state: WorkflowType.State, session: WorkflowSession) where WorkflowType: Workflow {
+        onDidChange?(oldWorkflow, newWorkflow, state, session)
+    }
+
+    func workflowDidReceiveAction<Action: WorkflowAction>(_ action: Action, workflow: Action.WorkflowType, session: WorkflowSession) {
+        onDidReceiveAction?(action, workflow, session)
+    }
+
+    func workflowWillApplyAction<Action: WorkflowAction>(_ action: Action, workflow: Action.WorkflowType, state: Action.WorkflowType.State, session: WorkflowSession) -> ((Action.WorkflowType.State, Action.WorkflowType.Output?) -> Void)? {
+        onApplyAction?(action, workflow, state, session)
+    }
+}
+
+// MARK: - Generic
+
+func drainMainQueueBySpinningRunLoop(timeoutSeconds: UInt = 1) {
+    var done = false
+    DispatchQueue.main.async { done = true }
+
+    let deadline = ContinuousClock.now + .seconds(timeoutSeconds)
+    while !done, ContinuousClock.now < deadline {
+        // Turn one iteration at a time
+        RunLoop.main.run(until: .now)
+    }
+}
+
+func drainMainQueue() async {
+    await withCheckedContinuation { done in
+        DispatchQueue.main.async { done.resume() }
+    }
+}

--- a/Workflow/Tests/WorkflowHostTests.swift
+++ b/Workflow/Tests/WorkflowHostTests.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import ReactiveSwift
 import XCTest
+
 @_spi(WorkflowRuntimeConfig) @testable import Workflow
 
 final class WorkflowHostTests: XCTestCase {
@@ -58,32 +60,84 @@ final class WorkflowHostTests: XCTestCase {
 final class WorkflowHost_EventEmissionTests: XCTestCase {
     // Previous versions of Workflow would fatalError under this scenario
     func test_event_sent_to_invalidated_sink_during_action_handling() {
-        let root = Parent()
-        let host = WorkflowHost(workflow: root)
+        let host = WorkflowHost(workflow: Parent())
+        let (lifetime, token) = ReactiveSwift.Lifetime.make()
+        defer { _ = token }
         let initialRendering = host.rendering.value
         var observedRenderCount = 0
 
         XCTAssertEqual(initialRendering.eventCount, 0)
 
-        let disposable = host.rendering.signal.observeValues { rendering in
-            XCTAssertEqual(rendering.eventCount, 1)
+        host
+            .rendering
+            .signal
+            .take(during: lifetime)
+            .observeValues { rendering in
+                XCTAssertEqual(rendering.eventCount, 1)
 
-            // emit another event using an old rendering
-            // while the first is still being processed, but
-            // the workflow that handles the event has been
-            // removed from the tree
-            if observedRenderCount == 0 {
-                initialRendering.eventHandler()
+                // emit another event using an old rendering
+                // while the first is still being processed, but
+                // the workflow that handles the event has been
+                // removed from the tree
+                if observedRenderCount == 0 {
+                    initialRendering.eventHandler()
+                }
+
+                observedRenderCount += 1
             }
-
-            observedRenderCount += 1
-        }
-        defer { disposable?.dispose() }
 
         // send an event and cause a re-render
         initialRendering.eventHandler()
 
         XCTAssertEqual(observedRenderCount, 1)
+
+        drainMainQueueBySpinningRunLoop()
+
+        // Ensure the invalidated sink doesn't process the event
+        let nextRendering = host.rendering.value
+        XCTAssertEqual(nextRendering.eventCount, 1)
+        XCTAssertEqual(observedRenderCount, 1)
+    }
+
+    func test_reentrant_event_during_render() {
+        let host = WorkflowHost(workflow: ReentrancyWorkflow())
+        let (lifetime, token) = ReactiveSwift.Lifetime.make()
+        defer { _ = token }
+        let initialRendering = host.rendering.value
+
+        var emitReentrantEvent = false
+
+        let renderExpectation = expectation(description: "render")
+        renderExpectation.expectedFulfillmentCount = 2
+
+        host
+            .rendering
+            .signal
+            .take(during: lifetime)
+            .observeValues { val in
+                defer { renderExpectation.fulfill() }
+                defer { emitReentrantEvent = true }
+                guard !emitReentrantEvent else { return }
+
+                // In a prior implementation, this would check state local
+                // to the underlying EventPipe and defer event handling
+                // into the future. If the RunLoop was spun after that
+                // point, the action could attempt to be handled and an
+                // we'd hit a trap when sending a sink an action in an
+                // invalid state.
+                //
+                // 'Real world' code could hit this case as there are some
+                // UI bindings that fire when a rendering/output is updated
+                // that call into system API that do sometimes spin the
+                // RunLoop manually (e.g. stuff calling into WebKit).
+                initialRendering.sink.send(.event)
+                drainMainQueueBySpinningRunLoop()
+            }
+
+        // Send an event and cause a re-render
+        initialRendering.sink.send(.event)
+
+        waitForExpectations(timeout: 1)
     }
 }
 
@@ -114,6 +168,35 @@ extension WorkflowHostTests {
 }
 
 // MARK: Utility Types
+
+extension WorkflowHost_EventEmissionTests {
+    struct ReentrancyWorkflow: Workflow {
+        typealias State = Void
+        typealias Output = Never
+
+        struct Rendering {
+            var sink: Sink<Action>!
+        }
+
+        func render(state: Void, context: RenderContext<Self>) -> Rendering {
+            let sink = context.makeSink(of: Action.self)
+            return Rendering(sink: sink)
+        }
+
+        enum Action: WorkflowAction {
+            typealias WorkflowType = ReentrancyWorkflow
+
+            case event
+
+            func apply(
+                toState state: inout WorkflowType.State,
+                context: ApplyContext<WorkflowType>
+            ) -> WorkflowType.Output? {
+                nil
+            }
+        }
+    }
+}
 
 extension WorkflowHost_EventEmissionTests {
     struct Parent: Workflow {
@@ -180,5 +263,15 @@ extension WorkflowHost_EventEmissionTests {
                 .eventOccurred
             }
         }
+    }
+}
+
+private func drainMainQueueBySpinningRunLoop(timeoutSeconds: UInt = 1) {
+    var done = false
+    DispatchQueue.main.async { done = true }
+
+    let deadline = ContinuousClock.now + .seconds(timeoutSeconds)
+    while !done, ContinuousClock.now < deadline {
+        RunLoop.current.run(until: .now.addingTimeInterval(0.01))
     }
 }

--- a/Workflow/Tests/WorkflowHostTests.swift
+++ b/Workflow/Tests/WorkflowHostTests.swift
@@ -101,7 +101,13 @@ final class WorkflowHost_EventEmissionTests: XCTestCase {
     }
 
     func test_reentrant_event_during_render() {
-        let host = WorkflowHost(workflow: ReentrancyWorkflow())
+        let host = Runtime.withConfiguration { cfg in
+            // Test will only pass with the 'SinkEventHandler' enabled
+            cfg.useSinkEventHandler = true
+        } operation: {
+            WorkflowHost(workflow: ReentrancyWorkflow())
+        }
+
         let (lifetime, token) = ReactiveSwift.Lifetime.make()
         defer { _ = token }
         let initialRendering = host.rendering.value
@@ -190,10 +196,14 @@ struct WorkflowHost_SinkEventHandlerTests {
             receivedActionCount += 1
         }
 
-        let host = WorkflowHost(
-            workflow: StateTransitioningWorkflow(),
-            observers: [observer]
-        )
+        let host = Runtime.withConfiguration { cfg in
+            cfg.useSinkEventHandler = true
+        } operation: {
+            WorkflowHost(
+                workflow: StateTransitioningWorkflow(),
+                observers: [observer]
+            )
+        }
 
         let rendering = host.rendering.value
 
@@ -235,10 +245,14 @@ struct WorkflowHost_SinkEventHandlerTests {
     func enqueuesEventsDuringEventHandling() async throws {
         let observer = TestObserver()
 
-        let host = WorkflowHost(
-            workflow: StateTransitioningWorkflow(),
-            observers: [observer]
-        )
+        let host = Runtime.withConfiguration { cfg in
+            cfg.useSinkEventHandler = true
+        } operation: {
+            WorkflowHost(
+                workflow: StateTransitioningWorkflow(),
+                observers: [observer]
+            )
+        }
 
         let rendering = host.rendering.value
         let eventHandler = host.sinkEventHandler

--- a/Workflow/Tests/WorkflowHostTests.swift
+++ b/Workflow/Tests/WorkflowHostTests.swift
@@ -15,6 +15,7 @@
  */
 
 import ReactiveSwift
+import Testing
 import XCTest
 
 @_spi(WorkflowRuntimeConfig) @testable import Workflow
@@ -167,6 +168,122 @@ extension WorkflowHostTests {
     }
 }
 
+// MARK: SinkEventHandler
+
+@MainActor
+@Suite
+struct WorkflowHost_SinkEventHandlerTests {
+    @Test
+    func correctStateAfterInit() {
+        let workflow = StateTransitioningWorkflow()
+        let host = WorkflowHost(workflow: workflow)
+
+        #expect(host.sinkEventHandler.state == .ready)
+    }
+
+    @Test
+    func enqueuesEventsDuringUpdate() async throws {
+        let observer = TestObserver()
+
+        var receivedActionCount = 0
+        observer.onDidReceiveAction = { _, _, _ in
+            receivedActionCount += 1
+        }
+
+        let host = WorkflowHost(
+            workflow: StateTransitioningWorkflow(),
+            observers: [observer]
+        )
+
+        let rendering = host.rendering.value
+
+        let eventHandler = host.sinkEventHandler
+        #expect(eventHandler.state == .ready)
+
+        var handlerStatesDuringUpdate: [SinkEventHandler.State] = []
+        observer.onDidChange = { _, _, _, _ in
+            handlerStatesDuringUpdate.append(eventHandler.state)
+        }
+
+        var handlerStatesDuringRender: [SinkEventHandler.State] = []
+        var emitOnce: (() -> Void)? = { rendering.toggle() }
+        observer.onWillRender = { _, _, _ in
+            handlerStatesDuringRender.append(eventHandler.state)
+            if let emit = emitOnce.take() {
+                // emit an event once – we expect it to be enqueued
+                emit()
+            }
+            return nil
+        }
+
+        host.update(workflow: StateTransitioningWorkflow())
+
+        #expect(handlerStatesDuringUpdate == [.busy])
+        #expect(handlerStatesDuringRender == [.busy])
+
+        // reentrant event should have been sent & queued
+        #expect(emitOnce == nil)
+        #expect(receivedActionCount == 0)
+
+        await drainMainQueue()
+
+        // reentrant event should have been handled
+        #expect(receivedActionCount == 1)
+    }
+
+    @Test
+    func enqueuesEventsDuringEventHandling() async throws {
+        let observer = TestObserver()
+
+        let host = WorkflowHost(
+            workflow: StateTransitioningWorkflow(),
+            observers: [observer]
+        )
+
+        let rendering = host.rendering.value
+        let eventHandler = host.sinkEventHandler
+
+        var didEmit = false
+        let emitActionOnce = {
+            var emitToggle: (() -> Void)? = { rendering.toggle() }
+            return {
+                guard let emit = emitToggle.take() else { return }
+                didEmit = true
+                emit()
+            }
+        }()
+
+        var receivedActionCount = 0
+        var handlerStatesOnExternalAction: [SinkEventHandler.State] = []
+        observer.onDidReceiveAction = { _, _, _ in
+            receivedActionCount += 1
+            handlerStatesOnExternalAction.append(eventHandler.state)
+        }
+
+        // emit a reentrant action during action
+        observer.onApplyAction = { _, _, _, _ in
+            emitActionOnce()
+            return nil
+        }
+
+        #expect(eventHandler.state == .ready)
+
+        // emit a 'normal' event, which the observer will
+        // see and emit a second one
+        rendering.toggle()
+
+        #expect(didEmit == true)
+        #expect(receivedActionCount == 1) // only the first processed so far
+        #expect(handlerStatesOnExternalAction == [.busy])
+
+        await drainMainQueue()
+
+        // reentrant event should have been handled
+        #expect(receivedActionCount == 2)
+        #expect(handlerStatesOnExternalAction == [.busy, .busy])
+    }
+}
+
 // MARK: Utility Types
 
 extension WorkflowHost_EventEmissionTests {
@@ -263,15 +380,5 @@ extension WorkflowHost_EventEmissionTests {
                 .eventOccurred
             }
         }
-    }
-}
-
-private func drainMainQueueBySpinningRunLoop(timeoutSeconds: UInt = 1) {
-    var done = false
-    DispatchQueue.main.async { done = true }
-
-    let deadline = ContinuousClock.now + .seconds(timeoutSeconds)
-    while !done, ContinuousClock.now < deadline {
-        RunLoop.current.run(until: .now.addingTimeInterval(0.01))
     }
 }

--- a/Workflow/Tests/WorkflowObserverTests.swift
+++ b/Workflow/Tests/WorkflowObserverTests.swift
@@ -609,53 +609,6 @@ extension WorkflowObserverTests {
 
 // MARK: - Utilities
 
-private final class TestObserver: WorkflowObserver {
-    var onSessionBegan: ((WorkflowSession) -> Void)?
-    var onSessionEnded: ((WorkflowSession) -> Void)?
-    /// (Workflow, State, Session) -> Void
-    var onDidMakeInitialState: ((Any, Any, WorkflowSession) -> Void)?
-    /// (Workflow, State, Session) -> ((Rendering) -> Void)?
-    var onWillRender: ((Any, Any, WorkflowSession) -> ((Any) -> Void)?)?
-    /// (Workflow [old], Workflow [new], State, Session) -> Void
-    var onDidChange: ((Any, Any, Any, WorkflowSession) -> Void)?
-    /// (Action, Workflow, Session) -> Void
-    var onDidReceiveAction: ((Any, Any, WorkflowSession) -> Void)?
-    /// (Action, Workflow, State, Session) -> ((State, Output?) -> Void)?
-    var onApplyAction: ((Any, Any, Any, WorkflowSession) -> ((Any, Any) -> Void)?)?
-
-    func sessionDidBegin(_ session: WorkflowSession) {
-        onSessionBegan?(session)
-    }
-
-    func sessionDidEnd(_ session: WorkflowSession) {
-        onSessionEnded?(session)
-    }
-
-    func workflowDidMakeInitialState<WorkflowType>(
-        _ workflow: WorkflowType,
-        initialState: WorkflowType.State,
-        session: WorkflowSession
-    ) where WorkflowType: Workflow {
-        onDidMakeInitialState?(workflow, initialState, session)
-    }
-
-    func workflowWillRender<WorkflowType>(_ workflow: WorkflowType, state: WorkflowType.State, session: WorkflowSession) -> ((WorkflowType.Rendering) -> Void)? where WorkflowType: Workflow {
-        onWillRender?(workflow, state, session)
-    }
-
-    func workflowDidChange<WorkflowType>(from oldWorkflow: WorkflowType, to newWorkflow: WorkflowType, state: WorkflowType.State, session: WorkflowSession) where WorkflowType: Workflow {
-        onDidChange?(oldWorkflow, newWorkflow, state, session)
-    }
-
-    func workflowDidReceiveAction<Action: WorkflowAction>(_ action: Action, workflow: Action.WorkflowType, session: WorkflowSession) {
-        onDidReceiveAction?(action, workflow, session)
-    }
-
-    func workflowWillApplyAction<Action: WorkflowAction>(_ action: Action, workflow: Action.WorkflowType, state: Action.WorkflowType.State, session: WorkflowSession) -> ((Action.WorkflowType.State, Action.WorkflowType.Output?) -> Void)? {
-        onApplyAction?(action, workflow, state, session)
-    }
-}
-
 private struct Child: Workflow {
     var prop: String
 


### PR DESCRIPTION
#### Terminology

1. `Sink`: public action handler type vended out to client code. these are the primary channel through which events from the 'outside world' are sent into a Workflow runtime. is a value type that wraps a (weak) reference to internal event handling infrastructure.
1. `ReusableSink`: internal action handler type that receives actions forwarded through from `Sink`s. it is a reference type that is weakly referenced by `Sink`s.
1. `EventPipe`: internal action handler type that implements an event handling state machine. it is a reference type that is owned by either a `ReusableSink` to propagate 'outside' events, or by a `SubtreeManager` to propagate outputs from child workflows.
1. `SubtreeManager`: type that coordinates interactions between a workflow node, its children, and the 'outside world'.

#### Background

the current event handling system in Workflow tracks event processing state locally – each node has a 'subtree manager' which is responsible for orchestrating interactions with both child workflow outputs and events from the 'outside world' sent to the corresponding node. each `SubtreeManager` coordinates a collection of 'event pipes' which handle event propagation; the 'outside world' has (indirect) access to them via 'sinks', and child workflow's communicate 'up' to their parents through `EventPipe` instances. these event pipes also encode the state machine transitions for event handling – if they're sent events in an invalid state they will generally halt the program.

the `EventPipe` state machine consists of the following states:

1. `preparing`: the pipe has been created, but this state indicates a call to the corresponding node's `render()` method is still ongoing.
1. `pending`: the corresponding node's `render()` method is complete, but the full 'render pass' over the entire tree may not yet be.
1. `enabled`: the tree's render pass is finished, and the event pipe is valid to use. this state has a corresponding event handler closure that can be invoked when handling an event.
1. `invalid`: the event pipe is no longer valid to use. a node's event pipes are invalidated as one of the first parts of a render pass.

the currently expected state transitions are:

1. <none> -> `preparing`
    - `preparing` is the initial state
1. `preparing` -> `pending`
    - after a node finishes `render()`
1. `pending` -> `enabled`
    - after the tree finishes a render pass
1. `enabled` -> `invalid`
    - when a node is about to be re-rendered[^1]

[^1]: as an aside, it's reasonable to wonder if we may be allowing nodes to 'linger on' without invalidating their event handling infrastructure appropriately. what happens if a node is rendered in one pass and not rendered in the next? i think in most cases it just deallocates and so implicitly ends up ignoring any subsequent events, but... would probably be good to verify that and formalize what should be happening...

the way the current event pipe state machine works is:

1. during a render pass, every node gets new event pipes created, initially in the `preparing` state. any existing event pipes are set to the `invalid` state.
1. after a node is rendered, the event pipes that were created for that pass are moved to the `pending` state.
1. after a render pass is 'complete' and any Output and a new Rendering have been emitted, the nodes in the tree are walked and all event pipes are moved to the `enabled` state and hooked up with the right callbacks to invoke when they're sent events.

some additional notes about the current implementation:

1. a number of invalid state transitions are banned outright and will cause a runtime trap if attempted.
1. the `ReusableSink` type contains logic to attempt to detect certain forms of reentrancy. specifically it will check if the event pipe state is `pending` and if it is, will enqueue the forwarding of the event into the future.
1. there is some limited reentrancy detection implemented when event pipes in the `invalid` state are reentrantly messaged.

#### Issue

the existing implementation seems to have generally worked reasonably well in practice, but there are cases when it falls down. in particular, two problematic cases that have been seen 'in the wild' are:

1. reentrant action emissions from synchronous side effects. perhaps the 'canonical' example of this is when an action is being processed that, during processing, leads to a change in `UIResponder` state (.e.g `resignFirstResponder()` is called), and some _other_ part of the Workflow tree responds to that change by emitting another action.

1. APIs that do manual `RunLoop` spinning, leading to reentrant action handling. one instance of this we've seen is when the UI layer responds to a new rendering by deriving an attributed string from HTML via some the `UIKit` extension methods it can end up spinning the main thread's run loop waiting for `WebKit` to do HTML processing, and if there are other Workflow events that have been enqueued they will cause the runtime to attempt to reentrantly process an event (generally leading to a `fatalError()`).

as the existing implementation models the event handling state machine at the node level, it seems ill-equipped to deal with this problem holistically since the 'is the tree currently processing an event' bit of information is inherently a tree-level fact. we could try to augment the existing code with a state that represents 'the runtime is currently handling an event', but that seems somewhat awkward to fit into the existing model since a node would have to walk to the root and then update the whole tree with this new state[^2].

[^2]: except maybe _not_ the path from node to root? see, it seems kind of awkward...

#### Proposed Solution

in this PR, the approach taken to solve this is:

- introduce a new `SinkEventHandler` type to track tree-level event processing state
- plumb a new callback closure through the tree down to the `ReusableSink` instances (which are responsible for forwarding 'external' events into the `EventPipe` machinery)
    - the new callback takes two parameters: a closure to be immediately invoked if there is no event currently being handled, and a closure to be enqueued and called in the future if there is.
- the callback implementation checks the current state and either invokes the 'run now' closure (adjusting processing state as appropriate) or enqueues the 'run later' closure.

#### Alternatives

i also drafted a more minimal change to address the new test case that i added which simulates the 'spinning the run loop during a render pass' problem in https://github.com/square/workflow-swift/pull/379. instead of changing the plumbing and adding tree-level state tracking, it just changes how the enqueing logic in the `ReusableSink` implementation works. previously the enqueuing logic would defer handling and unconditionally forward the event through after the async block was processed. after the change, the method becomes fully recursive, so will check whether the original action should be enqueued again. while this approach requires changing less code, it is also less of a 'real' fix, as it won't solve cases in which someone, say, emits a second sink event targeting an ancestor node in the tree while a first sink event is being handled.

---

#### Updates

after initial feedback, made the following changes:

- made the new event handling behavior conditional and added a `RuntimeConfig` value to opt into it
- added a queue precondition check into the new `ReusableSink` event handling logic
- removed the `initializing` state from `SinkEventHandler` in favor of just 'busy' and 'ready'
- added a mechanism to explicitly enter the `busy` state while invoking a block so that the `WorkflowHost` can update the root node and ensure no event handling can synchronously occur during that process
- added several new test cases (and minor refactoring of existing test utilities)
