### PR TITLE
feat: Enable use of WorkflowCombineTesting without specifying a concrete Publisher type

### DIFF
--- a/WorkflowCombine/Sources/PublisherWorkflow.swift
+++ b/WorkflowCombine/Sources/PublisherWorkflow.swift
@@ -20,15 +20,14 @@ import Combine
 import Foundation
 import Workflow
 
-struct PublisherWorkflow<WorkflowPublisher: Publisher>: Workflow where WorkflowPublisher.Failure == Never {
-    typealias Output = WorkflowPublisher.Output
+struct PublisherWorkflow<Output>: Workflow {
     typealias State = Void
     typealias Rendering = Void
 
-    let publisher: WorkflowPublisher
+    let publisher: AnyPublisher<Output, Never>
 
-    init(publisher: WorkflowPublisher) {
-        self.publisher = publisher
+    init<WorkflowPublisher: Publisher>(publisher: WorkflowPublisher) where WorkflowPublisher.Failure == Never, WorkflowPublisher.Output == Output {
+        self.publisher = publisher.eraseToAnyPublisher()
     }
 
     func render(state: State, context: RenderContext<Self>) -> Rendering {

--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -28,16 +28,14 @@ extension RenderTester {
     /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
     ///
     /// - Parameters:
-    ///   - publisher: Type of the Publisher-based Workflow to expect
     ///   - producingOutput: An output that will be returned when this worker is requested, if any.
     ///   - key: Key to expect this `Workflow` to be rendered with.
-    public func expect<PublisherType: Publisher>(
-        publisher: PublisherType.Type,
-        producingOutput output: PublisherType.Output? = nil,
+    public func expectPublisher<Output>(
+        producingOutput output: Output? = nil,
         key: String = ""
-    ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
+    ) -> RenderTester<WorkflowType> {
         expectWorkflow(
-            type: PublisherWorkflow<PublisherType>.self,
+            type: PublisherWorkflow<Output>.self,
             key: key,
             producingRendering: (),
             producingOutput: output,
@@ -45,7 +43,30 @@ extension RenderTester {
         )
     }
 
-    @available(*, deprecated, renamed: "expect(publisher:producingOutput:key:)")
+    /// Expect a `Publisher`-based Workflow.
+    ///
+    /// `PublisherWorkflow` is used to subscribe to `Publisher`s.
+    ///
+    /// - Parameters:
+    ///   - publisher: Type of the Publisher-based Workflow to expect
+    ///   - producingOutput: An output that will be returned when this worker is requested, if any.
+    ///   - key: Key to expect this `Workflow` to be rendered with.
+    @available(*, deprecated, message: "Use expectPublisher(producingOutput:key:) instead")
+    public func expect<PublisherType: Publisher>(
+        publisher: PublisherType.Type,
+        producingOutput output: PublisherType.Output? = nil,
+        key: String = ""
+    ) -> RenderTester<WorkflowType> where PublisherType.Failure == Never {
+        expectWorkflow(
+            type: PublisherWorkflow<PublisherType.Output>.self,
+            key: key,
+            producingRendering: (),
+            producingOutput: output,
+            assertions: { _ in }
+        )
+    }
+
+    @available(*, deprecated, message: "Use expectPublisher(producingOutput:key:) instead")
     public func expect<PublisherType: Publisher>(
         publisher: PublisherType.Type,
         output: PublisherType.Output,

--- a/WorkflowCombine/TestingTests/PublisherTests.swift
+++ b/WorkflowCombine/TestingTests/PublisherTests.swift
@@ -22,6 +22,14 @@ class PublisherTests: XCTestCase {
                 key: "123"
             )
             .render {}
+
+        TestWorkflow()
+            .renderTester()
+            .expectPublisher(
+                producingOutput: 1,
+                key: "123"
+            )
+            .render {}
     }
 
     func test_publisher_no_output() {
@@ -30,6 +38,15 @@ class PublisherTests: XCTestCase {
             .expect(
                 publisher: Publishers.Sequence<[Int], Never>.self,
                 producingOutput: nil,
+                key: "123"
+            )
+            .render {}
+            .assertNoAction()
+
+        TestWorkflow()
+            .renderTester()
+            .expectPublisher(
+                producingOutput: Int?.none,
                 key: "123"
             )
             .render {}


### PR DESCRIPTION
## Changes

* Add `expectPublisher(producingOutput:key:)` API that is generic only over the output of the publisher rather 
* Update `PublisherWorkflow` to only be generic over the output rather than the Publisher type

## Rationale

The current API shape requires that tests pass in a concrete `Publisher` type. This can be quite tedious depending on the context, resulting in having to pass in types like `Publishers.Map<AnyPublisher<Bool, Never>, AnyWorkflowAction<SomeWorkflow>>>`.

This differs from `WorkflowReactiveSwift`, for example, which has a workflow that is only [generic over the output](https://github.com/square/workflow-swift/blob/88db7f0267814343e35e40868f568ae3c348b4cc/WorkflowReactiveSwift/Sources/SignalProducerWorkflow.swift#L45) and has an `expect` API that [only requires providing the output type](https://github.com/square/workflow-swift/blob/88db7f0267814343e35e40868f568ae3c348b4cc/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift#L35-L36)

## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
