### PR TITLE
Remove XCTest dependency from testing modules and convert tests to Swift Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,8 +82,7 @@ let package = Package(
                 .product(name: "CustomDump", package: "swift-custom-dump"),
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
             ],
-            path: "WorkflowTesting/Sources",
-            linkerSettings: [.linkedFramework("XCTest")]
+            path: "WorkflowTesting/Sources"
         ),
 
         // MARK: WorkflowUI
@@ -139,8 +138,7 @@ let package = Package(
         .target(
             name: "WorkflowReactiveSwiftTesting",
             dependencies: ["WorkflowReactiveSwift", "WorkflowTesting"],
-            path: "WorkflowReactiveSwift/Testing",
-            linkerSettings: [.linkedFramework("XCTest")]
+            path: "WorkflowReactiveSwift/Testing"
         ),
 
         // MARK: WorkflowRxSwift
@@ -160,8 +158,7 @@ let package = Package(
                 "WorkflowTesting",
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
             ],
-            path: "WorkflowRxSwift/Testing",
-            linkerSettings: [.linkedFramework("XCTest")]
+            path: "WorkflowRxSwift/Testing"
         ),
 
         // MARK: WorkflowCombine
@@ -178,8 +175,7 @@ let package = Package(
                 "WorkflowTesting",
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
             ],
-            path: "WorkflowCombine/Testing",
-            linkerSettings: [.linkedFramework("XCTest")]
+            path: "WorkflowCombine/Testing"
         ),
 
         // MARK: WorkflowConcurrency
@@ -196,8 +192,7 @@ let package = Package(
                 "WorkflowTesting",
                 .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
             ],
-            path: "WorkflowConcurrency/Testing",
-            linkerSettings: [.linkedFramework("XCTest")]
+            path: "WorkflowConcurrency/Testing"
         ),
 
         // MARK: ViewEnvironment

