### PR TITLE
Gate Perception suppression to debug

### DIFF
--- a/Samples/Tuist/Package.resolved
+++ b/Samples/Tuist/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "41b89b8b68d8c56c622dbb7132258f1a3e638b25",
-        "version" : "1.7.0"
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "2bc86522d115234d1f588efe2bcb4ce4be8f8b82",
-        "version" : "510.0.3"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {

--- a/WorkflowSwiftUI/Sources/Store.swift
+++ b/WorkflowSwiftUI/Sources/Store.swift
@@ -57,7 +57,7 @@ public final class Store<Model: ObservableModel>: Perceptible {
         }
     }
 
-    /// Reads a value from the state, suppressing Perception's runtime warning on iOS 17+.
+    /// Suppresses Perception's debug-only runtime warning on iOS 17+.
     ///
     /// On iOS 17+, `Store` conforms to `Observable` and SwiftUI's native observation tracks state
     /// access. However, `PerceptionRegistrar.access` resolves to the `Perceptible` overload at
@@ -67,16 +67,22 @@ public final class Store<Model: ObservableModel>: Perceptible {
     /// tracking the access. `WithPerceptionTracking` does not suppress the warning either, because
     /// binding getters and child store scoping are evaluated by SwiftUI's attribute graph outside
     /// of the `WithPerceptionTracking` closure. Setting `skipPerceptionChecking` directly bypasses
-    /// the `check()` gate on iOS 17+ while preserving the warning on earlier OS versions.
-    private func readState<T>(keyPath: KeyPath<State, T>) -> T {
-        #if canImport(Observation)
+    /// the debug-only `check()` gate on iOS 17+ while preserving the warning on earlier OS
+    /// versions.
+    private func withPerceptionCheckSuppressed<T>(_ operation: () -> T) -> T {
+        #if DEBUG && canImport(Observation)
         if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-            return _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
-                state[keyPath: keyPath]
-            }
+            return _PerceptionLocals.$skipPerceptionChecking.withValue(true, operation: operation)
         }
         #endif
-        return state[keyPath: keyPath]
+        return operation()
+    }
+
+    /// Reads a value from the state, suppressing Perception's debug-only runtime warning on iOS 17+.
+    private func readState<T>(keyPath: KeyPath<State, T>) -> T {
+        withPerceptionCheckSuppressed {
+            state[keyPath: keyPath]
+        }
     }
 
     fileprivate func setModel(_ newModel: Model) {
@@ -237,24 +243,17 @@ extension Store {
 
     /// Track access to a child store wrapper.
     ///
-    /// On iOS 17+, `skipPerceptionChecking` is set for the same reason as ``readState(keyPath:)``
-    /// — the `Perceptible` overload is selected at compile time and fires a false-positive warning.
+    /// On iOS 17+, `skipPerceptionChecking` is set for the same reason as
+    /// ``readState(keyPath:)`` — the `Perceptible` overload is selected at compile time and fires
+    /// a false-positive warning in debug builds.
     func access(
         keyPath key: KeyPath<Model, some Any>,
         isChanged: @escaping (Model, Model) -> Bool,
         isInvalid: @escaping (Model) -> Bool = { _ in false }
     ) {
-        #if canImport(Observation)
-        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-            _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
-                _$observationRegistrar.access(self, keyPath: (\Store.model).appending(path: key))
-            }
-        } else {
+        withPerceptionCheckSuppressed {
             _$observationRegistrar.access(self, keyPath: (\Store.model).appending(path: key))
         }
-        #else
-        _$observationRegistrar.access(self, keyPath: (\Store.model).appending(path: key))
-        #endif
         if childModelAccesses[key] == nil {
             childModelAccesses[key] = ChildModelAccess(
                 keyPath: key,

--- a/WorkflowSwiftUI/Tests/StoreTests.swift
+++ b/WorkflowSwiftUI/Tests/StoreTests.swift
@@ -944,6 +944,45 @@ final class StoreTests: XCTestCase {
         await fulfillment(of: [childAgeDidChange], timeout: 0)
         XCTAssertEqual(childState.age, 1)
     }
+
+    @MainActor
+    func test_nativeOptionalChildStoreObservation() async throws {
+        guard #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) else {
+            throw XCTSkip("Requires iOS 17+")
+        }
+
+        var childState = ParentModel.ChildState(age: 0)
+        let childModel = StateAccessor(state: childState) { update in
+            update(&childState)
+        }
+
+        var model = ParentModel(
+            accessor: StateAccessor(state: State()) { _ in
+                XCTFail("parent state should not be mutated")
+            },
+            child: StateAccessor(state: .init()) { _ in
+                XCTFail("child state should not be mutated")
+            },
+            array: [],
+            identified: []
+        )
+        model.optional = childModel
+
+        let (store, setModel) = Store.make(model: model)
+
+        let optionalDidChange = expectation(description: "optional.didChange")
+        withObservationTracking {
+            // Reading the optional wrapper exercises Store.access(...).
+            _ = store.optional
+        } onChange: {
+            optionalDidChange.fulfill()
+        }
+
+        model.optional = nil
+        setModel(model)
+
+        await fulfillment(of: [optionalDidChange], timeout: 0)
+    }
 }
 
 @ObservableState


### PR DESCRIPTION
This PR builds on the changes from https://github.com/square/workflow-swift/pull/389.

## Summary
- gate `skipPerceptionChecking` behind `#if DEBUG` via a shared helper
- apply the debug-only suppression to both `readState` and child-wrapper `access(...)`
- add `test_nativeOptionalChildStoreObservation` so native observation covers the wrapper path through `Store.access(...)`
- include the updated `Samples/Tuist/Package.resolved`

## Why
Perception only consults `skipPerceptionChecking` from its debug-only checking path, so release builds do not need the TaskLocal wrapper. The new native optional-wrapper test closes the coverage gap in the path that motivated the original suppression.

## Test plan
- [x] Ensure the new test passes
- [x] Look for regressions on the `ObservableComposition` app.