### PR TITLE
Update CI Xcode and macOS

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,14 +8,12 @@ on:
     branches: [ main ]
 
 env:
-  # Xcode 16.3 gets us Swift 6.1, required for docc merge
-  XCODE_VERSION: 16.3
+  XCODE_VERSION: 26.3
 
 jobs:
   build:
     name: Generate API docs and publish to GitHub pages
-    # macos-15 is required for Xcode 16.3
-    runs-on: macos-15
+    runs-on: macos-26
 
     permissions:
       # Needed to push to gh-pages branch

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -11,7 +11,7 @@ on:
   pull_request:
 
 env:
-  XCODE_VERSION: 16.4.0
+  XCODE_VERSION: 26.3
   TUIST_TEST_DEVICE: iPad (10th generation)
   TUIST_TEST_PLATFORM: iOS
 
@@ -22,7 +22,7 @@ env:
 
 jobs:
   development-tests:
-    runs-on: macos-15
+    runs-on: macos-26
 
     name: "development-tests [iOS ${{ matrix.sdk }}]"
 
@@ -41,8 +41,8 @@ jobs:
             simctl_runtime: "com.apple.CoreSimulator.SimRuntime.iOS-17-5"
             installation_required: true
 
-          - sdk: "18.5"
-            simctl_runtime: "com.apple.CoreSimulator.SimRuntime.iOS-18-5"
+          - sdk: "26.2"
+            simctl_runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-2"
             installation_required: false
 
     steps:
@@ -54,7 +54,9 @@ jobs:
 
     - name: Install iOS ${{ matrix.sdk }}
       if: ${{ matrix.installation_required }}
-      run: sudo xcodes runtimes install "iOS ${{ matrix.sdk }}"
+      run: |
+        sudo xcodes runtimes install "iOS ${{ matrix.sdk }}"
+        xcrun simctl list
 
     - name: Ensure sim exists
       run: |
@@ -69,16 +71,22 @@ jobs:
     - name: Run Tests
       run: tuist test --path Samples ${{ matrix.scheme }} --os "${{ matrix.sdk }}"
 
-  # FIXME: these should probably be run with a matrix too
   snapshot-tests:
-    runs-on: macos-15
+    runs-on: macos-26
 
     env:
-      TUIST_TEST_OS: 18.5
+      TUIST_TEST_OS: 26.2
       TUIST_TEST_SCHEME: SnapshotTests
+
+    name: "snapshot-tests [iOS ${{ matrix.sdk }}]"
 
     strategy:
       fail-fast: false # Don’t fail-fast so that we get all snapshot test changes
+      matrix:
+        include:
+          - sdk: "26.2"
+            simctl_runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-2"
+            installation_required: false
 
     steps:
     - uses: actions/checkout@v4
@@ -87,6 +95,19 @@ jobs:
     - name: Switch Xcode
       run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
+    - name: Install iOS ${{ matrix.sdk }}
+      if: ${{ matrix.installation_required }}
+      run: |
+        sudo xcodes runtimes install "iOS ${{ matrix.sdk }}"
+        xcrun simctl list
+
+    - name: Ensure sim exists
+      run: |
+        xcrun simctl create \
+          "${{ env.TUIST_TEST_DEVICE }}" \
+          "${{ env.TUIST_TEST_DEVICE }}" \
+          "${{ matrix.simctl_runtime }}"
+
     - name: Install dependencies
       run: tuist install --path Samples
 
@@ -94,7 +115,7 @@ jobs:
       run: tuist test --path Samples
 
   package-tests:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - uses: actions/checkout@v4
@@ -102,13 +123,24 @@ jobs:
     - name: Switch Xcode
       run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
+    - name: Clear cache
+      run: swift package clean
+
+    # Workaround for https://github.com/swiftlang/swift-package-manager/issues/9495
+    - name: Setup SwiftSyntax
+      run: |
+        swift package edit swift-syntax
+        swift build --triple arm64-darwin-macosx --build-tests --jobs 2
+
     # Command line swift runs on the host platform.
     # On macOS we can run macro tests.
     - name: Test macOS
       run: swift test
 
   tutorial:
-    runs-on: macos-15
+    runs-on: macos-26
+    env:
+      TUIST_TEST_DEVICE: iPad Air 11-inch (M3)
 
     steps:
     - uses: actions/checkout@v4
@@ -124,7 +156,7 @@ jobs:
       run: tuist test --path Samples/Tutorial TutorialTests
 
   swiftformat:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
     - uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "7.1.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.6.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0" ..< "601.0.0-prerelease"),
-        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.5"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "601.0.0"),
+        .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.7.3"),
         .package(url: "https://github.com/pointfreeco/swift-identified-collections", from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.4.0"),
         .package(url: "https://github.com/pointfreeco/swift-perception", "1.5.0" ..< "3.0.0"),

--- a/WorkflowSwiftUI/Sources/Store.swift
+++ b/WorkflowSwiftUI/Sources/Store.swift
@@ -402,7 +402,7 @@ extension Store {
             endIndex: models.endIndex
         ) { index in
             self.scope(
-                key: collection.appending(path: \.[_offset: index]),
+                key: collection.appending(path: \.[index]),
                 getModel: { model in
                     model[keyPath: collection][index]
                 },


### PR DESCRIPTION
Changes:
* Bump CI runners to `macos-26`
* Bump Xcode version used on CI to `26.3`
* Bump SwiftSyntax, `swift-case-paths` to work around compiler crashes