--- a/WorkflowCombine/Testing/PublisherTesting.swift
+++ b/WorkflowCombine/Testing/PublisherTesting.swift
@@ -19,7 +19,6 @@
 import Combine
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowCombine
 
 extension RenderTester {

--- a/WorkflowCombine/Testing/WorkerTesting.swift
+++ b/WorkflowCombine/Testing/WorkerTesting.swift
@@ -18,7 +18,6 @@
 import IssueReporting
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowCombine
 
 extension RenderTester {

--- a/WorkflowConcurrency/Testing/WorkerTesting.swift
+++ b/WorkflowConcurrency/Testing/WorkerTesting.swift
@@ -18,7 +18,6 @@
 import IssueReporting
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowConcurrency
 
 extension RenderTester {

--- a/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
+++ b/WorkflowReactiveSwift/Testing/SignalProducerWorkflowTesting.swift
@@ -17,7 +17,6 @@
 #if DEBUG
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowReactiveSwift
 
 extension RenderTester {

--- a/WorkflowReactiveSwift/Testing/WorkerTesting.swift
+++ b/WorkflowReactiveSwift/Testing/WorkerTesting.swift
@@ -18,7 +18,6 @@
 import IssueReporting
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowReactiveSwift
 
 extension RenderTester {

--- a/WorkflowRxSwift/Testing/ObservableTesting.swift
+++ b/WorkflowRxSwift/Testing/ObservableTesting.swift
@@ -17,7 +17,6 @@
 #if DEBUG
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowRxSwift
 
 extension RenderTester {

--- a/WorkflowRxSwift/Testing/WorkerTesting.swift
+++ b/WorkflowRxSwift/Testing/WorkerTesting.swift
@@ -18,7 +18,6 @@
 import IssueReporting
 import Workflow
 import WorkflowTesting
-import XCTest
 @testable import WorkflowRxSwift
 
 extension RenderTester {

--- a/WorkflowTesting/Sources/Internal/AppliedAction.swift
+++ b/WorkflowTesting/Sources/Internal/AppliedAction.swift
@@ -16,7 +16,6 @@
 
 import IssueReporting
 import Workflow
-import XCTest
 
 struct AppliedAction<WorkflowType: Workflow> {
     let erasedAction: Any

--- a/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
+++ b/WorkflowTesting/Sources/Internal/RenderTester+TestContext.swift
@@ -17,7 +17,6 @@
 #if DEBUG
 
 import IssueReporting
-import XCTest
 
 @testable import Workflow
 

--- a/WorkflowTesting/Sources/RenderTesterResult.swift
+++ b/WorkflowTesting/Sources/RenderTesterResult.swift
@@ -17,7 +17,6 @@
 import CustomDump
 import IssueReporting
 import Workflow
-import XCTest
 
 /// The result of a `RenderTester` rendering. Used to verify state, output, and actions that were produced as a result of
 /// actions performed during the render (such as child workflow output being produced).

--- a/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -16,7 +16,6 @@
 
 import CustomDump
 import IssueReporting
-import XCTest
 
 @testable import Workflow
 

--- a/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -19,7 +19,6 @@
 // `@testable import Workflow` will fail compilation in Release mode.
 #if DEBUG
 
-import XCTest
 @testable import Workflow
 
 extension Workflow {

--- a/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
@@ -15,92 +15,91 @@
  */
 
 import IssueReporting
+import Testing
 import Workflow
-import XCTest
-
 @testable import WorkflowTesting
 
-final class WorkflowActionTesterTests: XCTestCase {
-    func test_stateTransitions() {
+struct WorkflowActionTesterTests {
+    @Test func stateTransitions() {
         TestAction
             .tester(withState: false)
             .send(action: .toggleTapped)
-            .verifyState { XCTAssertTrue($0) }
+            .verifyState { #expect($0) }
     }
 
-    func test_stateTransitions_throw() throws {
+    @Test func stateTransitions_throw() throws {
         try TestAction
             .tester(withState: false)
             .send(action: .toggleTapped)
             .verifyState {
                 try throwingNoop()
-                XCTAssertTrue($0)
+                #expect($0)
             }
     }
 
-    func test_stateTransitions_equatable() {
+    @Test func stateTransitions_equatable() {
         TestAction
             .tester(withState: false)
             .send(action: .toggleTapped)
             .assert(state: true)
     }
 
-    func test_noOutputs() {
+    @Test func noOutputs() {
         TestAction
             .tester(withState: false)
             .send(action: .toggleTapped)
             .assertNoOutput()
     }
 
-    func test_outputs() {
+    @Test func outputs() {
         TestAction
             .tester(withState: false)
             .send(action: .exitTapped)
             .verifyOutput { output in
-                XCTAssertEqual(output, .finished)
+                #expect(output == .finished)
             }
     }
 
-    func test_outputs_throw() throws {
+    @Test func outputs_throw() throws {
         try TestAction
             .tester(withState: false)
             .send(action: .exitTapped)
             .verifyOutput { output in
                 try throwingNoop()
-                XCTAssertEqual(output, .finished)
+                #expect(output == .finished)
             }
     }
 
-    func test_outputs_equatable() {
+    @Test func outputs_equatable() {
         TestAction
             .tester(withState: false)
             .send(action: .exitTapped)
             .assert(output: .finished)
     }
 
-    func test_deprecated_methods() {
+    @Test func deprecated_methods() {
         TestAction
             .tester(withState: false)
             .send(action: .exitTapped)
             .assert(output: .finished)
             .verifyState { state in
-                XCTAssertFalse(state)
+                #expect(!state)
             }
     }
 
-    func test_testerExtension() {
+    @Test func erExtension() {
         let state = true
         let tester = TestAction
             .tester(withState: true)
-        XCTAssertEqual(state, tester.state)
-        XCTAssertNil(tester.output)
+        #expect(state == tester.state)
+        #expect(tester.output == nil)
     }
 }
 
 // MARK: - ApplyContext Tests
 
 extension WorkflowActionTesterTests {
-    func test_old_api_still_work_if_props_arent_read() {
+    @Test func old_api_still_work_if_props_arent_read() {
         TestActionWithProps
             .tester(withState: true)
             .send(action: .dontReadProps)
@@ -108,7 +107,7 @@ extension WorkflowActionTesterTests {
             .assert(output: .value("did not read props"))
     }
 
-    func test_new_api_works_if_you_provide_props() {
+    @Test func new_api_works_if_you_provide_props() {
         TestActionWithProps
             .tester(
                 withState: true,
@@ -119,7 +118,7 @@ extension WorkflowActionTesterTests {
             .assert(output: .value("read prop: 42"))
     }
 
-    func test_new_api_works_with_optional_props() {
+    @Test func new_api_works_with_optional_props() {
         TestActionWithProps
             .tester(
                 withState: true,
@@ -138,19 +137,14 @@ extension WorkflowActionTesterTests {
             .assert(state: true)
             .assert(output: .value("read optional prop: <nil>"))
     }
+}
 
-    // FIXME: ideally an 'exit/death test' would somehow be used for this...
-    /*
-     func test_old_api_explodes_if_accessing_through_apply_context() {
-         XCTExpectFailure("This test should fail")
+// withExpectedIssue records a known issue under Swift Testing, which
+// causes xcodebuild to exit with code 65. Keep this as XCTest until
+// that xcodebuild bug is resolved.
+import XCTest
 
-         TestActionWithProps
-             .tester(withState: true)
-             .send(action: .readProps)
-             .assert(state: true)
-     }
-      */
-
+final class WorkflowActionTesterExpectedFailureTests: XCTestCase {
     func test_old_api_errors_accessing_optional_through_apply_context_without_proper_setup() {
         withExpectedIssue("reading optional value through context without workflow should fail but not crash") {
             TestActionWithProps

--- a/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
+import IssueReporting
+import Testing
 import Workflow
 import WorkflowTesting
-import XCTest
 
-final class WorkflowRenderTesterTests: XCTestCase {
-    func test_render() {
+struct WorkflowRenderTesterTests {
+    @Test func render() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
         var testedAssertion = false
 
         renderTester
             .render { screen in
-                XCTAssertEqual("initial", screen.text)
+                #expect(screen.text == "initial")
                 testedAssertion = true
             }
             .assert(
@@ -35,36 +36,36 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 )
             )
 
-        XCTAssertTrue(testedAssertion)
+        #expect(testedAssertion)
     }
 
-    func test_simple_render() {
+    @Test func simple_render() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
 
         renderTester
             .render { screen in
-                XCTAssertEqual("initial", screen.text)
+                #expect(screen.text == "initial")
             }
             .assertNoAction()
     }
 
-    func test_simple_render_throw() throws {
+    @Test func simple_render_throw() throws {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
 
         try renderTester
             .render { screen in
-                let text = try XCTUnwrap(screen.text)
-                XCTAssertEqual("initial", text)
+                let text = try #require(screen.text)
+                #expect(text == "initial")
             }
             .assertNoAction()
     }
 
-    func test_action() {
+    @Test func action() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
 
         renderTester
             .render { screen in
-                XCTAssertEqual("initial", screen.text)
+                #expect(screen.text == "initial")
                 screen.tapped()
             }
             .assert(
@@ -75,7 +76,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
             )
     }
 
-    func test_sideEffects() {
+    @Test func sideEffects() {
         let renderTester = SideEffectWorkflow().renderTester()
 
         renderTester
@@ -87,7 +88,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .assert(state: .success)
     }
 
-    func test_output() {
+    @Test func output() {
         OutputWorkflow()
             .renderTester()
             .render { rendering in
@@ -96,7 +97,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
             .assert(output: .success)
     }
 
-    func test_ignoredOutput() {
+    @Test func ignoredOutput() {
         OutputIgnoringWorkflow(text: "hello")
             .renderTester()
             .expectWorkflowIgnoringOutput(
@@ -104,12 +105,12 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 producingRendering: "olleh"
             )
             .render { rendering in
-                XCTAssertEqual("olleh", rendering)
+                #expect(rendering == "olleh")
             }
             .assertNoOutput()
     }
 
-    func test_ignoredOutput_opaqueChild() {
+    @Test func ignoredOutput_opaqueChild() {
         OpaqueChildOutputIgnoringWorkflow(
             childProvider: {
                 OutputWorkflow()
@@ -123,11 +124,11 @@ final class WorkflowRenderTesterTests: XCTestCase {
             producingRendering: "test"
         )
         .render { rendering in
-            XCTAssertEqual(rendering, "test")
+            #expect(rendering == "test")
         }
     }
 
-    func test_opaqueChild() {
+    @Test func opaqueChild() {
         OpaqueChildWorkflow(
             childProvider: {
                 MockChildWorkflow().asAnyWorkflow()
@@ -139,11 +140,11 @@ final class WorkflowRenderTesterTests: XCTestCase {
             producingRendering: "test"
         )
         .render { rendering in
-            XCTAssertEqual(rendering, "test")
+            #expect(rendering == "test")
         }
     }
 
-    func test_childWorkflow() {
+    @Test func childWorkflow() {
         ParentWorkflow(initialText: "hello")
             .renderTester()
             .expectWorkflow(
@@ -151,12 +152,12 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 producingRendering: "olleh"
             )
             .render { rendering in
-                XCTAssertEqual("olleh", rendering)
+                #expect(rendering == "olleh")
             }
             .assertNoAction()
     }
 
-    func test_childWorkflowAction() {
+    @Test func childWorkflowAction() {
         ParentWorkflow(initialText: "hello")
             .renderTester()
             .expectWorkflow(
@@ -165,12 +166,11 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 producingOutput: ChildWorkflow.Output.success
             )
             .render { rendering in
-                XCTAssertEqual("olleh", rendering)
+                #expect(rendering == "olleh")
             }.assert(action: ParentWorkflow.Action.childSuccess)
     }
 
-    func test_childWorkflowOutput() {
-        // Test that a child emitting an output is handled as an action by the parent
+    @Test func childWorkflowOutput() {
         ParentWorkflow(initialText: "hello")
             .renderTester()
             .expectWorkflow(
@@ -179,11 +179,11 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 producingOutput: .failure
             )
             .render { rendering in
-                XCTAssertEqual("olleh", rendering)
+                #expect(rendering == "olleh")
             }
             .assertNoOutput()
             .verifyState { state in
-                XCTAssertEqual("Failed", state.text)
+                #expect(state.text == "Failed")
             }
             .assertStateModifications { state in
                 state.text = "Failed"
@@ -194,7 +194,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
 // MARK: - ApplyContext Tests
 
 extension WorkflowRenderTesterTests {
-    func test_applyContext_exposesProps() {
+    @Test func applyContext_exposesProps() {
         PropsWorkflow(prop1: "ichi", prop2: 42)
             .renderTester()
             .expectSideEffect(
@@ -202,13 +202,13 @@ extension WorkflowRenderTesterTests {
                 producingAction: PropsWorkflow.Action.emit
             )
             .render { rendering in
-                XCTAssertEqual(rendering, "")
+                #expect(rendering == "")
             }
             .verifyAction { (action: PropsWorkflow.Action) in
-                XCTAssertEqual(action, .emit)
+                #expect(action == .emit)
             }
             .verifyState { newState in
-                XCTAssertEqual(newState, "prop1: ichi, prop2: 42")
+                #expect(newState == "prop1: ichi, prop2: 42")
             }
     }
 }
@@ -220,7 +220,9 @@ struct PropsWorkflow: Workflow {
     var prop1 = ""
     var prop2 = 0
 
-    func makeInitialState() -> String { "" }
+    func makeInitialState() -> String {
+        ""
+    }
 
     func render(state: State, context: RenderContext<PropsWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
@@ -366,7 +368,7 @@ private struct MockChildWorkflow: Workflow {
     typealias Rendering = String
 
     func render(state: Void, context: RenderContext<MockChildWorkflow>) -> String {
-        XCTFail("should never be rendered")
+        Issue.record("should never be rendered")
         return ""
     }
 }


### PR DESCRIPTION
## Summary

- Remove `import XCTest` and `linkerSettings: [.linkedFramework("XCTest")]` from all 5 public testing modules (12 source files, Package.swift)
- Convert 2 test files to Swift Testing (`WorkflowActionTesterTests`, `WorkflowRenderTesterTests`)

## Motivation

The public testing modules (`WorkflowTesting`, `WorkflowReactiveSwiftTesting`, `WorkflowRxSwiftTesting`, `WorkflowCombineTesting`, `WorkflowConcurrencyTesting`) had `import XCTest` despite not using any XCTest symbols — all failure reporting goes through `reportIssue()` from `IssueReporting`, which auto-bridges to both frameworks at runtime. Removing the hard dependency unblocks downstream consumers who want to write tests using Swift Testing.

## xcodebuild compatibility notes

Three test files were prototyped as Swift Testing but kept as XCTest due to xcodebuild issues:

- **WorkflowObserverTests**: `.serialized` trait with nested `@Suite` structs causes xcodebuild to report `TEST FAILED` even when all tests pass
- **WorkflowRenderTesterFailureTests**: `withKnownIssue` causes xcodebuild exit code 65 on known issues
- **WorkerTests**: `withCheckedContinuation` replacing `XCTestExpectation` hangs under xcodebuild when awaiting ReactiveSwift signals

These can be revisited as xcodebuild's Swift Testing support matures.

## Test plan

- [x] All 5 public testing modules build without XCTest linkage
- [x] `swift build --build-tests` compiles all test targets
- [x] `tuist test --path Samples UnitTests` passes locally
- [x] `TestingFrameworkCompatibilityTests` validates dual-framework support

🤖 Generated with [Claude Code](https://claude.com/claude-code)